### PR TITLE
feat: 关注页推荐/动态标签栏固定在顶部，横滑切换不再带动标签栏

### DIFF
--- a/app/src/main/java/com/github/zly2006/zhihu/ui/FollowScreen.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/FollowScreen.kt
@@ -88,6 +88,10 @@ class FollowScreenData : ViewModel() {
     var selectedTabIndex by mutableIntStateOf(0)
 }
 
+// 固定标签栏用的是 PrimaryTabRow，其纯文字高度为 Material3 默认的 48dp；
+// 关注页内容按此值留出顶部空间，必须与实际标签栏高度保持一致
+private val FOLLOW_TAB_ROW_HEIGHT = 48.dp
+
 const val FOLLOW_SCREEN_TAB_ROW_TAG = "follow_screen_tab_row"
 const val FOLLOW_SCREEN_PAGER_TAG = "follow_screen_pager"
 const val FOLLOWING_USERS_ROW_TAG = "following_users_row"
@@ -172,21 +176,18 @@ fun FollowScreen(
 @Composable
 fun FollowTopLevelPage(
     selectedTabIndex: Int,
-    onTabSelected: (Int) -> Unit,
     scrollToTopTrigger: Int = 0,
     innerPadding: PaddingValues = PaddingValues(0.dp),
     isActive: Boolean = true,
 ) {
+    // 标签栏由 MainTabsPager 固定在顶部渲染，这里只放内容并为其留出顶部空间
     Column(
         modifier = Modifier
-            .padding(bottom = innerPadding.calculateBottomPadding())
-            .then(if (isActive) Modifier else Modifier.clearAndSetSemantics {}),
+            .padding(
+                top = innerPadding.calculateTopPadding() + FOLLOW_TAB_ROW_HEIGHT,
+                bottom = innerPadding.calculateBottomPadding(),
+            ).then(if (isActive) Modifier else Modifier.clearAndSetSemantics {}),
     ) {
-        FollowTabRow(
-            selectedTabIndex = selectedTabIndex,
-            onTabSelected = onTabSelected,
-            modifier = Modifier.padding(top = innerPadding.calculateTopPadding()),
-        )
         when (selectedTabIndex) {
             0 -> FollowRecommendScreen(
                 scrollToTopTrigger = scrollToTopTrigger,
@@ -201,7 +202,7 @@ fun FollowTopLevelPage(
 }
 
 @Composable
-private fun FollowTabRow(
+internal fun FollowTabRow(
     selectedTabIndex: Int,
     onTabSelected: (Int) -> Unit,
     modifier: Modifier = Modifier,

--- a/app/src/main/java/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -30,6 +30,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -586,36 +587,60 @@ private fun MainTabsPager(
     innerPadding: androidx.compose.foundation.layout.PaddingValues,
     onFollowTabSelected: (Int) -> Unit,
 ) {
-    HorizontalPager(
-        state = pagerState,
-        modifier = Modifier.fillMaxSize(),
-    ) { pageIndex ->
-        val page = pages.getOrNull(pageIndex) ?: return@HorizontalPager
-        when (page) {
-            MainTabPage.HomePage -> HomeScreen(
-                scrollToTopTrigger = scrollToTopTrigger,
-                innerPadding = innerPadding,
-            )
-            MainTabPage.FollowRecommendPage -> FollowTopLevelPage(
-                selectedTabIndex = 0,
+    Box(modifier = Modifier.fillMaxSize()) {
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxSize(),
+        ) { pageIndex ->
+            val page = pages.getOrNull(pageIndex) ?: return@HorizontalPager
+            when (page) {
+                MainTabPage.HomePage -> HomeScreen(
+                    scrollToTopTrigger = scrollToTopTrigger,
+                    innerPadding = innerPadding,
+                )
+                MainTabPage.FollowRecommendPage -> FollowTopLevelPage(
+                    selectedTabIndex = 0,
+                    scrollToTopTrigger = scrollToTopTrigger,
+                    innerPadding = innerPadding,
+                    isActive = pagerState.currentPage == pageIndex,
+                )
+                MainTabPage.FollowDynamicPage -> FollowTopLevelPage(
+                    selectedTabIndex = 1,
+                    scrollToTopTrigger = scrollToTopTrigger,
+                    innerPadding = innerPadding,
+                    isActive = pagerState.currentPage == pageIndex,
+                )
+                MainTabPage.HotListPage -> HotListScreen(innerPadding)
+                MainTabPage.DailyPage -> DailyScreen()
+                MainTabPage.OnlineHistoryPage -> OnlineHistoryScreen()
+                MainTabPage.AccountPage -> AccountSettingScreen(innerPadding)
+            }
+        }
+
+        // 关注页的标签栏固定在主 Pager 之上，不随推荐/动态横滑移动。
+        // 用 targetPage 而非 currentPage 判定显隐：滑离关注页时标签栏随滑动即时淡出，
+        // 落到邻页时已消失，不会滞留遮挡邻页顶部
+        val followTab = pages.getOrNull(pagerState.targetPage).followTabIndex()
+        var lastFollowTab by remember { mutableIntStateOf(0) }
+        if (followTab >= 0) lastFollowTab = followTab
+        AnimatedVisibility(
+            visible = followTab >= 0,
+            enter = fadeIn(tween(150)),
+            exit = fadeOut(tween(150)),
+        ) {
+            FollowTabRow(
+                selectedTabIndex = if (followTab >= 0) followTab else lastFollowTab,
                 onTabSelected = onFollowTabSelected,
-                scrollToTopTrigger = scrollToTopTrigger,
-                innerPadding = innerPadding,
-                isActive = pagerState.currentPage == pageIndex,
+                modifier = Modifier.padding(top = innerPadding.calculateTopPadding()),
             )
-            MainTabPage.FollowDynamicPage -> FollowTopLevelPage(
-                selectedTabIndex = 1,
-                onTabSelected = onFollowTabSelected,
-                scrollToTopTrigger = scrollToTopTrigger,
-                innerPadding = innerPadding,
-                isActive = pagerState.currentPage == pageIndex,
-            )
-            MainTabPage.HotListPage -> HotListScreen(innerPadding)
-            MainTabPage.DailyPage -> DailyScreen()
-            MainTabPage.OnlineHistoryPage -> OnlineHistoryScreen()
-            MainTabPage.AccountPage -> AccountSettingScreen(innerPadding)
         }
     }
+}
+
+private fun MainTabPage?.followTabIndex(): Int = when (this) {
+    MainTabPage.FollowRecommendPage -> 0
+    MainTabPage.FollowDynamicPage -> 1
+    else -> -1
 }
 
 private fun isTopLevelDest(navEntry: NavBackStackEntry?): Boolean = navEntry.hasRoute(MainTabs::class)


### PR DESCRIPTION
## 背景
原 #343 想让关注页推荐/动态切换时标签栏固定，但其实现把推荐/动态做成嵌套的内层 HorizontalPager，导致推荐↔动态不跟手、进出关注页手感不对称、偶发卡在两页中间。本 PR 为该需求的重做（拍平方案），不引入嵌套 Pager。

## 改动
- 推荐/动态保持为主 HorizontalPager 的两个相邻页（单层、跟手）。
- FollowTabRow 从 FollowTopLevelPage 抽出，由 MainTabsPager 在主 Pager 之上固定渲染；仅关注页显示，按 targetPage 在滑离时淡出，不遮挡相邻页顶部。
- 关注页内容留 48dp 顶部空间避开固定标签栏。

## 测试
- ktlintCheck / testLiteDebugUnitTest / assembleLiteDebug 通过；模拟器 + 真机实测手感。
- UI 双 agent 复检：修复“离开时标签栏淡出滞留遮挡邻页”，其余意见为既有/设计如此。