### PR TITLE
feat: 添加个人主页关注订阅板块

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/PeopleScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/PeopleScreenInstrumentedTest.kt
@@ -27,6 +27,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.zly2006.zhihu.data.DataHolder
 import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.ArticleType
+import com.github.zly2006.zhihu.navigation.CollectionContent
 import com.github.zly2006.zhihu.navigation.Person
 import com.github.zly2006.zhihu.navigation.Pin
 import com.github.zly2006.zhihu.navigation.Question
@@ -36,6 +37,8 @@ import com.github.zly2006.zhihu.test.RecordingNavigator
 import com.github.zly2006.zhihu.test.performVerticalSwipeCycle
 import com.github.zly2006.zhihu.test.resetAppPreferences
 import com.github.zly2006.zhihu.test.setScreenContent
+import com.github.zly2006.zhihu.ui.FollowedQuestion
+import com.github.zly2006.zhihu.ui.FollowedTopic
 import com.github.zly2006.zhihu.ui.PEOPLE_SCREEN_ACTIVITIES_LIST_TAG
 import com.github.zly2006.zhihu.ui.PEOPLE_SCREEN_ANSWERS_LIST_TAG
 import com.github.zly2006.zhihu.ui.PEOPLE_SCREEN_ANSWER_COUNT_TAG
@@ -59,6 +62,7 @@ import com.github.zly2006.zhihu.ui.PEOPLE_SCREEN_PINS_LIST_TAG
 import com.github.zly2006.zhihu.ui.PEOPLE_SCREEN_QUESTIONS_LIST_TAG
 import com.github.zly2006.zhihu.ui.PEOPLE_SCREEN_RECOMMENDATION_BLOCK_BUTTON_TAG
 import com.github.zly2006.zhihu.ui.PEOPLE_SCREEN_ROOT_TAG
+import com.github.zly2006.zhihu.ui.PEOPLE_SCREEN_SUBSCRIPTIONS_LIST_TAG
 import com.github.zly2006.zhihu.ui.PeopleListUiState
 import com.github.zly2006.zhihu.ui.PeopleProfileUiState
 import com.github.zly2006.zhihu.ui.PeopleScreen
@@ -69,12 +73,15 @@ import com.github.zly2006.zhihu.ui.peopleScreenAnswerItemTag
 import com.github.zly2006.zhihu.ui.peopleScreenArticleItemTag
 import com.github.zly2006.zhihu.ui.peopleScreenCollectionItemTag
 import com.github.zly2006.zhihu.ui.peopleScreenColumnItemTag
+import com.github.zly2006.zhihu.ui.peopleScreenFollowedQuestionItemTag
+import com.github.zly2006.zhihu.ui.peopleScreenFollowedTopicItemTag
 import com.github.zly2006.zhihu.ui.peopleScreenFollowerActionTag
 import com.github.zly2006.zhihu.ui.peopleScreenFollowerItemTag
 import com.github.zly2006.zhihu.ui.peopleScreenFollowingActionTag
 import com.github.zly2006.zhihu.ui.peopleScreenFollowingItemTag
 import com.github.zly2006.zhihu.ui.peopleScreenPinItemTag
 import com.github.zly2006.zhihu.ui.peopleScreenQuestionItemTag
+import com.github.zly2006.zhihu.ui.peopleScreenSubscriptionTabTag
 import com.github.zly2006.zhihu.ui.peopleScreenTabTag
 import com.github.zly2006.zhihu.viewmodel.feed.BaseFeedViewModel
 import org.junit.Assert.assertEquals
@@ -297,6 +304,47 @@ class PeopleScreenInstrumentedTest {
         )
     }
 
+    @Test
+    fun followingSubscriptionsTabMatchesOfficialEntryPointsOffline() {
+        /*
+         * Expected behavior:
+         * 1. The profile tab row exposes a Zhihu-Web-style "关注订阅" entry.
+         * 2. Inside that page, non-duplicated official entry names are available as chips:
+         *    我订阅的专栏、关注的话题、关注的问题、关注的收藏夹.
+         * 3. Followed questions and followed collections use native navigation destinations,
+         *    matching the app's existing question and collection-detail screens.
+         */
+        val navigator = setPeopleScreen(
+            overrides = PeopleScreenTestOverrides(
+                initialUiState = seededUiState(itemCount = 8),
+                initialPage = 9,
+            ),
+        )
+
+        composeRule.onNodeWithTag(PEOPLE_SCREEN_SUBSCRIPTIONS_LIST_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(peopleScreenSubscriptionTabTag(0)).assertExists()
+        composeRule.onNodeWithTag(peopleScreenSubscriptionTabTag(1)).assertExists()
+        composeRule.onNodeWithTag(peopleScreenSubscriptionTabTag(2)).assertExists()
+        composeRule.onNodeWithTag(peopleScreenSubscriptionTabTag(3)).assertExists()
+
+        composeRule.onNodeWithTag(peopleScreenSubscriptionTabTag(1)).performClick()
+        composeRule.onNodeWithTag(peopleScreenFollowedTopicItemTag("topic-1")).assertIsDisplayed()
+
+        composeRule.onNodeWithTag(peopleScreenSubscriptionTabTag(2)).performClick()
+        composeRule.onNodeWithTag(peopleScreenFollowedQuestionItemTag("1")).performClick()
+
+        composeRule.onNodeWithTag(peopleScreenSubscriptionTabTag(3)).performClick()
+        composeRule.onNodeWithTag(peopleScreenCollectionItemTag("follow-collection-1")).performClick()
+
+        assertEquals(
+            listOf(
+                Question(1L, "关注的问题 1"),
+                CollectionContent("follow-collection-1"),
+            ),
+            navigator.destinations,
+        )
+    }
+
     private fun setPeopleScreen(overrides: PeopleScreenTestOverrides): RecordingNavigator = composeRule.setScreenContent {
         PeopleScreen(
             person = ROOT_PERSON,
@@ -362,6 +410,22 @@ class PeopleScreenInstrumentedTest {
         ),
         following = PeopleListUiState(
             items = List(itemCount) { index -> seededPeople("following", index + 1, "关注的人") },
+            isEnd = false,
+        ),
+        followingColumns = PeopleListUiState(
+            items = List(itemCount) { index -> seededFollowedColumn(index + 1) },
+            isEnd = false,
+        ),
+        followingTopics = PeopleListUiState(
+            items = List(itemCount) { index -> seededFollowedTopic(index + 1) },
+            isEnd = false,
+        ),
+        followingQuestions = PeopleListUiState(
+            items = List(itemCount) { index -> seededFollowedQuestion(index + 1) },
+            isEnd = false,
+        ),
+        followingCollections = PeopleListUiState(
+            items = List(itemCount) { index -> seededFollowedCollection(index + 1) },
             isEnd = false,
         ),
     )
@@ -445,6 +509,33 @@ class PeopleScreenInstrumentedTest {
         description = "专栏描述 $index",
         articlesCount = index,
         followerCount = 30 + index,
+    )
+
+    private fun seededFollowedColumn(index: Int) = DataHolder.Column(
+        id = "follow-column-$index",
+        title = "我订阅的专栏 $index",
+        description = "订阅专栏描述 $index",
+        articlesCount = index,
+        followerCount = 30 + index,
+    )
+
+    private fun seededFollowedTopic(index: Int) = FollowedTopic(
+        id = "topic-$index",
+        name = "关注的话题 $index",
+        avatarUrl = "https://example.invalid/topic-$index.png",
+    )
+
+    private fun seededFollowedQuestion(index: Int) = FollowedQuestion(
+        id = index.toString(),
+        title = "关注的问题 $index",
+    )
+
+    private fun seededFollowedCollection(index: Int) = DataHolder.Collection(
+        id = "follow-collection-$index",
+        title = "关注的收藏夹 $index",
+        url = "https://www.zhihu.com/collection/follow-collection-$index",
+        answerCount = index,
+        followerCount = 40 + index,
     )
 
     private fun seededPeople(prefix: String, index: Int, namePrefix: String) = DataHolder.People(

--- a/app/src/main/java/com/github/zly2006/zhihu/data/DataHolder.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/data/DataHolder.kt
@@ -767,6 +767,7 @@ object DataHolder {
         val avatarUrl: String = "",
         val articlesCount: Int = 0,
         val followerCount: Int = 0,
+        val followers: Int = 0,
         val isFollowing: Boolean = false,
         val created: Long = 0L,
         val updated: Long = 0L,

--- a/app/src/main/java/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.FilterAlt
+import androidx.compose.material.icons.filled.Groups
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Palette
@@ -115,6 +116,7 @@ internal const val ACCOUNT_SETTINGS_LOGIN_ITEM_TAG = "accountSettings.loginItem"
 internal const val ACCOUNT_SETTINGS_PROFILE_HEADER_TAG = "accountSettings.profileHeader"
 internal const val ACCOUNT_SETTINGS_PROFILE_NAME_TAG = "accountSettings.profileName"
 internal const val ACCOUNT_SETTINGS_SHORTCUT_COLLECTIONS_TAG = "accountSettings.shortcutCollections"
+internal const val ACCOUNT_SETTINGS_SHORTCUT_SUBSCRIPTIONS_TAG = "accountSettings.shortcutSubscriptions"
 internal const val ACCOUNT_SETTINGS_SHORTCUT_NOTIFICATION_TAG = "accountSettings.shortcutNotification"
 internal const val ACCOUNT_SETTINGS_SHORTCUT_HISTORY_TAG = "accountSettings.shortcutHistory"
 internal const val ACCOUNT_SETTINGS_APPEARANCE_TAG = "accountSettings.appearance"
@@ -321,6 +323,37 @@ fun AccountSettingScreen(
                         }
                         Column(
                             Modifier
+                                .testTag(ACCOUNT_SETTINGS_SHORTCUT_SUBSCRIPTIONS_TAG)
+                                .weight(1f)
+                                .clip(RoundedCornerShape(4.dp))
+                                .background(MaterialTheme.colorScheme.primaryContainer)
+                                .clickable {
+                                    navigator.onNavigate(
+                                        Person(
+                                            id = data.self?.id ?: "",
+                                            urlToken = data.self?.urlToken ?: "",
+                                            name = data.username,
+                                            jumpTo = "关注订阅",
+                                        ),
+                                    )
+                                }.padding(8.dp, 16.dp),
+                            verticalArrangement = Arrangement.Center,
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                        ) {
+                            Icon(
+                                Icons.Default.Groups,
+                                null,
+                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                            )
+                            Spacer(Modifier.height(4.dp))
+                            Text(
+                                "关注订阅",
+                                style = MaterialTheme.typography.labelLarge,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            )
+                        }
+                        Column(
+                            Modifier
                                 .testTag(ACCOUNT_SETTINGS_SHORTCUT_NOTIFICATION_TAG)
                                 .weight(1f)
                                 .clip(RoundedCornerShape(4.dp))
@@ -390,6 +423,22 @@ fun AccountSettingScreen(
                             icon = { Icon(Icons.Default.BookmarkBorder, null) },
                             onClick = {
                                 data.self?.urlToken?.let { navigator.onNavigate(Collections(it)) }
+                            },
+                        )
+                        SettingItem(
+                            title = { Text("查看关注订阅") },
+                            description = { Text("话题、问题、专栏和收藏夹") },
+                            icon = { Icon(Icons.Default.Groups, null) },
+                            modifier = Modifier.testTag(ACCOUNT_SETTINGS_SHORTCUT_SUBSCRIPTIONS_TAG),
+                            onClick = {
+                                navigator.onNavigate(
+                                    Person(
+                                        id = data.self?.id ?: "",
+                                        urlToken = data.self?.urlToken ?: "",
+                                        name = data.username,
+                                        jumpTo = "关注订阅",
+                                    ),
+                                )
                             },
                         )
                     }

--- a/app/src/main/java/com/github/zly2006/zhihu/ui/PeopleScreen.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/PeopleScreen.kt
@@ -18,6 +18,7 @@
 package com.github.zly2006.zhihu.ui
 
 import android.content.Context
+import android.content.Intent
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.animation.ExperimentalAnimationApi
@@ -25,6 +26,8 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -52,6 +55,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -61,15 +65,18 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import com.github.zly2006.zhihu.BuildConfig
 import com.github.zly2006.zhihu.MainActivity
+import com.github.zly2006.zhihu.WebviewActivity
 import com.github.zly2006.zhihu.data.AccountData
 import com.github.zly2006.zhihu.data.DataHolder
 import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.ArticleType
+import com.github.zly2006.zhihu.navigation.CollectionContent
 import com.github.zly2006.zhihu.navigation.LocalNavigator
 import com.github.zly2006.zhihu.navigation.Person
 import com.github.zly2006.zhihu.navigation.Pin
@@ -92,6 +99,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonPrimitive
@@ -224,6 +232,80 @@ class PeopleColumnContributionsViewModel(
         get() = "data[*].articles_count,followers,author"
 }
 
+@Serializable
+data class FollowedQuestion(
+    val id: String,
+    val type: String = "question",
+    val url: String = "",
+    val title: String = "",
+    val questionType: String = "",
+    val created: Long = 0L,
+    val updatedTime: Long = 0L,
+)
+
+@Serializable
+data class FollowedTopic(
+    val id: String = "",
+    val type: String = "topic",
+    val url: String = "",
+    val name: String = "",
+    val avatarUrl: String? = null,
+    val topicType: String? = null,
+    val topic: DataHolder.Topic? = null,
+) {
+    val displayId: String get() = topic?.id ?: id
+    val displayName: String get() = topic?.name ?: name
+    val displayAvatarUrl: String? get() = topic?.avatarUrl ?: avatarUrl
+}
+
+class PeopleFollowingCollectionsViewModel(
+    val person: Person,
+) : PaginationViewModel<DataHolder.Collection>(
+        typeOf<DataHolder.Collection>(),
+    ) {
+    override val initialUrl: String
+        get() = "https://www.zhihu.com/api/v4/members/${person.userTokenOrId}/following-favlists"
+
+    override val include: String
+        get() = "data[*].updated_time,answer_count,follower_count,creator"
+}
+
+class PeopleFollowingQuestionsViewModel(
+    val person: Person,
+) : PaginationViewModel<FollowedQuestion>(
+        typeOf<FollowedQuestion>(),
+    ) {
+    override val initialUrl: String
+        get() = "https://www.zhihu.com/api/v4/members/${person.userTokenOrId}/following-questions"
+
+    override val include: String
+        get() = ""
+}
+
+class PeopleFollowingTopicsViewModel(
+    val person: Person,
+) : PaginationViewModel<FollowedTopic>(
+        typeOf<FollowedTopic>(),
+    ) {
+    override val initialUrl: String
+        get() = "https://www.zhihu.com/api/v4/members/${person.userTokenOrId}/following-topic-contributions"
+
+    override val include: String
+        get() = ""
+}
+
+class PeopleFollowingColumnsViewModel(
+    val person: Person,
+) : PaginationViewModel<DataHolder.Column>(
+        typeOf<DataHolder.Column>(),
+    ) {
+    override val initialUrl: String
+        get() = "https://www.zhihu.com/api/v4/members/${person.userTokenOrId}/following-columns"
+
+    override val include: String
+        get() = "data[*].articles_count,followers,author"
+}
+
 class PersonViewModel(
     val person: Person,
 ) : ViewModel() {
@@ -248,6 +330,10 @@ class PersonViewModel(
     val columnsFeedModel = PeopleColumnContributionsViewModel(person)
     val followersFeedModel = PeopleFollowersViewModel(person)
     val followingFeedModel = PeopleFollowingViewModel(person)
+    val followingCollectionsFeedModel = PeopleFollowingCollectionsViewModel(person)
+    val followingQuestionsFeedModel = PeopleFollowingQuestionsViewModel(person)
+    val followingTopicsFeedModel = PeopleFollowingTopicsViewModel(person)
+    val followingColumnsFeedModel = PeopleFollowingColumnsViewModel(person)
     val subFeedModels = arrayOf(
         answersFeedModel,
         articlesFeedModel,
@@ -410,6 +496,14 @@ private val PEOPLE_SCREEN_TITLES = listOf(
     "专栏",
     "粉丝",
     "关注",
+    "关注订阅",
+)
+
+private val PEOPLE_SCREEN_SUBSCRIPTION_TITLES = listOf(
+    "我订阅的专栏",
+    "关注的话题",
+    "关注的问题",
+    "关注的收藏夹",
 )
 
 const val PEOPLE_SCREEN_ROOT_TAG = "people_screen_root"
@@ -426,6 +520,8 @@ const val PEOPLE_SCREEN_PINS_LIST_TAG = "people_screen_pins_list"
 const val PEOPLE_SCREEN_COLUMNS_LIST_TAG = "people_screen_columns_list"
 const val PEOPLE_SCREEN_FOLLOWERS_LIST_TAG = "people_screen_followers_list"
 const val PEOPLE_SCREEN_FOLLOWING_LIST_TAG = "people_screen_following_list"
+const val PEOPLE_SCREEN_SUBSCRIPTION_TABS_TAG = "people_screen_subscription_tabs"
+const val PEOPLE_SCREEN_SUBSCRIPTIONS_LIST_TAG = "people_screen_subscriptions_list"
 const val PEOPLE_SCREEN_ANSWER_COUNT_TAG = "people_screen_stat_answers"
 const val PEOPLE_SCREEN_ARTICLE_COUNT_TAG = "people_screen_stat_articles"
 const val PEOPLE_SCREEN_FOLLOWER_COUNT_TAG = "people_screen_stat_followers"
@@ -461,6 +557,12 @@ fun peopleScreenFollowerActionTag(id: String): String = "people_screen_follower_
 fun peopleScreenFollowingItemTag(id: String): String = "people_screen_following_item_$id"
 
 fun peopleScreenFollowingActionTag(id: String): String = "people_screen_following_action_$id"
+
+fun peopleScreenSubscriptionTabTag(index: Int): String = "people_screen_subscription_tab_$index"
+
+fun peopleScreenFollowedQuestionItemTag(id: String): String = "people_screen_followed_question_item_$id"
+
+fun peopleScreenFollowedTopicItemTag(id: String): String = "people_screen_followed_topic_item_$id"
 
 private fun peopleScreenInitialPage(person: Person): Int {
     val jumpToIndex = PEOPLE_SCREEN_TITLES.indexOf(person.jumpTo)
@@ -502,6 +604,10 @@ data class PeopleScreenUiState(
     val columns: PeopleListUiState<DataHolder.Column> = PeopleListUiState(),
     val followers: PeopleListUiState<DataHolder.People> = PeopleListUiState(),
     val following: PeopleListUiState<DataHolder.People> = PeopleListUiState(),
+    val followingColumns: PeopleListUiState<DataHolder.Column> = PeopleListUiState(),
+    val followingTopics: PeopleListUiState<FollowedTopic> = PeopleListUiState(),
+    val followingQuestions: PeopleListUiState<FollowedQuestion> = PeopleListUiState(),
+    val followingCollections: PeopleListUiState<DataHolder.Collection> = PeopleListUiState(),
 )
 
 /**
@@ -525,6 +631,10 @@ data class PeopleScreenTestOverrides(
     val onColumnsLoadMore: (() -> Unit)? = null,
     val onFollowersLoadMore: (() -> Unit)? = null,
     val onFollowingLoadMore: (() -> Unit)? = null,
+    val onFollowingColumnsLoadMore: (() -> Unit)? = null,
+    val onFollowingTopicsLoadMore: (() -> Unit)? = null,
+    val onFollowingQuestionsLoadMore: (() -> Unit)? = null,
+    val onFollowingCollectionsLoadMore: (() -> Unit)? = null,
 )
 
 private fun PersonViewModel.toUiState(): PeopleScreenUiState = PeopleScreenUiState(
@@ -577,6 +687,22 @@ private fun PersonViewModel.toUiState(): PeopleScreenUiState = PeopleScreenUiSta
     following = PeopleListUiState(
         items = followingFeedModel.allData,
         isEnd = followingFeedModel.isEnd,
+    ),
+    followingColumns = PeopleListUiState(
+        items = followingColumnsFeedModel.allData,
+        isEnd = followingColumnsFeedModel.isEnd,
+    ),
+    followingTopics = PeopleListUiState(
+        items = followingTopicsFeedModel.allData,
+        isEnd = followingTopicsFeedModel.isEnd,
+    ),
+    followingQuestions = PeopleListUiState(
+        items = followingQuestionsFeedModel.allData,
+        isEnd = followingQuestionsFeedModel.isEnd,
+    ),
+    followingCollections = PeopleListUiState(
+        items = followingCollectionsFeedModel.allData,
+        isEnd = followingCollectionsFeedModel.isEnd,
     ),
 )
 
@@ -1028,7 +1154,136 @@ fun PeopleScreen(
                             )
                         }
                     }
+
+                    9 -> {
+                        FollowingSubscriptionsPage(
+                            uiState = uiState,
+                            onLoadMore = { subscriptionPage ->
+                                if (testOverrides != null) {
+                                    when (subscriptionPage) {
+                                        0 -> testOverrides.onFollowingColumnsLoadMore?.invoke()
+                                        1 -> testOverrides.onFollowingTopicsLoadMore?.invoke()
+                                        2 -> testOverrides.onFollowingQuestionsLoadMore?.invoke()
+                                        3 -> testOverrides.onFollowingCollectionsLoadMore?.invoke()
+                                    }
+                                } else {
+                                    when (subscriptionPage) {
+                                        0 -> viewModel.followingColumnsFeedModel.loadMore(context)
+                                        1 -> viewModel.followingTopicsFeedModel.loadMore(context)
+                                        2 -> viewModel.followingQuestionsFeedModel.loadMore(context)
+                                        3 -> viewModel.followingCollectionsFeedModel.loadMore(context)
+                                    }
+                                }
+                            },
+                            modifier = Modifier.testTag(peopleScreenPageTag(page)),
+                        )
+                    }
                 }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun FollowingSubscriptionsPage(
+    uiState: PeopleScreenUiState,
+    onLoadMore: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var selectedPage by rememberSaveable { mutableIntStateOf(0) }
+
+    LaunchedEffect(selectedPage) {
+        onLoadMore(selectedPage)
+    }
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        FlowRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(PEOPLE_SCREEN_SUBSCRIPTION_TABS_TAG)
+                .padding(vertical = 8.dp, horizontal = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            PEOPLE_SCREEN_SUBSCRIPTION_TITLES.forEachIndexed { index, title ->
+                OutlinedButton(
+                    onClick = { selectedPage = index },
+                    modifier = Modifier.testTag(peopleScreenSubscriptionTabTag(index)),
+                    shape = RoundedCornerShape(8.dp),
+                    colors = if (selectedPage == index) {
+                        ButtonDefaults.outlinedButtonColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        )
+                    } else {
+                        ButtonDefaults.outlinedButtonColors()
+                    },
+                ) {
+                    Text(title)
+                }
+            }
+        }
+
+        when (selectedPage) {
+            0 -> PaginatedList(
+                items = uiState.followingColumns.items,
+                onLoadMore = { onLoadMore(0) },
+                isEnd = { uiState.followingColumns.isEnd },
+                footer = ProgressIndicatorFooter,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag(PEOPLE_SCREEN_SUBSCRIPTIONS_LIST_TAG),
+                key = { it.id },
+            ) { column ->
+                ColumnListItem(
+                    column = column,
+                    itemTag = peopleScreenColumnItemTag(column.id),
+                )
+            }
+
+            1 -> PaginatedList(
+                items = uiState.followingTopics.items,
+                onLoadMore = { onLoadMore(1) },
+                isEnd = { uiState.followingTopics.isEnd },
+                footer = ProgressIndicatorFooter,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag(PEOPLE_SCREEN_SUBSCRIPTIONS_LIST_TAG),
+                key = { it.displayId },
+            ) { topic ->
+                FollowedTopicListItem(topic)
+            }
+
+            2 -> PaginatedList(
+                items = uiState.followingQuestions.items,
+                onLoadMore = { onLoadMore(2) },
+                isEnd = { uiState.followingQuestions.isEnd },
+                footer = ProgressIndicatorFooter,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag(PEOPLE_SCREEN_SUBSCRIPTIONS_LIST_TAG),
+                key = { it.id },
+            ) { question ->
+                FollowedQuestionListItem(question)
+            }
+
+            3 -> PaginatedList(
+                items = uiState.followingCollections.items,
+                onLoadMore = { onLoadMore(3) },
+                isEnd = { uiState.followingCollections.isEnd },
+                footer = ProgressIndicatorFooter,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag(PEOPLE_SCREEN_SUBSCRIPTIONS_LIST_TAG),
+                key = { it.id },
+            ) { collection ->
+                CollectionListItem(
+                    collection = collection,
+                    itemTag = peopleScreenCollectionItemTag(collection.id),
+                )
             }
         }
     }
@@ -1039,19 +1294,13 @@ private fun CollectionListItem(
     collection: DataHolder.Collection,
     itemTag: String? = null,
 ) {
-    val context = LocalContext.current
+    val navigator = LocalNavigator.current
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .then(if (itemTag != null) Modifier.testTag(itemTag) else Modifier)
             .clickable {
-                // TODO: Navigate to collection detail
-                Toast
-                    .makeText(
-                        context,
-                        "收藏夹详情功能开发中",
-                        Toast.LENGTH_SHORT,
-                    ).show()
+                navigator.onNavigate(CollectionContent(collection.id))
             }.padding(vertical = 8.dp, horizontal = 4.dp),
     ) {
         Text(
@@ -1135,13 +1384,7 @@ private fun ColumnListItem(
             .fillMaxWidth()
             .then(if (itemTag != null) Modifier.testTag(itemTag) else Modifier)
             .clickable {
-                // TODO: Navigate to column detail
-                Toast
-                    .makeText(
-                        context,
-                        "专栏详情功能开发中",
-                        Toast.LENGTH_SHORT,
-                    ).show()
+                openInWebview(context, column.webUrl())
             }.padding(vertical = 8.dp, horizontal = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -1161,13 +1404,77 @@ private fun ColumnListItem(
                 )
             }
             Text(
-                text = "${column.articlesCount} 文章 · ${column.followerCount} 关注",
+                text = "${column.articlesCount} 文章 · ${column.followerCount.coerceAtLeast(column.followers)} 关注",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(top = 4.dp),
             )
         }
     }
+}
+
+@Composable
+private fun FollowedQuestionListItem(question: FollowedQuestion) {
+    val navigator = LocalNavigator.current
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(peopleScreenFollowedQuestionItemTag(question.id))
+            .clickable {
+                question.id.toLongOrNull()?.let {
+                    navigator.onNavigate(Question(it, question.title))
+                }
+            }.padding(vertical = 8.dp, horizontal = 4.dp),
+    ) {
+        Text(
+            text = question.title,
+            style = MaterialTheme.typography.titleMedium,
+        )
+    }
+}
+
+@Composable
+private fun FollowedTopicListItem(topic: FollowedTopic) {
+    val context = LocalContext.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(peopleScreenFollowedTopicItemTag(topic.displayId))
+            .clickable {
+                openInWebview(context, "https://www.zhihu.com/topic/${topic.displayId}")
+            }.padding(vertical = 8.dp, horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AsyncImage(
+            model = topic.displayAvatarUrl,
+            contentDescription = "话题头像",
+            modifier = Modifier
+                .padding(end = 12.dp)
+                .size(40.dp)
+                .clip(CircleShape),
+        )
+        Text(
+            text = topic.displayName,
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+private fun DataHolder.Column.webUrl(): String = when {
+    url.contains("/api/v4/columns/") ->
+        url
+            .replace("http://", "https://")
+            .replace("/api/v4/columns/", "/column/")
+
+    url.startsWith("http") && !url.contains("/api/") -> url.replace("http://", "https://")
+    else -> "https://www.zhihu.com/column/$id"
+}
+
+private fun openInWebview(context: Context, url: String) {
+    context.startActivity(
+        Intent(Intent.ACTION_VIEW, url.toUri(), context, WebviewActivity::class.java),
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -138,7 +138,9 @@ abstract class PaginationViewModel<T : Any>(
             @Suppress("HttpUrlsUsage")
             val json = AccountData.fetchGet(context, url.replace("http://", "https://")) {
                 url {
-                    parameters["include"] = include
+                    if (include.isNotEmpty()) {
+                        parameters["include"] = include
+                    }
                 }
                 signFetchRequest()
             }!!


### PR DESCRIPTION
## Summary
- add a PeopleScreen `关注订阅` tab for followed content types missing from the existing profile tabs
- support subscribed columns, followed topics, followed questions, and followed collections
- add an account shortcut to open the current user's `关注订阅` tab
- make collection/question entries use native navigation and use WebView fallback for topics/columns

## Notes
- Existing `关注` and `粉丝` profile tabs remain the source for followed/follower user lists, so `关注订阅` intentionally avoids duplicating those entries.

## Verification
- ./gradlew assembleLiteDebug
- ./gradlew ktlintFormat
- ANDROID_SERIAL=emulator-5554 ./gradlew --no-configuration-cache connectedLiteDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.github.zly2006.zhihu.PeopleScreenInstrumentedTest
- ui-test dump on emulator-5554 after installing lite debug; live AVD was logged out, so logged-in account shortcut was covered by instrumentation and subagent review
- picky-user review: issues PU-20260519-005, PU-20260519-006, PU-20260519-007 fixed and re-reviewed pass
- ui-voyager review: pass, no new issue IDs

Fixes #302
