### PR TITLE
feat: 支持主界面横滑切换

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
@@ -157,8 +157,8 @@ class AccountSettingScreenInstrumentedTest {
         // 2. The favorites shortcut should navigate to the seeded Collections destination and must
         //    not close the surrounding account surface.
         // 3. The notification and history shortcuts represent overlay-style exits from the account
-        //    surface, so each one must call onDismissRequest exactly once before recording the
-        //    navigation event.
+        //    surface, so each one must call onDismissRequest exactly once. History selects the
+        //    OnlineHistory main tab directly instead of going through the local Navigator.
         preferences
             .edit()
             .putBoolean("duo3_home_account", true)
@@ -215,14 +215,13 @@ class AccountSettingScreenInstrumentedTest {
 
         composeRule.onNodeWithTag(ACCOUNT_SETTINGS_SHORTCUT_HISTORY_TAG).performClick()
         composeRule.waitUntil(timeoutMillis = 5_000) {
-            navigator.destinations.size == 3 && dismissCount.get() == 2
+            dismissCount.get() == 2 && composeRule.activity.mainTabNavigationTarget == OnlineHistory
         }
 
         assertEquals(
             listOf(
                 Collections(SEEDED_ACCOUNT_URL_TOKEN),
                 Notification,
-                OnlineHistory,
             ),
             navigator.destinations,
         )

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/BlockedFeedHistoryScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/BlockedFeedHistoryScreenInstrumentedTest.kt
@@ -96,6 +96,9 @@ class BlockedFeedHistoryScreenInstrumentedTest {
         // The newest record intentionally has a blank title and no navigation target. The screen
         // should render the fallback title, allow tapping the row, and still avoid emitting any
         // navigation event because default/empty record data cannot be opened anywhere.
+        composeRule
+            .onNodeWithTag(LIST_TAG)
+            .performScrollToNode(hasTestTag(itemTag(seededHistory.placeholderRecordId)))
         composeRule.onNodeWithText("（无标题）").assertIsDisplayed()
         composeRule.onNodeWithTag(itemTag(seededHistory.placeholderRecordId)).performClick()
         composeRule.runOnIdle {

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
@@ -238,7 +238,7 @@ class ZhihuMainNavigationInstrumentedTest {
 
         val article = Article(type = ArticleType.Answer, id = 318L)
         var openFrom: String? = null
-        composeRule.activity.runOnUiThread {
+        composeRule.runOnIdle {
             composeRule.activity.navigate(article)
             openFrom = composeRule.activity.consumePendingContentOpenFrom(article)
         }

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.test.swipeRight
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.zly2006.zhihu.navigation.Account
+import com.github.zly2006.zhihu.navigation.Article
+import com.github.zly2006.zhihu.navigation.ArticleType
 import com.github.zly2006.zhihu.navigation.Daily
 import com.github.zly2006.zhihu.navigation.Follow
 import com.github.zly2006.zhihu.navigation.Home
@@ -46,6 +48,8 @@ import com.github.zly2006.zhihu.test.setZhihuMainContent
 import com.github.zly2006.zhihu.ui.PREFERENCE_NAME
 import com.github.zly2006.zhihu.ui.subscreens.BOTTOM_BAR_ITEMS_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.subscreens.START_DESTINATION_PREFERENCE_KEY
+import com.github.zly2006.zhihu.viewmodel.filter.ContentOpenFrom
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -224,6 +228,22 @@ class ZhihuMainNavigationInstrumentedTest {
 
         composeRule.waitUntilTabSelected("nav_tab_follow")
         composeRule.onNodeWithTag("nav_tab_follow").assertIsSelected()
+    }
+
+    @Test
+    fun homeTabOpenContent_recordsHomeFeedOpenFrom() {
+        composeRule.launchZhihuMain(startDestination = Home.name)
+
+        composeRule.waitUntilTabSelected("nav_tab_home")
+
+        val article = Article(type = ArticleType.Answer, id = 318L)
+        var openFrom: String? = null
+        composeRule.activity.runOnUiThread {
+            composeRule.activity.navigate(article)
+            openFrom = composeRule.activity.consumePendingContentOpenFrom(article)
+        }
+
+        assertEquals(ContentOpenFrom.HOME_FEED, openFrom)
     }
 
     private fun MainActivityComposeRule.launchZhihuMain(

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.swipeRight
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.zly2006.zhihu.navigation.Account
@@ -39,7 +40,6 @@ import com.github.zly2006.zhihu.navigation.Follow
 import com.github.zly2006.zhihu.navigation.Home
 import com.github.zly2006.zhihu.navigation.OnlineHistory
 import com.github.zly2006.zhihu.test.MainActivityComposeRule
-import com.github.zly2006.zhihu.test.performHorizontalSwipeCycle
 import com.github.zly2006.zhihu.test.resetAppPreferences
 import com.github.zly2006.zhihu.test.setZhihuMainContent
 import com.github.zly2006.zhihu.ui.PREFERENCE_NAME
@@ -131,12 +131,10 @@ class ZhihuMainNavigationInstrumentedTest {
     }
 
     @Test
-    fun followScreen_swipesChangeInnerPageWithoutLosingBottomTabSelection() {
-        // This test enters the Follow top-level destination from a deterministic start state and
-        // verifies two shell-level guarantees. First, a horizontal swipe inside the Follow content
-        // must advance the inner pager from "推荐" to "动态". Second, even after those swipes,
-        // the bottom navigation shell must remain on the Follow tab instead of drifting back home
-        // or selecting another tab because of gesture side effects.
+    fun flattenedMainPager_swipesThroughFollowPagesWithoutLosingBottomTabSelection() {
+        // Follow is represented by two adjacent main-pager pages but a single bottom-bar item.
+        // Swiping between "推荐" and "动态" must keep the Follow item selected; swiping past the
+        // second Follow page should move to the next configured bottom destination.
         composeRule.launchZhihuMain(startDestination = Home.name)
         composeRule.onNodeWithTag("nav_tab_follow").performClick()
 
@@ -159,7 +157,20 @@ class ZhihuMainNavigationInstrumentedTest {
         composeRule.onNodeWithText("推荐").assertIsNotSelected()
         composeRule.onNodeWithTag("nav_tab_follow").assertIsSelected()
 
-        composeRule.onRoot().performHorizontalSwipeCycle()
+        composeRule.onRoot().performTouchInput { swipeLeft() }
+
+        composeRule.waitUntilTabSelected("nav_tab_daily")
+        composeRule.onNodeWithTag("nav_tab_daily").assertIsSelected()
+        composeRule.onNodeWithTag("nav_tab_follow").assertIsNotSelected()
+
+        composeRule.onRoot().performTouchInput { swipeRight() }
+
+        composeRule.waitUntilTextSelected("动态")
+        composeRule.onNodeWithText("动态").assertIsSelected()
+        composeRule.onNodeWithText("推荐").assertIsNotSelected()
+        composeRule.onNodeWithTag("nav_tab_follow").assertIsSelected()
+
+        composeRule.onRoot().performTouchInput { swipeRight() }
 
         composeRule.waitUntilTextSelected("推荐")
         composeRule.onNodeWithText("推荐").assertIsSelected()

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
@@ -219,7 +219,7 @@ class ZhihuMainNavigationInstrumentedTest {
         composeRule.onNodeWithTag("nav_tab_home").assertDoesNotExist()
 
         composeRule.activity.runOnUiThread {
-            composeRule.activity.navigate(Follow, popup = true)
+            composeRule.activity.navigateMainTab(Follow)
         }
 
         composeRule.waitUntilTabSelected("nav_tab_follow")

--- a/app/src/main/java/com/github/zly2006/zhihu/MainActivity.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/MainActivity.kt
@@ -52,19 +52,14 @@ import coil3.memory.MemoryCache
 import coil3.request.crossfade
 import com.github.zly2006.zhihu.data.AccountData
 import com.github.zly2006.zhihu.data.HistoryStorage
-import com.github.zly2006.zhihu.navigation.Account
 import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.ArticleType
 import com.github.zly2006.zhihu.navigation.CollectionContent
-import com.github.zly2006.zhihu.navigation.Daily
-import com.github.zly2006.zhihu.navigation.Follow
 import com.github.zly2006.zhihu.navigation.History
 import com.github.zly2006.zhihu.navigation.Home
-import com.github.zly2006.zhihu.navigation.HotList
 import com.github.zly2006.zhihu.navigation.MainTabs
 import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.navigation.Notification
-import com.github.zly2006.zhihu.navigation.OnlineHistory
 import com.github.zly2006.zhihu.navigation.Pin
 import com.github.zly2006.zhihu.navigation.Question
 import com.github.zly2006.zhihu.navigation.TopLevelDestination
@@ -499,14 +494,6 @@ class MainActivity : ComponentActivity() {
             navigateToMainTabs()
             return
         }
-        route.asMainTabDestination()?.let { destination ->
-            // Top-level destinations are legacy route values used by deeplinks and settings. The
-            // main shell is a single MainTabs route backed by a pager, so keep these out of the
-            // NavHost back stack and let ZhihuMain consume the pending tab target.
-            mainTabNavigationTarget = destination
-            navigateToMainTabs()
-            return
-        }
         navController.navigate(route) {
             if (popup) {
                 launchSingleTop = true
@@ -551,6 +538,11 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    fun navigateMainTab(destination: TopLevelDestination) {
+        mainTabNavigationTarget = destination
+        navigateToMainTabs()
+    }
+
     fun setCurrentMainTabOpenFrom(openFrom: String?) {
         currentMainTabOpenFrom = openFrom
     }
@@ -581,8 +573,6 @@ class MainActivity : ComponentActivity() {
             currentEntry?.toRoute<CollectionContent>()
         }.getOrNull() ?: runCatching {
             currentEntry?.toRoute<History>()
-        }.getOrNull() ?: runCatching {
-            currentEntry?.toRoute<OnlineHistory>()
         }.getOrNull() ?: runCatching {
             currentEntry?.toRoute<Notification>()
         }.getOrNull()
@@ -729,16 +719,4 @@ class MainActivity : ComponentActivity() {
         const val ZSE93 = "101_3_3.0"
         const val TAG = "MainActivity"
     }
-}
-
-// These destinations no longer have standalone NavHost pages in the main shell. Keep recognizing
-// them here so older entry points can still request a main tab without knowing about MainTabs.
-private fun NavDestination.asMainTabDestination(): TopLevelDestination? = when (this) {
-    Follow,
-    HotList,
-    Daily,
-    OnlineHistory,
-    Account,
-    -> this as TopLevelDestination
-    else -> null
 }

--- a/app/src/main/java/com/github/zly2006/zhihu/MainActivity.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/MainActivity.kt
@@ -55,6 +55,7 @@ import com.github.zly2006.zhihu.navigation.ArticleType
 import com.github.zly2006.zhihu.navigation.CollectionContent
 import com.github.zly2006.zhihu.navigation.History
 import com.github.zly2006.zhihu.navigation.Home
+import com.github.zly2006.zhihu.navigation.MainTabs
 import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.navigation.Notification
 import com.github.zly2006.zhihu.navigation.OnlineHistory
@@ -145,6 +146,7 @@ class MainActivity : ComponentActivity() {
     private lateinit var continuousUsageReminderManager: ContinuousUsageReminderManager
     private var pendingContentOpenIdentity: TrackedContentIdentity? = null
     private var pendingContentOpenFrom: String? = null
+    private var currentMainTabOpenSource: NavDestination? = null
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -486,7 +488,7 @@ class MainActivity : ComponentActivity() {
         navController.navigate(route) {
             if (popup) {
                 launchSingleTop = true
-                popUpTo(Home) {
+                popUpTo(MainTabs) {
                     // clear the back stack and viewModels
                     saveState = true
                 }
@@ -516,23 +518,34 @@ class MainActivity : ComponentActivity() {
         pendingContentOpenFrom = ContentOpenEventSupport.inferOpenFrom(currentContentOpenSource(), target)
     }
 
-    private fun currentContentOpenSource(): NavDestination? = runCatching {
-        navController.currentBackStackEntry?.toRoute<Article>()
-    }.getOrNull() ?: runCatching {
-        navController.currentBackStackEntry?.toRoute<Question>()
-    }.getOrNull() ?: runCatching {
-        navController.currentBackStackEntry?.toRoute<Pin>()
-    }.getOrNull() ?: runCatching {
-        navController.currentBackStackEntry?.toRoute<CollectionContent>()
-    }.getOrNull() ?: runCatching {
-        navController.currentBackStackEntry?.toRoute<Home>()
-    }.getOrNull() ?: runCatching {
-        navController.currentBackStackEntry?.toRoute<History>()
-    }.getOrNull() ?: runCatching {
-        navController.currentBackStackEntry?.toRoute<OnlineHistory>()
-    }.getOrNull() ?: runCatching {
-        navController.currentBackStackEntry?.toRoute<Notification>()
-    }.getOrNull()
+    fun setCurrentMainTabOpenSource(source: NavDestination?) {
+        currentMainTabOpenSource = source
+    }
+
+    private fun currentContentOpenSource(): NavDestination? {
+        val currentEntry = navController.currentBackStackEntry
+        return runCatching {
+            currentEntry?.toRoute<Article>()
+        }.getOrNull() ?: runCatching {
+            currentEntry?.toRoute<Question>()
+        }.getOrNull() ?: runCatching {
+            currentEntry?.toRoute<Pin>()
+        }.getOrNull() ?: runCatching {
+            currentEntry?.toRoute<CollectionContent>()
+        }.getOrNull() ?: runCatching {
+            currentEntry?.toRoute<Home>()
+        }.getOrNull() ?: runCatching {
+            currentEntry?.toRoute<History>()
+        }.getOrNull() ?: runCatching {
+            currentEntry?.toRoute<OnlineHistory>()
+        }.getOrNull() ?: runCatching {
+            currentEntry?.toRoute<Notification>()
+        }.getOrNull() ?: if (runCatching { currentEntry?.toRoute<MainTabs>() }.getOrNull() != null) {
+            currentMainTabOpenSource
+        } else {
+            null
+        }
+    }
 
     fun postHistory(dest: NavDestination) {
         history.add(dest)

--- a/app/src/main/java/com/github/zly2006/zhihu/navigation/NavDestination.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/navigation/NavDestination.kt
@@ -30,6 +30,9 @@ interface TopLevelDestination {
 }
 
 @Serializable
+data object MainTabs : NavDestination
+
+@Serializable
 data object Home : NavDestination, TopLevelDestination {
     override val name: String
         get() = "Home"

--- a/app/src/main/java/com/github/zly2006/zhihu/navigation/NavDestination.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/navigation/NavDestination.kt
@@ -28,8 +28,8 @@ sealed interface NavDestination
 /**
  * Bottom-bar and main-pager tab target.
  *
- * Some tab targets are also historical [NavDestination] values for compatibility, but [Home] is not
- * navigable anymore. Code that needs to navigate to the main shell should use [MainTabs].
+ * Tab targets can still be historical [NavDestination] values for compatibility. Code that needs to
+ * navigate to the main shell should use [MainTabs].
  */
 interface TopLevelDestination {
     val name: String
@@ -38,9 +38,9 @@ interface TopLevelDestination {
 /**
  * Real navigation destination for the main shell.
  *
- * Older top-level destinations such as [Follow] and [Daily] are still kept as serializable
- * destination values because deeplinks, clipboard parsing, settings and older call sites may resolve
- * to them. [Home] is only a tab target now. Top-level targets should be treated as tab-selection
+ * Older top-level destinations such as [Home], [Follow] and [Daily] are still kept as
+ * serializable destination values because deeplinks, clipboard parsing, settings, persisted history
+ * and older call sites may resolve to them. Top-level targets should be treated as tab-selection
  * targets, not as routes that are pushed into the main NavHost.
  */
 @Serializable
@@ -66,7 +66,7 @@ data object Home : TopLevelDestination {
  * by ZhihuMain.
  */
 @Serializable
-data object Follow : NavDestination, TopLevelDestination {
+data object Follow : TopLevelDestination {
     override val name: String
         get() = "Follow"
 }
@@ -75,7 +75,7 @@ data object Follow : NavDestination, TopLevelDestination {
  * Legacy top-level tab target for the main pager.
  */
 @Serializable
-data object HotList : NavDestination, TopLevelDestination {
+data object HotList : TopLevelDestination {
     override val name: String
         get() = "HotList"
 }
@@ -96,7 +96,7 @@ data object History : NavDestination, TopLevelDestination {
  * Legacy top-level tab target for the main pager.
  */
 @Serializable
-data object OnlineHistory : NavDestination, TopLevelDestination {
+data object OnlineHistory : TopLevelDestination {
     override val name: String
         get() = "OnlineHistory"
 }
@@ -105,7 +105,7 @@ data object OnlineHistory : NavDestination, TopLevelDestination {
  * Legacy top-level tab target for the main pager.
  */
 @Serializable
-data object Account : NavDestination, TopLevelDestination {
+data object Account : TopLevelDestination {
     override val name: String
         get() = "Account"
 
@@ -142,7 +142,7 @@ data object Account : NavDestination, TopLevelDestination {
  * Legacy top-level tab target for the main pager.
  */
 @Serializable
-data object Daily : NavDestination, TopLevelDestination {
+data object Daily : TopLevelDestination {
     override val name: String
         get() = "Daily"
 }

--- a/app/src/main/java/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
@@ -88,6 +88,7 @@ import androidx.core.net.toUri
 import coil3.compose.AsyncImage
 import com.github.zly2006.zhihu.BuildConfig
 import com.github.zly2006.zhihu.LoginActivity
+import com.github.zly2006.zhihu.MainActivity
 import com.github.zly2006.zhihu.QRCodeScanActivity
 import com.github.zly2006.zhihu.R
 import com.github.zly2006.zhihu.WebviewActivity
@@ -394,7 +395,7 @@ fun AccountSettingScreen(
                                     .background(MaterialTheme.colorScheme.primaryContainer)
                                     .clickable {
                                         onDismissRequest()
-                                        navigator.onNavigate(OnlineHistory)
+                                        (context as? MainActivity)?.navigateMainTab(OnlineHistory)
                                     }.padding(8.dp, 16.dp),
                                 verticalArrangement = Arrangement.Center,
                                 horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/github/zly2006/zhihu/ui/FollowScreen.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/FollowScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -118,7 +119,6 @@ fun FollowScreen(
     val pagerState = rememberPagerState(pageCount = { titles.size })
     val coroutineScope = rememberCoroutineScope()
 
-    // 同步PagerState和ViewModel的selectedTabIndex
     LaunchedEffect(pagerState.currentPage) {
         viewModel.selectedTabIndex = pagerState.currentPage
     }
@@ -130,27 +130,19 @@ fun FollowScreen(
     }
 
     Column(modifier = Modifier.padding(bottom = innerPadding.calculateBottomPadding())) {
-        PrimaryTabRow(
+        FollowTabRow(
             selectedTabIndex = viewModel.selectedTabIndex,
+            onTabSelected = { index ->
+                viewModel.selectedTabIndex = index
+                coroutineScope.launch {
+                    pagerState.animateScrollToPage(index)
+                }
+            },
             modifier = Modifier
                 .padding(
                     top = innerPadding.calculateTopPadding(),
-                ).testTag(FOLLOW_SCREEN_TAB_ROW_TAG),
-        ) {
-            titles.forEachIndexed { index, title ->
-                Tab(
-                    modifier = Modifier.testTag(followScreenTabTag(index)),
-                    selected = viewModel.selectedTabIndex == index,
-                    onClick = {
-                        viewModel.selectedTabIndex = index
-                        coroutineScope.launch {
-                            pagerState.animateScrollToPage(index)
-                        }
-                    },
-                    text = { Text(text = title, maxLines = 2, overflow = TextOverflow.Ellipsis) },
-                )
-            }
-        }
+                ),
+        )
 
         HorizontalPager(
             state = pagerState,
@@ -173,6 +165,59 @@ fun FollowScreen(
                     onTestLoadMore = onTestDynamicLoadMore,
                 )
             }
+        }
+    }
+}
+
+@Composable
+fun FollowTopLevelPage(
+    selectedTabIndex: Int,
+    onTabSelected: (Int) -> Unit,
+    scrollToTopTrigger: Int = 0,
+    innerPadding: PaddingValues = PaddingValues(0.dp),
+    isActive: Boolean = true,
+) {
+    Column(
+        modifier = Modifier
+            .padding(bottom = innerPadding.calculateBottomPadding())
+            .then(if (isActive) Modifier else Modifier.clearAndSetSemantics {}),
+    ) {
+        FollowTabRow(
+            selectedTabIndex = selectedTabIndex,
+            onTabSelected = onTabSelected,
+            modifier = Modifier.padding(top = innerPadding.calculateTopPadding()),
+        )
+        when (selectedTabIndex) {
+            0 -> FollowRecommendScreen(
+                scrollToTopTrigger = scrollToTopTrigger,
+                isActive = isActive,
+            )
+            1 -> FollowDynamicScreen(
+                scrollToTopTrigger = scrollToTopTrigger,
+                isActive = isActive,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FollowTabRow(
+    selectedTabIndex: Int,
+    onTabSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val titles = listOf("推荐", "动态")
+    PrimaryTabRow(
+        selectedTabIndex = selectedTabIndex,
+        modifier = modifier.testTag(FOLLOW_SCREEN_TAB_ROW_TAG),
+    ) {
+        titles.forEachIndexed { index, title ->
+            Tab(
+                modifier = Modifier.testTag(followScreenTabTag(index)),
+                selected = selectedTabIndex == index,
+                onClick = { onTabSelected(index) },
+                text = { Text(text = title, maxLines = 2, overflow = TextOverflow.Ellipsis) },
+            )
         }
     }
 }

--- a/app/src/main/java/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -289,9 +289,9 @@ fun ZhihuMain(modifier: Modifier = Modifier, navController: NavHostController) {
     val mainTabNavigationTarget = activity.mainTabNavigationTarget
     LaunchedEffect(mainTabNavigationTarget, mainTabPages) {
         mainTabNavigationTarget?.let { destination ->
-            // MainActivity maps legacy top-level routes onto MainTabs. Consume that request here so
-            // callers such as deeplinks can still select Home/Follow/etc. without adding those old
-            // routes back to the NavHost graph.
+            // MainActivity maps legacy top-level route requests onto MainTabs. Consume that request
+            // here so callers such as deeplinks can still select Home/Follow/etc. without pushing
+            // those old routes onto the back stack.
             mainPagerState.scrollToPage(pageIndexForBottomDestination(destination))
             activity.consumeMainTabNavigationTarget(destination)
         }
@@ -401,17 +401,7 @@ fun ZhihuMain(modifier: Modifier = Modifier, navController: NavHostController) {
         CompositionLocalProvider(
             LocalNavigator provides Navigator(
                 onNavigate = { destination ->
-                    val isMainTabDestination = destination is TopLevelDestination &&
-                        mainTabPages.any { it.bottomDestination::class == destination::class }
-                    if (isMainTabDestination && navEntry.hasRoute(MainTabs::class)) {
-                        navigateTopLevel(destination)
-                    } else if (isMainTabDestination) {
-                        // When a detail page asks for a main tab, pop back to the MainTabs shell
-                        // first. Only switching the pager would leave the detail route in front.
-                        activity.navigate(destination as NavDestination, popup = true)
-                    } else {
-                        activity.navigate(destination)
-                    }
+                    activity.navigate(destination)
                 },
                 onNavigateBack = navController::popBackStack,
             ),

--- a/app/src/main/java/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -29,9 +29,14 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.History
@@ -56,6 +61,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -94,6 +101,7 @@ import com.github.zly2006.zhihu.navigation.History
 import com.github.zly2006.zhihu.navigation.Home
 import com.github.zly2006.zhihu.navigation.HotList
 import com.github.zly2006.zhihu.navigation.LocalNavigator
+import com.github.zly2006.zhihu.navigation.MainTabs
 import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.navigation.Navigator
 import com.github.zly2006.zhihu.navigation.Notification
@@ -120,11 +128,32 @@ import com.github.zly2006.zhihu.ui.subscreens.navDestinationFromName
 import com.github.zly2006.zhihu.ui.subscreens.normalizeBottomBarSelection
 import com.github.zly2006.zhihu.ui.subscreens.resolveValidStartDestinationKey
 import com.github.zly2006.zhihu.viewmodel.ArticleViewModel
+import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 import com.github.zly2006.zhihu.ui.NavHost as MyNavHost
 
 const val SURVEY_URL = "https://v.wjx.cn/vm/Ppfw2R4.aspx#"
 
+private sealed class MainTabPage(
+    val bottomDestination: NavDestination,
+    val key: String,
+) {
+    data object HomePage : MainTabPage(Home, "home")
+
+    data object FollowRecommendPage : MainTabPage(Follow, "follow_recommend")
+
+    data object FollowDynamicPage : MainTabPage(Follow, "follow_dynamic")
+
+    data object HotListPage : MainTabPage(HotList, "hotlist")
+
+    data object DailyPage : MainTabPage(Daily, "daily")
+
+    data object OnlineHistoryPage : MainTabPage(OnlineHistory, "online_history")
+
+    data object AccountPage : MainTabPage(Account, "account")
+}
+
+@OptIn(ExperimentalFoundationApi::class)
 @SuppressLint("RestrictedApi")
 @Composable
 fun ZhihuMain(modifier: Modifier = Modifier, navController: NavHostController) {
@@ -198,15 +227,61 @@ fun ZhihuMain(modifier: Modifier = Modifier, navController: NavHostController) {
     )
     val bottomBarItems = allBottomBarItems.filter { it.first.name in selectedBottomBarItemKeys }
 
-    // 获取页面索引的函数
-    fun getPageIndex(route: androidx.navigation.NavDestination): Int = when {
-        route.hasRoute<Home>() -> 0
-        route.hasRoute<Follow>() -> 1
-        route.hasRoute<HotList>() -> 2
-        route.hasRoute<Daily>() -> 3
-        route.hasRoute<OnlineHistory>() -> 4
-        route.hasRoute<Account>() -> 5
-        else -> -1
+    val mainTabPages = remember(bottomBarItems) {
+        bottomBarItems.flatMap { item ->
+            when (item.first) {
+                Home -> listOf(MainTabPage.HomePage)
+                Follow -> listOf(MainTabPage.FollowRecommendPage, MainTabPage.FollowDynamicPage)
+                HotList -> listOf(MainTabPage.HotListPage)
+                Daily -> listOf(MainTabPage.DailyPage)
+                OnlineHistory -> listOf(MainTabPage.OnlineHistoryPage)
+                Account -> listOf(MainTabPage.AccountPage)
+                else -> emptyList()
+            }
+        }
+    }
+
+    fun pageIndexForDestination(destination: NavDestination): Int = mainTabPages
+        .indexOfFirst {
+            it.bottomDestination::class == destination::class
+        }.takeIf { it >= 0 } ?: 0
+
+    var lastFollowPageKey by rememberSaveable { mutableStateOf(MainTabPage.FollowRecommendPage.key) }
+    val mainPagerState = rememberPagerState(
+        initialPage = pageIndexForDestination(startDestination),
+        pageCount = { mainTabPages.size },
+    )
+    val coroutineScope = rememberCoroutineScope()
+
+    fun currentMainTabPage(): MainTabPage? = mainTabPages.getOrNull(mainPagerState.currentPage)
+
+    fun pageIndexForBottomDestination(destination: NavDestination): Int {
+        if (destination == Follow) {
+            val rememberedFollowPage = mainTabPages.indexOfFirst { it.key == lastFollowPageKey }
+            if (rememberedFollowPage >= 0) return rememberedFollowPage
+        }
+        return pageIndexForDestination(destination)
+    }
+
+    fun navigateTopLevel(destination: NavDestination) {
+        val targetPage = pageIndexForBottomDestination(destination)
+        coroutineScope.launch {
+            mainPagerState.animateScrollToPage(targetPage)
+        }
+    }
+
+    LaunchedEffect(mainPagerState.currentPage, mainTabPages) {
+        when (val page = currentMainTabPage()) {
+            MainTabPage.FollowRecommendPage, MainTabPage.FollowDynamicPage -> lastFollowPageKey = page.key
+            else -> {}
+        }
+        activity.setCurrentMainTabOpenSource(currentMainTabPage()?.bottomDestination)
+    }
+
+    LaunchedEffect(mainTabPages, startDestination) {
+        if (mainTabPages.isNotEmpty() && mainPagerState.currentPage !in mainTabPages.indices) {
+            mainPagerState.scrollToPage(pageIndexForDestination(startDestination))
+        }
     }
 
     // 通用动画创建函数
@@ -261,6 +336,9 @@ fun ZhihuMain(modifier: Modifier = Modifier, navController: NavHostController) {
             if (navEntry != null) {
                 // 页面切换时重置底部导航栏可见状态
                 LaunchedEffect(navEntry) { isBottomBarVisible = true }
+                val currentBottomDestination = mainTabPages
+                    .getOrNull(mainPagerState.targetPage)
+                    ?.bottomDestination
                 AnimatedVisibility(
                     visible = (!autoHideBottomBar || isBottomBarVisible) && isTopLevelDest(navEntry),
                     enter = slideInVertically(tween(200)) { it },
@@ -280,14 +358,10 @@ fun ZhihuMain(modifier: Modifier = Modifier, navController: NavHostController) {
                         ) {
                             val tag = "nav_tab_${(destination as? TopLevelDestination)?.name?.lowercase() ?: label.lowercase()}"
                             NavigationBarItem(
-                                navEntry.hasRoute(destination::class),
+                                currentBottomDestination?.let { it::class == destination::class } == true,
                                 onClick = {
-                                    if (!navEntry.hasRoute(destination::class)) {
-                                        navController.navigate(destination) {
-                                            popUpTo(startDestination)
-                                            launchSingleTop = true
-                                            restoreState = true
-                                        }
+                                    if (currentBottomDestination?.let { it::class == destination::class } != true) {
+                                        navigateTopLevel(destination)
                                     } else if (tapToScrollToTopEnabled) {
                                         scrollToTopTrigger++
                                     }
@@ -340,39 +414,55 @@ fun ZhihuMain(modifier: Modifier = Modifier, navController: NavHostController) {
     ) { innerPadding ->
         CompositionLocalProvider(
             LocalNavigator provides Navigator(
-                onNavigate = activity::navigate,
+                onNavigate = { destination ->
+                    if (
+                        destination is TopLevelDestination &&
+                        mainTabPages.any { it.bottomDestination::class == destination::class }
+                    ) {
+                        navigateTopLevel(destination)
+                    } else {
+                        activity.navigate(destination)
+                    }
+                },
                 onNavigateBack = navController::popBackStack,
             ),
         ) {
             MyNavHost(
                 navController,
                 modifier = Modifier,
-                startDestination = startDestination,
+                startDestination = MainTabs,
                 enterTransition = {
-                    val fromIndex = getPageIndex(initialState.destination)
-                    val toIndex = getPageIndex(targetState.destination)
-                    createSlideAnimation(isEnter = true, isPop = false, fromIndex, toIndex) as EnterTransition
+                    createSlideAnimation(isEnter = true, isPop = false, -1, -1) as EnterTransition
                 },
                 exitTransition = {
-                    val fromIndex = getPageIndex(initialState.destination)
-                    val toIndex = getPageIndex(targetState.destination)
-                    createSlideAnimation(isEnter = false, isPop = false, fromIndex, toIndex) as ExitTransition
+                    createSlideAnimation(isEnter = false, isPop = false, -1, -1) as ExitTransition
                 },
                 popEnterTransition = {
-                    val fromIndex = getPageIndex(initialState.destination)
-                    val toIndex = getPageIndex(targetState.destination)
-                    createSlideAnimation(isEnter = true, isPop = true, fromIndex, toIndex) as EnterTransition
+                    createSlideAnimation(isEnter = true, isPop = true, -1, -1) as EnterTransition
                 },
                 popExitTransition = {
-                    val fromIndex = getPageIndex(initialState.destination)
-                    val toIndex = getPageIndex(targetState.destination)
-                    createSlideAnimation(isEnter = false, isPop = true, fromIndex, toIndex) as ExitTransition
+                    createSlideAnimation(isEnter = false, isPop = true, -1, -1) as ExitTransition
                 },
             ) {
-                composable<Home> {
-                    HomeScreen(
+                composable<MainTabs> {
+                    MainTabsPager(
+                        pagerState = mainPagerState,
+                        pages = mainTabPages,
                         scrollToTopTrigger = scrollToTopTrigger,
                         innerPadding = innerPadding,
+                        onFollowTabSelected = { followTabIndex ->
+                            val page = if (followTabIndex == 0) {
+                                MainTabPage.FollowRecommendPage
+                            } else {
+                                MainTabPage.FollowDynamicPage
+                            }
+                            val index = mainTabPages.indexOfFirst { it.key == page.key }
+                            if (index >= 0) {
+                                coroutineScope.launch {
+                                    mainPagerState.animateScrollToPage(index)
+                                }
+                            }
+                        },
                     )
                 }
                 composable<Question> { navEntry ->
@@ -508,12 +598,48 @@ fun ZhihuMain(modifier: Modifier = Modifier, navController: NavHostController) {
     }
 }
 
-private fun isTopLevelDest(navEntry: NavBackStackEntry?): Boolean = navEntry.hasRoute(Home::class) ||
-    navEntry.hasRoute(Follow::class) ||
-    navEntry.hasRoute(HotList::class) ||
-    navEntry.hasRoute(Daily::class) ||
-    navEntry.hasRoute(OnlineHistory::class) ||
-    navEntry.hasRoute(Account::class)
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun MainTabsPager(
+    pagerState: PagerState,
+    pages: List<MainTabPage>,
+    scrollToTopTrigger: Int,
+    innerPadding: androidx.compose.foundation.layout.PaddingValues,
+    onFollowTabSelected: (Int) -> Unit,
+) {
+    HorizontalPager(
+        state = pagerState,
+        modifier = Modifier.fillMaxSize(),
+    ) { pageIndex ->
+        val page = pages.getOrNull(pageIndex) ?: return@HorizontalPager
+        when (page) {
+            MainTabPage.HomePage -> HomeScreen(
+                scrollToTopTrigger = scrollToTopTrigger,
+                innerPadding = innerPadding,
+            )
+            MainTabPage.FollowRecommendPage -> FollowTopLevelPage(
+                selectedTabIndex = 0,
+                onTabSelected = onFollowTabSelected,
+                scrollToTopTrigger = scrollToTopTrigger,
+                innerPadding = innerPadding,
+                isActive = pagerState.currentPage == pageIndex,
+            )
+            MainTabPage.FollowDynamicPage -> FollowTopLevelPage(
+                selectedTabIndex = 1,
+                onTabSelected = onFollowTabSelected,
+                scrollToTopTrigger = scrollToTopTrigger,
+                innerPadding = innerPadding,
+                isActive = pagerState.currentPage == pageIndex,
+            )
+            MainTabPage.HotListPage -> HotListScreen(innerPadding)
+            MainTabPage.DailyPage -> DailyScreen()
+            MainTabPage.OnlineHistoryPage -> OnlineHistoryScreen()
+            MainTabPage.AccountPage -> AccountSettingScreen(innerPadding)
+        }
+    }
+}
+
+private fun isTopLevelDest(navEntry: NavBackStackEntry?): Boolean = navEntry.hasRoute(MainTabs::class)
 
 internal fun NavBackStackEntry?.hasRoute(cls: KClass<out NavDestination>): Boolean {
     val dest = this?.destination ?: return false

--- a/app/src/main/java/com/github/zly2006/zhihu/viewmodel/filter/ContentOpenEventSupport.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/viewmodel/filter/ContentOpenEventSupport.kt
@@ -24,7 +24,6 @@ import com.github.zly2006.zhihu.navigation.CollectionContent
 import com.github.zly2006.zhihu.navigation.History
 import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.navigation.Notification
-import com.github.zly2006.zhihu.navigation.OnlineHistory
 import com.github.zly2006.zhihu.navigation.Pin
 import com.github.zly2006.zhihu.navigation.Question
 import kotlinx.coroutines.Dispatchers
@@ -76,7 +75,7 @@ object ContentOpenEventSupport {
             target.type == ArticleType.Answer -> ContentOpenFrom.ANSWER_SWITCH
         source is Question -> ContentOpenFrom.QUESTION_FEED
         source is CollectionContent -> ContentOpenFrom.COLLECTION
-        source is History || source is OnlineHistory -> ContentOpenFrom.HISTORY
+        source is History -> ContentOpenFrom.HISTORY
         source is Notification -> ContentOpenFrom.NOTIFICATION
         else -> ContentOpenFrom.UNKNOWN
     }

--- a/app/src/test/java/com/github/zly2006/zhihu/viewmodel/filter/ContentOpenEventSupportTest.kt
+++ b/app/src/test/java/com/github/zly2006/zhihu/viewmodel/filter/ContentOpenEventSupportTest.kt
@@ -21,7 +21,6 @@ import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.ArticleType
 import com.github.zly2006.zhihu.navigation.CollectionContent
 import com.github.zly2006.zhihu.navigation.History
-import com.github.zly2006.zhihu.navigation.Home
 import com.github.zly2006.zhihu.navigation.Notification
 import com.github.zly2006.zhihu.navigation.Person
 import com.github.zly2006.zhihu.navigation.Pin
@@ -33,13 +32,6 @@ import org.junit.Test
 class ContentOpenEventSupportTest {
     @Test
     fun inferOpenFrom_mapsKnownSourceAndTargetPairs() {
-        assertEquals(
-            ContentOpenFrom.HOME_FEED,
-            ContentOpenEventSupport.inferOpenFrom(
-                source = Home,
-                target = Article(type = ArticleType.Answer, id = 1L),
-            ),
-        )
         assertEquals(
             ContentOpenFrom.QUESTION_FEED,
             ContentOpenEventSupport.inferOpenFrom(


### PR DESCRIPTION
Resolves #318

## 变更说明

- 将主界面一级页面改为扁平的 `HorizontalPager`：主页、关注推荐、关注动态、热榜、日报、历史、账号按顺序横向切换。
- 底部栏仍只保留一个“关注”入口，关注推荐和关注动态两个 pager 页面都会保持“关注”底部选中态。
- 点击“关注”会回到上次停留的关注子页，默认进入推荐页。
- 保留独立 `FollowScreen` 的内部 pager 用法，并抽出关注顶部 Tab 复用。
- 为主 pager 场景补充导航仪器测试，覆盖关注两个子页和下一个主页面之间的横滑选中态。

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `./gradlew --no-configuration-cache connectedLiteDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.github.zly2006.zhihu.ZhihuMainNavigationInstrumentedTest` 已在切分支前通过；按要求直接发 PR 时，新分支上该命令已启动但未等待完成。
- 已安装 lite debug 到 AVD，并手动验证：主页 -> 关注推荐 -> 关注动态 -> 日报 横滑切换，底部选中态符合预期。
