### PR TITLE
feat: 支持屏蔽用户评论，和问题浏览页面的回答

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/CommentScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/CommentScreenInstrumentedTest.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -72,8 +73,12 @@ import com.github.zly2006.zhihu.ui.commentRowTag
 import com.github.zly2006.zhihu.viewmodel.CommentItem
 import com.github.zly2006.zhihu.viewmodel.comment.BaseCommentViewModel
 import com.github.zly2006.zhihu.viewmodel.comment.CommentSortOrder
+import com.github.zly2006.zhihu.viewmodel.filter.BlocklistManager
 import io.ktor.client.HttpClient
 import io.ktor.http.HttpMethod
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonArray
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -87,8 +92,9 @@ class CommentScreenInstrumentedTest {
     val composeRule: MainActivityComposeRule = createAndroidComposeRule<MainActivity>()
 
     @Before
-    fun setUp() {
+    fun setUp() = runBlocking {
         composeRule.resetAppPreferences()
+        BlocklistManager.getInstance(composeRule.activity).clearAllBlockedUsers()
         ZhihuMockApi.mockJsonPrefix(
             method = HttpMethod.Post,
             urlPrefix = "https://www.zhihu.com/api/v4/comments/",
@@ -99,6 +105,11 @@ class CommentScreenInstrumentedTest {
             urlPrefix = "https://www.zhihu.com/api/v4/comments/",
             body = "{}",
         )
+    }
+
+    @After
+    fun tearDown() = runBlocking {
+        BlocklistManager.getInstance(composeRule.activity).clearAllBlockedUsers()
     }
 
     @Test
@@ -304,9 +315,76 @@ class CommentScreenInstrumentedTest {
 
         composeRule.onNodeWithText("离线发送的回复").assertIsDisplayed()
         composeRule.onAllNodesWithTag(COMMENT_REPLY_BANNER_TAG).assertCountEquals(0)
-        composeRule.onNodeWithText("回复 子回复作者 1...").assertDoesNotExist()
+        composeRule.onAllNodesWithText("回复 子回复作者 1...").assertCountEquals(0)
         composeRule.onNodeWithText("写下你的评论...").assertIsDisplayed()
         assertEquals(listOf(SeededChildCommentViewModel.Submission("离线发送的回复", "child-1")), viewModel.submissions)
+    }
+
+    @Test
+    fun blockedUsersAreRemovedFromRootAndEmbeddedChildComments() {
+        /*
+         * Expected behavior:
+         * 1. Production response processing should remove a root comment authored by a blocked user.
+         * 2. Kept root comments should also drop embedded child comments from blocked users before
+         *    the screen receives them.
+         */
+        val viewModel = SeededRootCommentViewModel(
+            article = ROOT_ARTICLE,
+            seededComments = emptyList(),
+        )
+        runBlocking {
+            val blocklistManager = BlocklistManager.getInstance(composeRule.activity)
+            blocklistManager.addBlockedUser("blocked-root-author", "被屏蔽根评论作者")
+            blocklistManager.addBlockedUser("blocked-child-author", "被屏蔽子评论作者")
+            viewModel.processForTest(
+                composeRule.activity,
+                listOf(
+                    seedComment(
+                        id = "blocked-root",
+                        authorId = "blocked-root-author",
+                        authorName = "被屏蔽根评论作者",
+                        content = "这条根评论不应展示",
+                    ),
+                    seedComment(
+                        id = "allowed-root",
+                        authorId = "allowed-root-author",
+                        authorName = "可见根评论作者",
+                        content = "这条根评论应展示",
+                        childCommentCount = 2,
+                        childComments = listOf(
+                            seedComment(
+                                id = "blocked-child",
+                                authorId = "blocked-child-author",
+                                authorName = "被屏蔽子评论作者",
+                                content = "这条内嵌子评论不应展示",
+                            ),
+                            seedComment(
+                                id = "allowed-child",
+                                authorId = "allowed-child-author",
+                                authorName = "可见子评论作者",
+                                content = "这条内嵌子评论应展示",
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        }
+
+        setCommentScreen(
+            viewModel = viewModel,
+            testOverrides = CommentScreenTestOverrides(
+                viewModel = viewModel,
+                skipInitialLoad = true,
+            ),
+        )
+
+        composeRule.onNodeWithTag(commentRowTag("allowed-root")).assertIsDisplayed()
+        composeRule.onNodeWithText("可见根评论作者").assertIsDisplayed()
+        composeRule.onNodeWithText("这条内嵌子评论应展示").assertIsDisplayed()
+        composeRule.onAllNodesWithTag(commentRowTag("blocked-root")).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(commentRowTag("blocked-child")).assertCountEquals(0)
+        composeRule.onAllNodesWithText("被屏蔽根评论作者").assertCountEquals(0)
+        composeRule.onAllNodesWithText("被屏蔽子评论作者").assertCountEquals(0)
     }
 
     private fun setCommentScreen(
@@ -347,6 +425,10 @@ class CommentScreenInstrumentedTest {
 
         override fun createCommentItem(comment: DataHolder.Comment, article: NavDestination): CommentItem =
             CommentItem(comment, CommentHolder(comment.id, article))
+
+        suspend fun processForTest(context: android.content.Context, data: List<DataHolder.Comment>) {
+            processResponse(context, data, JsonArray(emptyList()))
+        }
 
         override fun loadMore(context: android.content.Context) {
             loadMoreCount += 1

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/QuestionScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/QuestionScreenInstrumentedTest.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.zly2006.zhihu.data.CommonFeed
+import com.github.zly2006.zhihu.data.Feed
 import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.ArticleType
 import com.github.zly2006.zhihu.navigation.Question
@@ -55,12 +57,17 @@ import com.github.zly2006.zhihu.ui.QuestionScreenUiState
 import com.github.zly2006.zhihu.ui.questionFeedItemTag
 import com.github.zly2006.zhihu.viewmodel.feed.BaseFeedViewModel
 import com.github.zly2006.zhihu.viewmodel.feed.QuestionFeedViewModel
+import com.github.zly2006.zhihu.viewmodel.filter.BlocklistManager
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonArray
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import com.github.zly2006.zhihu.data.Person as FeedPerson
 
 @RunWith(AndroidJUnit4::class)
 class QuestionScreenInstrumentedTest {
@@ -68,8 +75,14 @@ class QuestionScreenInstrumentedTest {
     val composeRule: MainActivityComposeRule = createAndroidComposeRule<MainActivity>()
 
     @Before
-    fun setUp() {
+    fun setUp() = runBlocking {
         composeRule.resetAppPreferences()
+        BlocklistManager.getInstance(composeRule.activity).clearAllBlockedUsers()
+    }
+
+    @After
+    fun tearDown() = runBlocking {
+        BlocklistManager.getInstance(composeRule.activity).clearAllBlockedUsers()
     }
 
     @Test
@@ -181,6 +194,43 @@ class QuestionScreenInstrumentedTest {
         )
     }
 
+    @Test
+    fun blockedUserAnswersAreRemovedFromQuestionFeedProcessing() {
+        /*
+         * Expected behavior:
+         * 1. Question answer feeds should honor the same blocked-user switch used by the rest of the
+         *    content filter stack.
+         * 2. A blocked answer author should be removed before display items are created, while
+         *    unblocked answers continue through the existing display mapping.
+         */
+        val viewModel = TestableQuestionFeedViewModel(123456789L)
+        runBlocking {
+            BlocklistManager
+                .getInstance(composeRule.activity)
+                .addBlockedUser("blocked-answer-author", "被屏蔽回答作者")
+            viewModel.processForTest(
+                composeRule.activity,
+                listOf(
+                    seedAnswerFeed(
+                        id = 1L,
+                        authorId = "blocked-answer-author",
+                        authorName = "被屏蔽回答作者",
+                        excerpt = "这条回答不应展示",
+                    ),
+                    seedAnswerFeed(
+                        id = 2L,
+                        authorId = "allowed-answer-author",
+                        authorName = "可见回答作者",
+                        excerpt = "这条回答应展示",
+                    ),
+                ),
+            )
+        }
+
+        assertEquals(listOf("可见回答作者"), viewModel.displayItems.map { it.authorName })
+        assertEquals(listOf("这条回答应展示"), viewModel.displayItems.map { it.summary })
+    }
+
     private fun setScreen(overrides: QuestionScreenTestOverrides): RecordingNavigator = composeRule.setScreenContent {
         QuestionScreen(
             question = Question(questionId = 123456789L, title = "离线问题标题"),
@@ -247,4 +297,43 @@ class QuestionScreenInstrumentedTest {
             localFeedId = "offline-question-item-$id",
         )
     }
+
+    private class TestableQuestionFeedViewModel(
+        questionId: Long,
+    ) : QuestionFeedViewModel(questionId) {
+        suspend fun processForTest(context: android.content.Context, data: List<Feed>) {
+            processResponse(context, data, JsonArray(emptyList()))
+        }
+    }
+
+    private fun seedAnswerFeed(
+        id: Long,
+        authorId: String,
+        authorName: String,
+        excerpt: String,
+    ): Feed = CommonFeed(
+        id = "answer-feed-$id",
+        target = Feed.AnswerTarget(
+            id = id,
+            url = "https://www.zhihu.com/answer/$id",
+            author = FeedPerson(
+                id = authorId,
+                url = "https://www.zhihu.com/people/$authorId",
+                userType = "people",
+                urlToken = "$authorId-token",
+                name = authorName,
+                headline = "$authorName 的离线签名",
+                avatarUrl = "https://example.invalid/avatar/$authorId.png",
+            ),
+            voteupCount = 10,
+            commentCount = 1,
+            question = Feed.QuestionTarget(
+                id = 123456789L,
+                _title = "离线问题标题",
+                url = "https://www.zhihu.com/question/123456789",
+                type = "question",
+            ),
+            excerpt = excerpt,
+        ),
+    )
 }

--- a/app/src/main/java/com/github/zly2006/zhihu/viewmodel/CollectionContentViewModel.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/viewmodel/CollectionContentViewModel.kt
@@ -86,7 +86,7 @@ class CollectionContentViewModel(
     override val initialUrl: String
         get() = "https://www.zhihu.com/api/v4/collections/$collectionId/items"
 
-    override fun processResponse(context: Context, data: List<CollectionItem>, rawData: JsonArray) {
+    override suspend fun processResponse(context: Context, data: List<CollectionItem>, rawData: JsonArray) {
         super.processResponse(context, data, rawData)
         displayItems.addAll(data.map { createDisplayItem(it) }) // 展示用的已flatten数据
     }

--- a/app/src/main/java/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -126,7 +126,7 @@ abstract class PaginationViewModel<T : Any>(
         return AccountData.httpClient(context)
     }
 
-    protected open fun processResponse(context: Context, data: List<T>, rawData: JsonArray) {
+    protected open suspend fun processResponse(context: Context, data: List<T>, rawData: JsonArray) {
         debugData.addAll(rawData) // 保存原始JSON
         allData.addAll(data) // 保存未flatten的数据
     }

--- a/app/src/main/java/com/github/zly2006/zhihu/viewmodel/comment/BaseCommentViewModel.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/viewmodel/comment/BaseCommentViewModel.kt
@@ -28,6 +28,7 @@ import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.util.signFetchRequest
 import com.github.zly2006.zhihu.viewmodel.CommentItem
 import com.github.zly2006.zhihu.viewmodel.PaginationViewModel
+import com.github.zly2006.zhihu.viewmodel.filter.ContentFilterExtensions
 import io.ktor.client.HttpClient
 import io.ktor.client.request.delete
 import io.ktor.client.request.post
@@ -49,9 +50,9 @@ abstract class BaseCommentViewModel(
     protected val commentsMap = mutableMapOf<String, CommentItem>()
     var sortOrder by mutableStateOf(CommentSortOrder.SCORE)
 
-    override fun processResponse(context: Context, data: List<DataHolder.Comment>, rawData: JsonArray) {
+    override suspend fun processResponse(context: Context, data: List<DataHolder.Comment>, rawData: JsonArray) {
         debugData.addAll(rawData) // 保存原始JSON
-        data.forEach { comment ->
+        filterBlockedComments(context, data).forEach { comment ->
             if (allData.none { it.id == comment.id }) {
                 // 避免服务器返回重复评论时重复添加，造成LazyColumn key冲突
                 allData.add(comment)
@@ -62,6 +63,23 @@ abstract class BaseCommentViewModel(
             comment.childComments.forEach {
                 val childCommentItem = createCommentItem(it, article)
                 commentsMap[it.id] = childCommentItem
+            }
+        }
+    }
+
+    private suspend fun filterBlockedComments(
+        context: Context,
+        comments: List<DataHolder.Comment>,
+    ): List<DataHolder.Comment> {
+        val blockedUserIds = ContentFilterExtensions.getEnabledBlockedUserIds(context)
+        if (blockedUserIds.isEmpty()) return comments
+        return comments.mapNotNull { comment ->
+            if (comment.author.id in blockedUserIds) {
+                null
+            } else {
+                comment.copy(
+                    childComments = comment.childComments.filterNot { it.author.id in blockedUserIds },
+                )
             }
         }
     }

--- a/app/src/main/java/com/github/zly2006/zhihu/viewmodel/feed/BaseFeedViewModel.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/viewmodel/feed/BaseFeedViewModel.kt
@@ -75,7 +75,7 @@ abstract class BaseFeedViewModel : PaginationViewModel<Feed>(typeOf<Feed>()) {
             get() = localFeedId ?: localContentId ?: navDestination?.toString() ?: "$title|${summary.orEmpty()}|$details"
     }
 
-    override fun processResponse(context: Context, data: List<Feed>, rawData: JsonArray) {
+    override suspend fun processResponse(context: Context, data: List<Feed>, rawData: JsonArray) {
         super.processResponse(context, data, rawData)
         addDisplayItems(data.flatten().map { createDisplayItem(context, it) })
     }

--- a/app/src/main/java/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
@@ -62,7 +62,7 @@ class HomeFeedViewModel :
     }
 
     @OptIn(DelicateCoroutinesApi::class)
-    override fun processResponse(context: Context, data: List<Feed>, rawData: JsonArray) {
+    override suspend fun processResponse(context: Context, data: List<Feed>, rawData: JsonArray) {
         allData.addAll(data)
         debugData.addAll(rawData)
 

--- a/app/src/main/java/com/github/zly2006/zhihu/viewmodel/feed/OnlineHistoryViewModel.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/viewmodel/feed/OnlineHistoryViewModel.kt
@@ -29,7 +29,7 @@ import kotlinx.serialization.json.JsonArray
 class OnlineHistoryViewModel : BaseFeedViewModel() {
     override val initialUrl: String = "https://api.zhihu.com/unify-consumption/read_history?offset=0&limit=10"
 
-    override fun processResponse(context: Context, data: List<Feed>, rawData: JsonArray) {
+    override suspend fun processResponse(context: Context, data: List<Feed>, rawData: JsonArray) {
         val history = (context as MainActivity).history
 
         val response = rawData.mapNotNull {

--- a/app/src/main/java/com/github/zly2006/zhihu/viewmodel/feed/QuestionFeedViewModel.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/viewmodel/feed/QuestionFeedViewModel.kt
@@ -26,9 +26,11 @@ import com.github.zly2006.zhihu.data.AccountData
 import com.github.zly2006.zhihu.data.Feed
 import com.github.zly2006.zhihu.data.target
 import com.github.zly2006.zhihu.util.signFetchRequest
+import com.github.zly2006.zhihu.viewmodel.filter.ContentFilterExtensions
 import io.ktor.http.HttpMethod
+import kotlinx.serialization.json.JsonArray
 
-class QuestionFeedViewModel(
+open class QuestionFeedViewModel(
     private val questionId: Long,
 ) : BaseFeedViewModel() {
     var sortOrder by mutableStateOf("default")
@@ -41,6 +43,10 @@ class QuestionFeedViewModel(
         if (sortOrder != order) {
             sortOrder = order
         }
+    }
+
+    override suspend fun processResponse(context: Context, data: List<Feed>, rawData: JsonArray) {
+        super.processResponse(context, filterBlockedAnswers(context, data), rawData)
     }
 
     override fun createDisplayItem(context: Context, feed: Feed): FeedDisplayItem {
@@ -67,6 +73,15 @@ class QuestionFeedViewModel(
             }
         } catch (e: Exception) {
             Log.e("QuestionFeedViewModel", "Failed to follow/unfollow question: $questionId", e)
+        }
+    }
+
+    private suspend fun filterBlockedAnswers(context: Context, data: List<Feed>): List<Feed> {
+        val blockedUserIds = ContentFilterExtensions.getEnabledBlockedUserIds(context)
+        if (blockedUserIds.isEmpty()) return data
+        return data.filterNot { feed ->
+            val target = feed.target
+            target is Feed.AnswerTarget && target.author?.id in blockedUserIds
         }
     }
 }

--- a/app/src/main/java/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
@@ -102,6 +102,15 @@ object ContentFilterExtensions {
         return preferences.getBoolean("enableUserBlocking", true)
     }
 
+    suspend fun getEnabledBlockedUserIds(context: Context): Set<String> {
+        if (!isUserBlockingEnabled(context)) return emptySet()
+        return BlocklistManager
+            .getInstance(context)
+            .getAllBlockedUsers()
+            .map { it.userId }
+            .toSet()
+    }
+
     /**
      * 检查是否启用了主题屏蔽功能
      */


### PR DESCRIPTION
## 变更内容

- 在评论列表响应处理阶段过滤已屏蔽用户的根评论，并同步过滤随根评论返回的内嵌子评论。
- 在问题回答列表响应处理阶段过滤已屏蔽用户的回答。
- 将分页响应处理改为 suspend，统一复用已启用用户屏蔽时的屏蔽用户 ID 读取逻辑。
- 增加评论页与问题页的 instrumented 回归测试，覆盖屏蔽用户评论、内嵌子评论和问题回答过滤。

## 验证

- `JAVA_HOME=$(/usr/libexec/java_home -v 25) ./gradlew --no-daemon --no-configuration-cache --max-workers=1 assembleLiteDebug`
- `JAVA_HOME=$(/usr/libexec/java_home -v 25) ./gradlew --no-daemon --no-configuration-cache --max-workers=1 ktlintFormat`
- `JAVA_HOME=$(/usr/libexec/java_home -v 25) ./gradlew --no-daemon --no-configuration-cache --max-workers=1 assembleLiteDebugAndroidTest`
- AVD `Medium_Phone_2` 手工 `am instrument` 跑过 `CommentScreenInstrumentedTest` 和 `QuestionScreenInstrumentedTest`，共 7 条相关用例通过；后续重装后定向单测遇到模拟器启动 ANR，未发现应用异常栈。
- UI 复检：`picky-user` 未发现 #357 相关新增用户体验问题；`ui-voyager` 提出的旧测试初始化问题已修复并标记 fixed。

Resolves #357
