### PR TITLE
fix: 避免作者主页回答列表重复 key 崩溃

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/PeopleScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/PeopleScreenInstrumentedTest.kt
@@ -17,9 +17,11 @@
 
 package com.github.zly2006.zhihu
 
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -311,6 +313,40 @@ class PeopleScreenInstrumentedTest {
     }
 
     @Test
+    fun duplicatedAuthorAnswerKeysDoNotCrashAnswerListOffline() {
+        val duplicatedAnswerId = 2_544_209_984L
+        setPeopleScreen(
+            overrides = PeopleScreenTestOverrides(
+                initialUiState = seededUiState(itemCount = 0).copy(
+                    answers = PeopleSortedListUiState(
+                        sortBy = "voteups",
+                        items = listOf(
+                            seededAnswer(
+                                id = duplicatedAnswerId,
+                                questionId = 1001L,
+                                questionTitle = "重复 key 问题 A",
+                                excerpt = "重复 key 回答 A",
+                            ),
+                            seededAnswer(
+                                id = duplicatedAnswerId,
+                                questionId = 1002L,
+                                questionTitle = "重复 key 问题 B",
+                                excerpt = "重复 key 回答 B",
+                            ),
+                        ),
+                        isEnd = true,
+                    ),
+                ),
+            ),
+        )
+
+        composeRule.onNodeWithTag(PEOPLE_SCREEN_ANSWERS_LIST_TAG).assertIsDisplayed()
+        composeRule.onNodeWithText("重复 key 问题 A").assertIsDisplayed()
+        composeRule.onNodeWithText("重复 key 问题 B").assertIsDisplayed()
+        composeRule.onAllNodesWithTag(peopleScreenAnswerItemTag(duplicatedAnswerId)).assertCountEquals(2)
+    }
+
+    @Test
     fun followingSubscriptionsTabMatchesOfficialEntryPointsOffline() {
         /*
          * Expected behavior:
@@ -444,27 +480,32 @@ class PeopleScreenInstrumentedTest {
         ),
     )
 
-    private fun seededAnswer(id: Long) = DataHolder.Answer(
+    private fun seededAnswer(
+        id: Long,
+        questionId: Long = id,
+        questionTitle: String = "离线提问 $id",
+        excerpt: String = "离线回答摘要 $id",
+    ) = DataHolder.Answer(
         answerType = "answer",
         author = seededAuthor("answer-author-$id", "回答作者 $id"),
         canComment = DataHolder.CanComment(status = true, reason = ""),
         content = "<p>离线回答正文 $id</p>",
         createdTime = 1_713_500_000L,
-        excerpt = "离线回答摘要 $id",
+        excerpt = excerpt,
         id = id,
         question = DataHolder.AnswerModelQuestion(
             created = 1_713_400_000L,
-            id = id,
+            id = questionId,
             questionType = "normal",
-            title = "离线提问 $id",
+            title = questionTitle,
             type = "question",
             updatedTime = 1_713_500_100L,
-            url = "https://www.zhihu.com/question/$id",
+            url = "https://www.zhihu.com/question/$questionId",
         ),
         thanksCount = 0,
         type = "answer",
         updatedTime = 1_713_500_100L,
-        url = "https://www.zhihu.com/question/$id/answer/$id",
+        url = "https://www.zhihu.com/question/$questionId/answer/$id",
         voteupCount = id.toInt(),
     )
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/PaginatedList.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/PaginatedList.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
@@ -52,6 +53,60 @@ val ProgressIndicatorFooter: @Composable (LazyListState) -> Unit = { state ->
         if (LocalPullToRefreshViewModel.current?.isPullToRefresh != true) {
             CircularProgressIndicator()
         }
+    }
+}
+
+private const val DUPLICATE_KEY_PREFIX = "PaginatedListDuplicateKey"
+
+internal fun <T> uniquePaginatedListKeys(
+    items: List<T>,
+    key: (T) -> Any,
+): List<Any> {
+    val originalKeys = items.map(key)
+    val reservedKeys = originalKeys.toSet()
+    val usedKeys = mutableSetOf<Any>()
+    val duplicateOccurrences = mutableMapOf<Any, Int>()
+
+    return originalKeys.map { original ->
+        if (usedKeys.add(original)) {
+            original
+        } else {
+            val occurrence = duplicateOccurrences.getOrElse(original) { 1 }
+            duplicateOccurrences[original] = occurrence + 1
+            uniqueDuplicatePaginatedListKey(original, occurrence, reservedKeys, usedKeys)
+        }
+    }
+}
+
+private fun uniqueDuplicatePaginatedListKey(
+    original: Any,
+    occurrence: Int,
+    reservedKeys: Set<Any>,
+    usedKeys: MutableSet<Any>,
+): Any {
+    var collision = 0
+    while (true) {
+        val candidate = "$DUPLICATE_KEY_PREFIX:$occurrence:$collision:$original"
+        if (candidate !in reservedKeys && usedKeys.add(candidate)) {
+            return candidate
+        }
+        collision++
+    }
+}
+
+@Composable
+private fun <T> LazyItemScope.PaginatedListItem(
+    item: T,
+    itemContent: @Composable LazyItemScope.(T) -> Unit,
+) {
+    Box(
+        modifier = Modifier.animateItem(
+            fadeInSpec = spring(stiffness = Spring.StiffnessMediumLow),
+            fadeOutSpec = spring(stiffness = Spring.StiffnessMediumLow),
+            placementSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        ),
+    ) {
+        itemContent(item)
     }
 }
 
@@ -96,15 +151,14 @@ fun <T> PaginatedList(
     ) {
         topContent(this)
 
-        items(items, key = key) { item ->
-            Box(
-                modifier = Modifier.animateItem(
-                    fadeInSpec = spring(stiffness = Spring.StiffnessMediumLow),
-                    fadeOutSpec = spring(stiffness = Spring.StiffnessMediumLow),
-                    placementSpec = spring(stiffness = Spring.StiffnessMediumLow),
-                ),
-            ) {
-                itemContent(item)
+        if (key != null) {
+            val itemKeys = uniquePaginatedListKeys(items, key)
+            itemsIndexed(items, key = { index, _ -> itemKeys[index] }) { _, item ->
+                PaginatedListItem(item, itemContent)
+            }
+        } else {
+            items(items) { item ->
+                PaginatedListItem(item, itemContent)
             }
         }
 

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/ui/components/PaginatedListKeyTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/ui/components/PaginatedListKeyTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for Android.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.ui.components
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PaginatedListKeyTest {
+    @Test
+    fun uniqueKeysStayUnchanged() {
+        val keys = uniquePaginatedListKeys(listOf("answer:1", "article:1", "answer:2")) { it }
+
+        assertEquals(listOf("answer:1", "article:1", "answer:2"), keys)
+    }
+
+    @Test
+    fun duplicateKeysKeepFirstKeyAndSuffixLaterOccurrences() {
+        val keys = uniquePaginatedListKeys(listOf(2544209984L, 2544209984L, 42L, 2544209984L)) { it }
+
+        assertEquals(
+            listOf(
+                2544209984L,
+                "PaginatedListDuplicateKey:1:0:2544209984",
+                42L,
+                "PaginatedListDuplicateKey:2:0:2544209984",
+            ),
+            keys,
+        )
+    }
+
+    @Test
+    fun duplicateKeysAvoidExistingStringKeyCollisions() {
+        val collidingKey = "PaginatedListDuplicateKey:1:0:same"
+        val keys = uniquePaginatedListKeys(listOf("same", "same", collidingKey)) { it }
+
+        assertEquals(
+            listOf(
+                "same",
+                "PaginatedListDuplicateKey:1:1:same",
+                collidingKey,
+            ),
+            keys,
+        )
+    }
+}


### PR DESCRIPTION
## 修改内容

- 在 `PaginatedList` 内对调用方提供的 lazy item key 做唯一化处理：首个原始 key 保持不变，后续重复 key 增加内部后缀，避免 Compose `LazyColumn` 因重复 key 崩溃。
- 补充作者主页回答列表离线回归，用两个相同回答 id 的回答复现 issue #377 中的 key 冲突场景。
- 补充 `uniquePaginatedListKeys` 的 commonTest 覆盖唯一 key、重复 key、后缀碰撞规避。

Resolves #377

## 验证

- ✅ `./gradlew assembleLiteDebug`
- ✅ `./gradlew ktlintFormat`
- ✅ AVD 目标回归实际执行通过：`PeopleScreenInstrumentedTest#duplicatedAuthorAnswerKeysDoNotCrashAnswerListOffline`，结果文件显示 `tests=1 failures=0 errors=0 skipped=0`、`test_status: PASSED`、`OK (1 test)`。
- ⚠️ 同一次 `:app:connectedLiteDebugAndroidTest` Gradle 命令最后因既有 `prepareAndroidTestSecretAccount` 与 configuration cache 不兼容被标红；测试结果产物本身为通过。
- ⚠️ `:shared:jvmTest --tests com.github.zly2006.zhihu.ui.components.PaginatedListKeyTest` 未能执行到目标测试，卡在现有 `BlocklistBackupTest` 未解析 `BlocklistBackup/KeywordBackup/NlpKeywordBackup/UserBackup/TopicBackup` 的 shared 测试编译错误。
- ⚠️ UI 双代理复检未完整 live 覆盖：`picky-user` 返回 pass（caveat: AVD 锁阻断 live UI），`ui-voyager` 因资源等待超时未产出最终报告后已关闭；本次修改无文案/布局/交互变化，主要依据 diff 与目标 AVD 回归结果确认。

## 自我 review

- 已 grep `PaginatedList`、`LazyColumn`、`stableKey`、`key =` 相关调用；同类分页列表会统一走新的 key 唯一化层，没有复制额外一套页面级逻辑。
- 修复不改变列表数据、点击目标、测试 tag、排序/分页逻辑，只改变 Compose 内部 lazy key，避免重复返回数据触发局部 crash。