### PR TITLE
fix: 屏蔽用户功能在多个页面失效

### DIFF
--- a/app/src/main/java/com/github/zly2006/zhihu/ui/HotListScreen.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/HotListScreen.kt
@@ -95,6 +95,12 @@ fun HotListScreen(
                 FeedCard(
                     item,
                     thumbnailUrl = (item.feed as? HotListFeed)?.children?.firstOrNull()?.thumbnail,
+                    onBlockUser = { feedItem ->
+                        viewModel.handleBlockUser(context, feedItem) { authorInfo ->
+                            userToBlock = authorInfo
+                            showBlockUserDialog = true
+                        }
+                    },
                 )
             }
 


### PR DESCRIPTION
## 问题

多个页面的 `FeedCard` 调用缺少 `onBlockUser` 回调，导致菜单中「屏蔽用户」按钮可见但点击无响应。

### 受影响的页面

| 页面 | 文件 | ViewModel |
|------|------|----------|
| 热榜 | `HotListScreen.kt` | `HotListViewModel` (BaseFeedViewModel) |
| 搜索结果 | `SearchScreen.kt` | `SearchViewModel` (BaseFeedViewModel) |
| 问题详情页 | `QuestionScreen.kt` | `QuestionFeedViewModel` (BaseFeedViewModel) |
| 在线历史记录 | `OnlineHistoryScreen.kt` | `OnlineHistoryViewModel` (BaseFeedViewModel) |
| 本地历史记录 | `LegacyLocalHistoryScreen.kt` | `HistoryViewModel` (BaseFeedViewModel) |
| 收藏夹内容 | `CollectionContentScreen.kt` | `CollectionContentViewModel` (PaginationViewModel) |

仅 `HomeScreen` 和 `FollowScreen` 正确实现了该功能。

## 修复

### 1. BaseFeedViewModel 子类（5个页面）

补上 `onBlockUser` 回调，与 HomeScreen / FollowScreen 一致：

```kotlin
onBlockUser = { feedItem ->
    viewModel.handleBlockUser(context, feedItem) { authorInfo ->
        userToBlock = authorInfo
        showBlockUserDialog = true
    }
},
```

### 2. CollectionContentScreen（非 BaseFeedViewModel）

`CollectionContentViewModel` 继承自 `PaginationViewModel`，没有 `handleBlockUser` 方法。新增独立工具函数 `resolveAuthorForBlocking()` 供其使用：

```kotlin
onBlockUser = { feedItem ->
    coroutineScope.launch {
        val authorInfo = resolveAuthorForBlocking(context, feedItem)
        if (authorInfo != null) {
            userToBlock = authorInfo
            showBlockUserDialog = true
        } else {
            Toast.makeText(context, "无法获取屏蔽用户所需的数据", Toast.LENGTH_LONG).show()
        }
    }
},
```

### 3. 新增工具函数

在 `BlockUserDialog.kt` 中添加 `resolveAuthorForBlocking()` 独立函数，逻辑与 `BaseFeedViewModel.ensureAuthorInfo` 一致，供非 BaseFeedViewModel 的屏幕复用。