### PR TITLE
fix: 避免下一个回答按钮被遮挡

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
@@ -584,6 +584,7 @@ fun ArticleScreen(
 
     var previousScrollValue by remember { mutableIntStateOf(0) }
     var isScrollingUp by remember { mutableStateOf(false) }
+    var navigatingToNextAnswer by remember { mutableStateOf(false) }
     val density = LocalDensity.current
     val scrollDeltaThreshold = with(density) { ScrollThresholdDp.toPx() }
     var topBarHeight by remember { mutableIntStateOf(0) }
@@ -1519,33 +1520,6 @@ fun ArticleScreen(
                             }
                         }
                     }
-                    // Skip answer button
-                    if (article.type == ArticleType.Answer && buttonSkipAnswer) {
-                        var navigatingToNextAnswer by remember { mutableStateOf(false) }
-                        val showSkipButton = !autoHideSkipAnswerButton || isScrollingUp || scrollState.value == 0
-                        val skipButtonAlpha by animateFloatAsState(
-                            targetValue = if (showSkipButton) 1f else 0f,
-                            animationSpec = tween(200),
-                            label = "skipButtonAlpha",
-                        )
-                        DraggableRefreshButton(
-                            modifier = Modifier.graphicsLayer { alpha = skipButtonAlpha },
-                            onClick = {
-                                if (showSkipButton) {
-                                    navigatingToNextAnswer = true
-                                    navigateToNext()
-                                    navigatingToNextAnswer = false
-                                }
-                            },
-                            preferenceName = "buttonSkipAnswer",
-                        ) {
-                            if (navigatingToNextAnswer) {
-                                CircularProgressIndicator(modifier = Modifier.size(30.dp))
-                            } else {
-                                Icon(Icons.Filled.SkipNext, contentDescription = "下一个回答")
-                            }
-                        }
-                    }
                     // Status bar gradient overlay (duo3 only — not needed in master path)
                     val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
                     val surfaceColor = MaterialTheme.colorScheme.surfaceContainer
@@ -1582,7 +1556,7 @@ fun ArticleScreen(
     val progressBarBottomPadding = WindowInsets.systemBars.asPaddingValues().calculateBottomPadding() + 96.dp
 
     Box(
-        modifier = Modifier,
+        modifier = Modifier.fillMaxSize(),
     ) {
         // 根据模式渲染
         if (article.type == ArticleType.Answer && answerSwitchMode == "vertical") {
@@ -1626,6 +1600,33 @@ fun ArticleScreen(
                     end = 2.dp,
                 ),
         )
+
+        // Keep the skip button above both question and answer regions.
+        if (article.type == ArticleType.Answer && buttonSkipAnswer) {
+            val showSkipButton = !autoHideSkipAnswerButton || isScrollingUp || scrollState.value == 0
+            val skipButtonAlpha by animateFloatAsState(
+                targetValue = if (showSkipButton) 1f else 0f,
+                animationSpec = tween(200),
+                label = "skipButtonAlpha",
+            )
+            DraggableRefreshButton(
+                modifier = Modifier.graphicsLayer { alpha = skipButtonAlpha },
+                onClick = {
+                    if (showSkipButton) {
+                        navigatingToNextAnswer = true
+                        navigateToNext()
+                        navigatingToNextAnswer = false
+                    }
+                },
+                preferenceName = "buttonSkipAnswer",
+            ) {
+                if (navigatingToNextAnswer) {
+                    CircularProgressIndicator(modifier = Modifier.size(30.dp))
+                } else {
+                    Icon(Icons.Filled.SkipNext, contentDescription = "下一个回答")
+                }
+            }
+        }
     }
 
     // 全屏菜单


### PR DESCRIPTION
## 背景

基于 @Nacyoooooo 在 #375 的修复思路重新开 PR，原 PR 因目录迁移后产生 conflict。

Resolves #373

## 修改内容

- 将回答详情页「下一个回答」悬浮按钮从内容区域内部移动到外层 `Box`。
- 保留原有按钮拖动、自动隐藏、点击切换和加载态逻辑。
- 按 review 意见只修改 `ArticleScreen.kt`，不改动 `DraggableRefreshButton.kt`。

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- AVD `Medium_Phone_2` 安装 lite debug 包后验证：按钮拖到问题/作者区域仍可见，点击后可切换到下一个回答。
- `$ui-voyager` 复检：pass，未发现新增有效问题。
- `$picky-user` 复检：pass，未发现新增有效意见。

## Credit

修复思路来自 @Nacyoooooo 的 #375，commit 已添加 `Co-authored-by: chenzhihao <939832920@qq.com>`。