### PR TITLE
fix: 保留 MdAst 加粗文本旁空格

### DIFF
--- a/app/src/main/java/com/github/zly2006/zhihu/markdown/MdAst.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/markdown/MdAst.kt
@@ -94,10 +94,13 @@ private fun List<HtmlNode>.convertNodesToBlocks(): List<MarkdownNode> {
         currentParagraph = it
     }
 
-    for (node in this) {
+    for ((index, node) in this.withIndex()) {
         when (node) {
             is TextNode -> {
-                val text = node.text().trim()
+                val text = node.text().trimInlineBoundary(
+                    hasPreviousInline = currentParagraph != null,
+                    hasNextInline = drop(index + 1).hasNextInlineContent(),
+                )
                 if (text.isNotEmpty()) {
                     paragraph().appendChild(
                         Text(text),
@@ -137,6 +140,52 @@ private fun List<HtmlNode>.convertNodesToBlocks(): List<MarkdownNode> {
     }
 
     return blocks
+}
+
+private fun String.trimInlineBoundary(
+    hasPreviousInline: Boolean,
+    hasNextInline: Boolean,
+): String = when {
+    isBlank() -> if (hasPreviousInline && hasNextInline) " " else ""
+    hasPreviousInline && hasNextInline -> this
+    hasPreviousInline -> trimEnd()
+    hasNextInline -> trimStart()
+    else -> trim()
+}
+
+private fun List<HtmlNode>.hasNextInlineContent(): Boolean {
+    for (node in this) {
+        if (node is Element && node.isBlockBoundary()) {
+            return false
+        }
+        if (node.hasInlineContent()) {
+            return true
+        }
+    }
+    return false
+}
+
+private fun Element.isBlockBoundary(): Boolean = when (tagName().lowercase()) {
+    "br",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "p",
+    "blockquote",
+    "pre",
+    "ul",
+    "ol",
+    "hr",
+    "figure",
+    "table",
+    "div",
+    -> true
+    "img" -> attr("eeimg") == "2"
+    "a" -> attr("class").contains("video-box")
+    else -> false
 }
 
 private fun convertElementToBlock(element: Element): List<MarkdownNode> = when (element.tagName().lowercase()) {
@@ -379,7 +428,30 @@ private fun Element.toAlignment(): Table.Alignment = when (attr("align").lowerca
     else -> Table.Alignment.NONE
 }
 
-private fun extractInlineChildren(element: Element): List<MarkdownNode> = element.childNodes().flatMap(::extractInlineNode)
+private fun extractInlineChildren(element: Element): List<MarkdownNode> {
+    val childNodes = element.childNodes()
+    return childNodes.flatMapIndexed { index, child ->
+        if (child is TextNode && child.text().isBlank()) {
+            if (childNodes.take(index).any { it.hasInlineContent() } && childNodes.drop(index + 1).any { it.hasInlineContent() }) {
+                listOf(Text(" "))
+            } else {
+                emptyList()
+            }
+        } else {
+            extractInlineNode(child)
+        }
+    }
+}
+
+private fun HtmlNode.hasInlineContent(): Boolean = when (this) {
+    is TextNode -> text().isNotBlank()
+    is Element -> when (tagName().lowercase()) {
+        "br" -> false
+        "img" -> extractEquationTex(this) != null || extractImageUrl(this) != null
+        else -> childNodes().any { it.hasInlineContent() } || text().isNotBlank()
+    }
+    else -> false
+}
 
 private fun extractEquationTex(imgElement: Element): String? = extractImageUrl(imgElement)
     ?.takeIf { it.startsWith(ZHIHU_EQUATION_URL_PREFIX) }

--- a/app/src/test/java/com/github/zly2006/zhihu/markdown/MdAstTest.kt
+++ b/app/src/test/java/com/github/zly2006/zhihu/markdown/MdAstTest.kt
@@ -24,6 +24,8 @@ import com.hrm.markdown.parser.ast.MathBlock
 import com.hrm.markdown.parser.ast.NativeBlock
 import com.hrm.markdown.parser.ast.Node
 import com.hrm.markdown.parser.ast.Paragraph
+import com.hrm.markdown.parser.ast.StrongEmphasis
+import com.hrm.markdown.parser.ast.Text
 import org.jsoup.Jsoup
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -77,6 +79,33 @@ class MdAstTest {
     }
 
     @Test
+    fun paragraph_inline_strong_text_should_keep_space_between_english_words() {
+        val document = htmlToMdAst(
+            """
+            <p>The <strong>quick</strong> <strong>brown</strong> fox jumps.</p>
+            """.trimIndent(),
+        )
+
+        assertEquals("The quick brown fox jumps.", document.plainText())
+        assertEquals(2, document.allNodes().count { it is StrongEmphasis })
+    }
+
+    @Test
+    fun blockquote_inline_strong_text_should_keep_space_between_english_words() {
+        val document = htmlToMdAst(
+            """
+            <blockquote data-pid="P3CclW4S">你看<b>过</b>某样东西，不代表你真的<b>看见</b>它了。<br>Just because you have <b>looked</b> at something doesn’t mean that you have <b>seen</b> it.</blockquote>
+            """.trimIndent(),
+        )
+
+        assertEquals(
+            "你看过某样东西，不代表你真的看见它了。Just because you have looked at something doesn’t mean that you have seen it.",
+            document.plainText(),
+        )
+        assertEquals(4, document.allNodes().count { it is StrongEmphasis })
+    }
+
+    @Test
     fun extracted_answer_content_should_keep_equation_as_math_not_figure() {
         val htmlFile = File(
             requireNotNull(javaClass.classLoader?.getResource("zhihu_answer_2035661632110585441_content.html")).toURI(),
@@ -96,4 +125,10 @@ class MdAstTest {
 
     private fun Node.allNodes(): List<Node> =
         listOf(this) + if (this is ContainerNode) children.flatMap { it.allNodes() } else emptyList()
+
+    private fun Node.plainText(): String = when (this) {
+        is Text -> literal
+        is ContainerNode -> children.joinToString(separator = "") { it.plainText() }
+        else -> ""
+    }
 }


### PR DESCRIPTION
## 修改内容

- 修复 MdAst 在加粗 inline 文本旁丢失英文词间空格的问题。
- 同时覆盖 `<p>` 内联内容和 `blockquote` 裸 inline 内容两条解析路径。
- 增加英文加粗文本空格保留的回归测试。

Resolves #360