### PR TITLE
fix: latex支持\enclose

### DIFF
--- a/.agents/skills/release-markdown-fork/SKILL.md
+++ b/.agents/skills/release-markdown-fork/SKILL.md
@@ -141,6 +141,8 @@ Original version: (insert original version e.g. 1.x.x)
 Fork version: (insert fork version e.g. 0.0.1-alpha.N)
 ```
 
+DO NOT PUSH!
+
 ## Failure handling
 
 ### Sonatype upload hangs without returning deployment ID

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -202,8 +202,8 @@ dependencies {
     //noinspection GradleDependency
     implementation("androidx.browser:browser:1.8.0")
 
-    implementation("io.github.zly2006:markdown-parser-android:0.0.1-alpha.5")
-    implementation("io.github.zly2006:markdown-renderer-android:0.0.1-alpha.5")
+    implementation("io.github.zly2006:markdown-parser-android:0.0.1-alpha.6")
+    implementation("io.github.zly2006:markdown-renderer-android:0.0.1-alpha.6")
 
     implementation("io.coil-kt.coil3:coil-compose:$coil")
     implementation("io.coil-kt.coil3:coil-network-ktor3-android:$coil")


### PR DESCRIPTION
bump markdown fork.

Resolves: #307

Original version: 1.2.8
Fork version: 0.0.1-alpha.6