### PR TITLE
fix: 修复带图评论操作按钮被裁切

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/CommentScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/CommentScreenInstrumentedTest.kt
@@ -275,6 +275,77 @@ class CommentScreenInstrumentedTest {
     }
 
     @Test
+    fun commentWithImageKeepsReplyAndLikeActionsVisible() {
+        /*
+         * Expected behavior:
+         * 1. A comment containing an inline image should still render the same bottom action row as
+         *    text-only comments.
+         * 2. The reply and like buttons must remain visible and clickable after the image content is
+         *    laid out.
+         */
+        val childEntryCommentIds = mutableListOf<String>()
+        val seededComments = seedRootComments(count = 4)
+        val viewModel = SeededRootCommentViewModel(
+            article = ROOT_ARTICLE,
+            seededComments = seededComments,
+        )
+
+        setCommentScreen(
+            viewModel = viewModel,
+            onChildCommentClick = { childEntryCommentIds += it.item.id },
+            testOverrides = CommentScreenTestOverrides(
+                viewModel = viewModel,
+                skipInitialLoad = true,
+            ),
+        )
+
+        composeRule
+            .onNodeWithTag(COMMENT_SCREEN_LIST_TAG)
+            .performScrollToNode(hasTestTag(commentImageTag("root-1")))
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            runCatching {
+                composeRule.onNodeWithTag(commentImageTag("root-1"), useUnmergedTree = true).assertIsDisplayed()
+            }.isSuccess
+        }
+
+        composeRule.onNodeWithTag(commentReplyButtonTag("root-1")).assertIsDisplayed()
+        composeRule.onNodeWithTag(commentLikeButtonTag("root-1")).assertIsDisplayed()
+        val rowBounds = composeRule
+            .onAllNodesWithTag(commentRowTag("root-1"))
+            .fetchSemanticsNodes()
+            .single()
+            .boundsInRoot
+        val imageBounds = composeRule
+            .onAllNodesWithTag(commentImageTag("root-1"), useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .single()
+            .boundsInRoot
+        val replyBounds = composeRule
+            .onAllNodesWithTag(commentReplyButtonTag("root-1"))
+            .fetchSemanticsNodes()
+            .single()
+            .boundsInRoot
+        val likeBounds = composeRule
+            .onAllNodesWithTag(commentLikeButtonTag("root-1"))
+            .fetchSemanticsNodes()
+            .single()
+            .boundsInRoot
+        val expectedBottom = maxOf(imageBounds.bottom, replyBounds.bottom, likeBounds.bottom)
+        assertTrue(
+            "Comment row should include image and action row bounds, but row bottom was " +
+                "${rowBounds.bottom} and content bottom was $expectedBottom",
+            rowBounds.bottom >= expectedBottom,
+        )
+        composeRule.onNodeWithTag(commentReplyButtonTag("root-1")).performClick()
+        composeRule.onNodeWithTag(commentLikeButtonTag("root-1")).performClick()
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            seededComments.first().likeCount == 6 && seededComments.first().liked
+        }
+
+        assertEquals(listOf("root-1"), childEntryCommentIds)
+    }
+
+    @Test
     fun childCommentViewSupportsReplyCancelAndOfflineSendFlow() {
         /*
          * Expected behavior:

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CommentScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CommentScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -216,9 +215,7 @@ fun SwipeToReplyContainer(
     var hasVibrated by remember { mutableStateOf(false) }
 
     Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(IntrinsicSize.Min),
+        modifier = modifier.fillMaxWidth(),
     ) {
         // --- 背景层 (图标) ---
         // 只有在发生位移时才计算显示逻辑
@@ -237,7 +234,7 @@ fun SwipeToReplyContainer(
 
             Box(
                 modifier = Modifier
-                    .fillMaxSize()
+                    .matchParentSize()
                     .padding(horizontal = 16.dp),
                 contentAlignment = align,
             ) {


### PR DESCRIPTION
## 变更内容

- 修复评论行滑动容器使用 `IntrinsicSize.Min` 导致带图片评论内容被压缩、底部回复/点赞区域被裁切的问题。
- 保留并复用现有评论 action row，没有新增另一套回复/点赞布局。
- 新增带图评论回归测试，校验图片、回复按钮、点赞按钮都落在同一评论行布局边界内，并验证回复/点赞交互仍可用。

Resolves #369

## 验证结果

- ✅ `./gradlew assembleLiteDebug`
- ✅ `./gradlew ktlintFormat`
- ✅ `./gradlew --no-configuration-cache :app:connectedLiteDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.github.zly2006.zhihu.CommentScreenInstrumentedTest#commentWithImageKeepsReplyAndLikeActionsVisible --continue`
- ✅ 安装并启动 lite APK，`python3 .agents/skills/ui-test/llm_test_helper.py dump` 成功输出当前页面结构
- ✅ 自我 review：`git diff --check` 通过；grep 确认未残留 `IntrinsicSize`，未分叉出第二套评论 action row

## UI 复检

- `picky-user`: pass，未发现新的有效问题；目标评论页未能稳定进入，因此为有限覆盖评审。
- `ui-voyager`: 未发现确认 bug；由于缺少稳定评论页入口/深链，现场漫游只覆盖到 Hot Search 页面，目标评论行视觉复核主要由新增 instrumented test 覆盖。
