### PR TITLE
优化关注页面标签栏的交互体验

### DIFF
--- a/app/src/main/java/com/github/zly2006/zhihu/ui/FollowScreen.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/FollowScreen.kt
@@ -61,9 +61,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.ViewModel
@@ -143,10 +148,38 @@ fun FollowScreen(
                 ),
         )
 
+        val nestedScrollConnection = remember(pagerState) {
+            object : NestedScrollConnection {
+                override fun onPostScroll(
+                    consumed: Offset,
+                    available: Offset,
+                    source: NestedScrollSource
+                ): Offset {
+                    return if (consumed.x != 0f) {
+                        Offset(available.x, 0f)
+                    } else {
+                        Offset.Zero
+                    }
+                }
+
+                override suspend fun onPostFling(
+                    consumed: Velocity,
+                    available: Velocity
+                ): Velocity {
+                    return if (consumed.x != 0f) {
+                        Velocity(available.x, 0f)
+                    } else {
+                        Velocity.Zero
+                    }
+                }
+            }
+        }
+
         HorizontalPager(
             state = pagerState,
             modifier = Modifier
                 .fillMaxSize()
+                .nestedScroll(nestedScrollConnection)
                 .testTag(FOLLOW_SCREEN_PAGER_TAG),
         ) { page ->
             when (page) {

--- a/app/src/main/java/com/github/zly2006/zhihu/ui/FollowScreen.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/FollowScreen.kt
@@ -62,7 +62,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -165,37 +164,6 @@ fun FollowScreen(
                     onTestLoadMore = onTestDynamicLoadMore,
                 )
             }
-        }
-    }
-}
-
-@Composable
-fun FollowTopLevelPage(
-    selectedTabIndex: Int,
-    onTabSelected: (Int) -> Unit,
-    scrollToTopTrigger: Int = 0,
-    innerPadding: PaddingValues = PaddingValues(0.dp),
-    isActive: Boolean = true,
-) {
-    Column(
-        modifier = Modifier
-            .padding(bottom = innerPadding.calculateBottomPadding())
-            .then(if (isActive) Modifier else Modifier.clearAndSetSemantics {}),
-    ) {
-        FollowTabRow(
-            selectedTabIndex = selectedTabIndex,
-            onTabSelected = onTabSelected,
-            modifier = Modifier.padding(top = innerPadding.calculateTopPadding()),
-        )
-        when (selectedTabIndex) {
-            0 -> FollowRecommendScreen(
-                scrollToTopTrigger = scrollToTopTrigger,
-                isActive = isActive,
-            )
-            1 -> FollowDynamicScreen(
-                scrollToTopTrigger = scrollToTopTrigger,
-                isActive = isActive,
-            )
         }
     }
 }

--- a/app/src/main/java/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -62,7 +62,6 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -141,9 +140,7 @@ private sealed class MainTabPage(
 ) {
     data object HomePage : MainTabPage(Home, "home")
 
-    data object FollowRecommendPage : MainTabPage(Follow, "follow_recommend")
-
-    data object FollowDynamicPage : MainTabPage(Follow, "follow_dynamic")
+    data object FollowPage : MainTabPage(Follow, "follow")
 
     data object HotListPage : MainTabPage(HotList, "hotlist")
 
@@ -232,7 +229,7 @@ fun ZhihuMain(modifier: Modifier = Modifier, navController: NavHostController) {
         bottomBarItems.flatMap { item ->
             when (item.first) {
                 Home -> listOf(MainTabPage.HomePage)
-                Follow -> listOf(MainTabPage.FollowRecommendPage, MainTabPage.FollowDynamicPage)
+                Follow -> listOf(MainTabPage.FollowPage)
                 HotList -> listOf(MainTabPage.HotListPage)
                 Daily -> listOf(MainTabPage.DailyPage)
                 OnlineHistory -> listOf(MainTabPage.OnlineHistoryPage)
@@ -250,7 +247,6 @@ fun ZhihuMain(modifier: Modifier = Modifier, navController: NavHostController) {
             it.bottomDestination::class == startDestination::class
         }.takeIf { it >= 0 } ?: 0
 
-    var lastFollowPageKey by rememberSaveable { mutableStateOf(MainTabPage.FollowRecommendPage.key) }
     val mainPagerState = rememberPagerState(
         initialPage = pageIndexForDestination(startDestination),
         pageCount = { mainTabPages.size },
@@ -260,13 +256,8 @@ fun ZhihuMain(modifier: Modifier = Modifier, navController: NavHostController) {
     fun currentMainTabPage(): MainTabPage? = mainTabPages.getOrNull(mainPagerState.currentPage)
     var currentMainTabDestination by remember { mutableStateOf(startDestination) }
 
-    fun pageIndexForBottomDestination(destination: TopLevelDestination): Int {
-        if (destination == Follow) {
-            val rememberedFollowPage = mainTabPages.indexOfFirst { it.key == lastFollowPageKey }
-            if (rememberedFollowPage >= 0) return rememberedFollowPage
-        }
-        return pageIndexForDestination(destination)
-    }
+    fun pageIndexForBottomDestination(destination: TopLevelDestination): Int =
+        pageIndexForDestination(destination)
 
     fun navigateTopLevel(destination: TopLevelDestination) {
         val targetPage = pageIndexForBottomDestination(destination)
@@ -276,10 +267,6 @@ fun ZhihuMain(modifier: Modifier = Modifier, navController: NavHostController) {
     }
 
     LaunchedEffect(mainPagerState.currentPage, mainTabPages) {
-        when (val page = currentMainTabPage()) {
-            MainTabPage.FollowRecommendPage, MainTabPage.FollowDynamicPage -> lastFollowPageKey = page.key
-            else -> {}
-        }
         currentMainTabPage()?.bottomDestination?.let { destination ->
             currentMainTabDestination = destination
             activity.setCurrentMainTabOpenFrom(destination.openFrom)
@@ -429,19 +416,6 @@ fun ZhihuMain(modifier: Modifier = Modifier, navController: NavHostController) {
                         pages = mainTabPages,
                         scrollToTopTrigger = scrollToTopTrigger,
                         innerPadding = innerPadding,
-                        onFollowTabSelected = { followTabIndex ->
-                            val page = if (followTabIndex == 0) {
-                                MainTabPage.FollowRecommendPage
-                            } else {
-                                MainTabPage.FollowDynamicPage
-                            }
-                            val index = mainTabPages.indexOfFirst { it.key == page.key }
-                            if (index >= 0) {
-                                coroutineScope.launch {
-                                    mainPagerState.animateScrollToPage(index)
-                                }
-                            }
-                        },
                     )
                 }
                 composable<Question> { navEntry ->
@@ -584,7 +558,6 @@ private fun MainTabsPager(
     pages: List<MainTabPage>,
     scrollToTopTrigger: Int,
     innerPadding: androidx.compose.foundation.layout.PaddingValues,
-    onFollowTabSelected: (Int) -> Unit,
 ) {
     HorizontalPager(
         state = pagerState,
@@ -596,19 +569,9 @@ private fun MainTabsPager(
                 scrollToTopTrigger = scrollToTopTrigger,
                 innerPadding = innerPadding,
             )
-            MainTabPage.FollowRecommendPage -> FollowTopLevelPage(
-                selectedTabIndex = 0,
-                onTabSelected = onFollowTabSelected,
+            MainTabPage.FollowPage -> FollowScreen(
                 scrollToTopTrigger = scrollToTopTrigger,
                 innerPadding = innerPadding,
-                isActive = pagerState.currentPage == pageIndex,
-            )
-            MainTabPage.FollowDynamicPage -> FollowTopLevelPage(
-                selectedTabIndex = 1,
-                onTabSelected = onFollowTabSelected,
-                scrollToTopTrigger = scrollToTopTrigger,
-                innerPadding = innerPadding,
-                isActive = pagerState.currentPage == pageIndex,
             )
             MainTabPage.HotListPage -> HotListScreen(innerPadding)
             MainTabPage.DailyPage -> DailyScreen()


### PR DESCRIPTION
## 现在的表现

在关注页面左右滑动切换"推荐"和"动态"时，顶部的标签栏会跟着一起滑动。

https://github.com/user-attachments/assets/f2f245f5-11bf-47fb-a6d5-d73a5c311671

## 更新后的表现

不管在"推荐"还是"动态"之间怎么滑动，标签栏始终固定在屏幕顶部，比较符合用户的交互直觉。

https://github.com/user-attachments/assets/98cb6516-f3ba-4100-9fe4-7ce6d710230f
