### PR TITLE
feat: 添加知乎严选付费内容过滤开关

### DIFF
--- a/app/src/main/java/com/github/zly2006/zhihu/ui/subscreens/ContentFilterSettingsScreen.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/subscreens/ContentFilterSettingsScreen.kt
@@ -400,6 +400,19 @@ fun ContentFilterSettingsScreen(
                     highlightedKey = setting,
                 )
 
+                val blockPaidContent = remember { mutableStateOf(preferences.getBoolean("blockPaidContent", true)) }
+                SettingItemWithSwitch(
+                    title = { Text("屏蔽知乎严选付费内容") },
+                    description = { Text("屏蔽知乎盐选会员专享的付费回答和文章") },
+                    checked = blockPaidContent.value,
+                    onCheckedChange = {
+                        blockPaidContent.value = it
+                        preferences.edit { putBoolean("blockPaidContent", it) }
+                    },
+                    settingKey = "blockPaidContent",
+                    highlightedKey = setting,
+                )
+
                 val reverseBlock = remember { mutableStateOf(preferences.getBoolean("reverseBlock", false)) }
                 SettingItemWithSwitch(
                     title = { Text("反向屏蔽（吃\uD83D\uDCA9模式）") },

--- a/app/src/main/java/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
@@ -351,17 +351,18 @@ object ContentFilterExtensions {
         val blockZhihuAdPlatform = preferences.getBoolean("blockZhihuAdPlatform", true)
         val blockZhihuSchool = preferences.getBoolean("blockZhihuSchool", true)
         val blockWeChatOfficialAccount = preferences.getBoolean("blockWeChatOfficialAccount", true)
+        val blockPaidContent = preferences.getBoolean("blockPaidContent", true)
 
         return when (val raw = content.raw) {
             is DataHolder.Answer -> {
-                if (raw.paidInfo != null) {
+                if (blockPaidContent && raw.paidInfo != null) {
                     "知乎盐选付费内容"
                 } else {
                     getLinkBasedAdReason(raw.content, blockZhihuAdPlatform, blockZhihuSchool, blockWeChatOfficialAccount)
                 }
             }
             is DataHolder.Article -> {
-                if (raw.paidInfo != null) {
+                if (blockPaidContent && raw.paidInfo != null) {
                     "知乎盐选付费内容"
                 } else {
                     getLinkBasedAdReason(raw.content, blockZhihuAdPlatform, blockZhihuSchool, blockWeChatOfficialAccount)


### PR DESCRIPTION
新增 blockPaidContent 配置项，用户可在「推荐系统与内容过滤 → 广告屏蔽」中
控制是否屏蔽知乎盐选会员专享的付费回答和文章，默认开启。