### PR TITLE
fix: 修复 compose 行内公式解析

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
@@ -63,7 +63,15 @@ import com.fleeksoft.ksoup.nodes.Node as HtmlNode
 import com.hrm.markdown.parser.ast.Node as MarkdownNode
 
 private var parsingDocument: Document? = null
-private const val ZHIHU_EQUATION_URL_PREFIX = "https://www.zhihu.com/equation?tex="
+private const val ZHIHU_EQUATION_HOST = "www.zhihu.com"
+private const val ZHIHU_EQUATION_PATH = "/equation"
+private val equationImageUrlAttributes = listOf(
+    "src",
+    "data-actualsrc",
+    "data-original",
+    "data-thumbnail",
+    "data-default-watermark-src",
+)
 
 fun htmlToMdAst(html: String): Document {
     val document = Document()
@@ -452,10 +460,29 @@ private fun HtmlNode.hasInlineContent(): Boolean = when (this) {
     else -> false
 }
 
-private fun extractEquationTex(imgElement: Element): String? = extractImageUrl(imgElement::attr)
-    ?.takeIf { it.startsWith(ZHIHU_EQUATION_URL_PREFIX) }
-    ?.let { Url(it).parameters["tex"].orEmpty() }
-    ?.takeIf { it.isNotBlank() }
+private fun extractEquationTex(imgElement: Element): String? =
+    equationImageUrlAttributes
+        .asSequence()
+        .map { imgElement.attr(it) }
+        .mapNotNull(::extractEquationTexFromUrl)
+        .firstOrNull()
+
+private fun extractEquationTexFromUrl(url: String): String? {
+    val normalized = when {
+        url.isBlank() -> return null
+        url.startsWith("//") -> "https:$url"
+        url.startsWith("/") -> "https://$ZHIHU_EQUATION_HOST$url"
+        else -> url
+    }
+    return runCatching {
+        val parsed = Url(normalized)
+        parsed.host
+            .takeIf { it.equals(ZHIHU_EQUATION_HOST, ignoreCase = true) }
+            ?.takeIf { parsed.encodedPath == ZHIHU_EQUATION_PATH }
+            ?.let { parsed.parameters["tex"].orEmpty() }
+            ?.takeIf { it.isNotBlank() }
+    }.getOrNull()
+}
 
 /**
  * 将一个 HTML 节点转换为 Markdown 内联节点列表

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/markdown/MdAstTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/markdown/MdAstTest.kt
@@ -65,6 +65,32 @@ class MdAstTest {
     }
 
     @Test
+    fun inline_equation_should_ignore_image_token_and_use_equation_src() {
+        val document = htmlToMdAst(
+            """
+            <p>函数 <img eeimg="1" src="https://www.zhihu.com/equation?tex=f%28x%29%3Dx%5E2" data-original-token="v2-token" alt="f(x)=x^2"/> 单调递增。</p>
+            """.trimIndent(),
+        )
+        val nodes = document.allNodes()
+
+        assertEquals(1, nodes.count { it is InlineMath && it.literal == "f(x)=x^2" })
+        assertFalse(nodes.any { it is Figure && it.imageUrl.contains("v2-token") })
+    }
+
+    @Test
+    fun inline_equation_should_read_actualsrc_when_src_is_placeholder() {
+        val document = htmlToMdAst(
+            """
+            <p>结论为 <img eeimg="1" src="data:image/svg+xml;utf8,%3Csvg%3E%3C/svg%3E" data-actualsrc="//www.zhihu.com/equation?tex=a%5E2%2Bb%5E2%3Dc%5E2" alt="a^2+b^2=c^2"/>。</p>
+            """.trimIndent(),
+        )
+        val nodes = document.allNodes()
+
+        assertEquals(1, nodes.count { it is InlineMath && it.literal == "a^2+b^2=c^2" })
+        assertFalse(nodes.any { it is Figure && it.imageUrl.startsWith("data:image") })
+    }
+
+    @Test
     fun paragraph_with_only_inline_equation_with_space_should_convert_to_math_block() {
         val document = htmlToMdAst(
             """


### PR DESCRIPTION
## 变更

- 修复 Markdown AST 中公式图片的识别逻辑，不再通过普通图片 URL 选择器读取公式地址，避免 `data-original-token` 抢先把公式图转换成普通图片。
- 支持从 `src`、`data-actualsrc`、`data-original`、`data-thumbnail`、`data-default-watermark-src` 中识别知乎 `/equation?tex=` 地址。
- 增加行内公式回归测试，覆盖 token 抢占和 lazy placeholder 两类路径。

## 验证

- `./gradlew assembleLiteDebug`：通过
- `./gradlew ktlintFormat`：通过
- `git diff --check`：通过
- `./gradlew :shared:jvmTest --tests com.github.zly2006.zhihu.markdown.MdAstTest`：未能执行到目标用例，当前 `shared/src/commonTest/kotlin/com/github/zly2006/zhihu/shared/filter/BlocklistBackupTest.kt` 存在 `BlocklistBackup` / `KeywordBackup` / `NlpKeywordBackup` / `UserBackup` / `TopicBackup` 未解析的既有编译错误，`compileTestKotlinJvm` 先失败。

Resolves #368