### PR TITLE
feat: Auto-hide the topBar and add a control button to toggle the feature on or off.

### DIFF
--- a/app/src/main/java/com/github/zly2006/zhihu/v2/ui/AccountSettingScreen.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/v2/ui/AccountSettingScreen.kt
@@ -284,6 +284,17 @@ fun AccountSettingScreen(
                     preferences.edit().putBoolean("webviewHardwareAcceleration", it).apply()
                 }
             )
+
+            val isTitleAutoHide = remember { mutableStateOf(preferences.getBoolean("titleAutoHide", false)) }
+            SwitchSettingItem(
+                title = "标题栏自动隐藏",
+                description = "自动隐藏标题栏，随着滚动自动隐藏，当再滚动到顶部时自动显示",
+                checked = isTitleAutoHide.value,
+                onCheckedChange = {
+                    isTitleAutoHide.value = it
+                    preferences.edit().putBoolean("titleAutoHide", it).apply()
+                }
+            )
         }
         val updateState by UpdateManager.updateState.collectAsState()
         LaunchedEffect(updateState) {

--- a/app/src/main/java/com/github/zly2006/zhihu/v2/ui/ArticleScreen.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/v2/ui/ArticleScreen.kt
@@ -119,6 +119,7 @@ fun ArticleScreen(
     var isScrollingUp by remember { mutableStateOf(false) }
     val density = LocalDensity.current
     val scrollDeltaThreshold = with(density) { ScrollThresholdDp.toPx() }
+    var topBarHeight by remember { mutableStateOf(0) }
 
     LaunchedEffect(scrollState.value) {
         val currentScroll = scrollState.value
@@ -132,11 +133,13 @@ fun ArticleScreen(
 
     val showTopBar by remember {
         derivedStateOf {
+            val canScroll = scrollState.maxValue > topBarHeight
             val remainingScrollSpace = scrollState.maxValue - scrollState.value
             val isNearBottom = remainingScrollSpace < scrollDeltaThreshold
             val isNearTop = scrollState.value < scrollDeltaThreshold
             when {
                 !isTitleAutoHide -> true       // 强制显示模式
+                !canScroll -> true             // 内容不足时强制显示
                 isNearBottom -> false          // 底部区域强制隐藏
                 isScrollingUp -> true          // 向上滚动时显示
                 isNearTop -> true              // 顶部区域强制显示
@@ -144,7 +147,7 @@ fun ArticleScreen(
             }
         }
     }
-    var topBarHeight by remember { mutableStateOf(0) }
+//    var topBarHeight by remember { mutableStateOf(0) }
     var title by remember { mutableStateOf(article.title) }
     var authorName by remember { mutableStateOf(article.authorName) }
     var authorBio by remember { mutableStateOf(article.authorBio) }

--- a/app/src/main/java/com/github/zly2006/zhihu/v2/ui/ArticleScreen.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/v2/ui/ArticleScreen.kt
@@ -5,8 +5,16 @@ package com.github.zly2006.zhihu.v2.ui
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.Context.MODE_PRIVATE
 import android.util.Log
 import android.widget.Toast
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -25,6 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -97,6 +106,17 @@ fun ArticleScreen(
     val httpClient = context.httpClient
 
     val scrollState = rememberScrollState()
+    // 获取自动隐藏配置
+    val preferences = LocalContext.current.getSharedPreferences(PREFERENCE_NAME, MODE_PRIVATE)
+    val isTitleAutoHide by remember { mutableStateOf(preferences.getBoolean("titleAutoHide", false)) }
+    val showTopBar by remember {
+        derivedStateOf {
+            // 当关闭自动隐藏时始终显示标题
+            if (!isTitleAutoHide) true
+            else scrollState.value < 100
+        }
+    }
+    var topBarHeight by remember { mutableStateOf(0) }
     var title by remember { mutableStateOf(article.title) }
     var authorName by remember { mutableStateOf(article.authorName) }
     var authorBio by remember { mutableStateOf(article.authorBio) }
@@ -258,16 +278,36 @@ fun ArticleScreen(
             .fillMaxSize()
             .padding(16.dp),
         topBar = {
-            Text(
-                text = title,
-                fontSize = 24.sp,
-                fontWeight = FontWeight.Bold,
-                lineHeight = 32.sp,
-                modifier = Modifier.padding(bottom = 8.dp)
-                    .clickable {
-                        onNavigate(Question(questionId, title))
+            Box(
+                modifier = Modifier
+                    .wrapContentHeight(unbounded = true)
+                    .onGloballyPositioned { coordinates ->
+                        topBarHeight = coordinates.size.height
                     }
-            )
+            ) {
+                AnimatedVisibility(
+                    visible = showTopBar,
+                    enter = fadeIn() + expandVertically(
+                        expandFrom = Alignment.Top,
+                        initialHeight = { 0 }  // 更自然的展开动画
+                    ) + slideInVertically { it / 2 },  // 添加滑动效果
+                    exit = fadeOut() + shrinkVertically(
+                        shrinkTowards = Alignment.Top,
+                        targetHeight = { 0 }
+                    ) + slideOutVertically { it / 2 },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        text = title,
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Bold,
+                        lineHeight = 32.sp,
+                        modifier = Modifier
+                            .padding(bottom = 8.dp)
+                            .clickable { onNavigate(Question(questionId, title)) }
+                    )
+                }
+            }
         },
         bottomBar = {
             if (backStackEntry.hasRoute(Article::class)) {


### PR DESCRIPTION
# 新增特性：文章页面标题自动隐藏 #4 

## 说明

核心是为在 ArticleScreen 中的 topBar 添加自动隐藏动画。并为该功能添加了一个控制开关，默认关闭。

## 测试（GIF动图较大，可能加载缓慢）

### 测试机型1
- 型号：OnePlus7 Pro
- OS：LineageOS 22.1
- Android版本：15

| 配置页面 | 效果展示 |
|-----------|-----------|
| ![关闭](https://github.com/user-attachments/assets/8518cb7e-26d1-4afa-b86a-7e5ec92e37cf) | ![关闭](https://github.com/user-attachments/assets/6e48b3d1-5b94-4dbc-93e7-00aff6ae63f7) |
| ![打开](https://github.com/user-attachments/assets/1860c2db-8962-42ac-8a52-67bb9bdc6176) | ![打开](https://github.com/user-attachments/assets/9d21b208-610a-4bd1-a0ac-5f1b3d8eb256) |

### 测试机型2

- 型号：MEIZU 20 Pro
- OS：Flyme 11.2.1.0A
- Android版本：14

| 配置页面 | 效果展示 |
|-----------|-----------|
| ![关闭](https://github.com/user-attachments/assets/a8480c55-7100-461e-a19f-30f87b81b07a) | ![关闭](https://github.com/user-attachments/assets/00d84cfc-ab3a-4bac-ac96-6d2466b33e2b) |
| ![打开](https://github.com/user-attachments/assets/ecd17357-18fb-481b-a8df-59eb3cff63e7) | ![打开](https://github.com/user-attachments/assets/7169659d-919f-4aa3-8db9-7ef62acedb39) |

### Nightly Build

![firefox_iBQiDFq5D6](https://github.com/user-attachments/assets/1d4133a1-c907-47cd-8849-41be482714e3)
