### PR TITLE
refactor: 重新划分页环境接口

### DIFF
--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/AndroidUiRuntimes.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/AndroidUiRuntimes.kt
@@ -71,7 +71,7 @@ import com.github.zly2006.zhihu.viewmodel.filter.exportAllBlocklistToJson
 import com.github.zly2006.zhihu.viewmodel.filter.getBlocklistManager
 import com.github.zly2006.zhihu.viewmodel.filter.importAllBlocklistFromJson
 import com.github.zly2006.zhihu.viewmodel.local.LocalHomeFeedViewModel
-import com.github.zly2006.zhihu.viewmodel.notificationPaginationEnvironment
+import com.github.zly2006.zhihu.viewmodel.notificationEnvironment
 import com.github.zly2006.zhihu.viewmodel.za.AndroidHomeFeedViewModel
 import com.github.zly2006.zhihu.viewmodel.za.MixedHomeFeedViewModel
 import io.ktor.client.HttpClient
@@ -477,7 +477,7 @@ actual fun rememberNotificationScreenRuntime(
 ): NotificationScreenRuntime {
     val context = LocalContext.current
     val environment = remember(context, settingsStore, viewModel) {
-        viewModel.notificationPaginationEnvironment(context, settingsStore)
+        viewModel.notificationEnvironment(context, settingsStore)
     }
     return NotificationScreenRuntime(
         environment = environment,

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
@@ -567,12 +567,12 @@ open class SharedAndroidPaginationEnvironment(
         }
 }
 
-class SharedAndroidNotificationPaginationEnvironment(
+class SharedAndroidNotificationEnvironment(
     context: Context,
     allowGuestAccess: Boolean,
     override val notificationSettingsStore: NotificationSettingsStore,
 ) : SharedAndroidPaginationEnvironment(context, allowGuestAccess),
-    NotificationPaginationEnvironment
+    NotificationEnvironment
 
 fun PaginationViewModel<*>.paginationEnvironment(context: Context): AndroidContextPaginationEnvironment =
     SharedAndroidPaginationEnvironment(context, allowGuestAccess)
@@ -583,11 +583,11 @@ actual fun rememberPaginationEnvironment(allowGuestAccess: Boolean): PaginationE
     return remember(context, allowGuestAccess) { SharedAndroidPaginationEnvironment(context, allowGuestAccess) }
 }
 
-fun PaginationViewModel<*>.notificationPaginationEnvironment(
+fun PaginationViewModel<*>.notificationEnvironment(
     context: Context,
     notificationSettingsStore: NotificationSettingsStore,
-): NotificationPaginationEnvironment =
-    SharedAndroidNotificationPaginationEnvironment(context, allowGuestAccess, notificationSettingsStore)
+): NotificationEnvironment =
+    SharedAndroidNotificationEnvironment(context, allowGuestAccess, notificationSettingsStore)
 
 fun PaginationEnvironment.androidContext(): Context =
     (this as? AndroidContextPaginationEnvironment)?.context
@@ -602,7 +602,7 @@ fun PaginationViewModel<*>.loadMore(context: Context) {
 }
 
 fun PaginationViewModel<*>.httpClient(context: Context): HttpClient =
-    httpClient(paginationEnvironment(context))
+    paginationEnvironment(context).httpClient()
 
 private fun HttpRequestBuilder.addIncludeAndSign(include: String) {
     url {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CollectionContentScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CollectionContentScreen.kt
@@ -134,8 +134,7 @@ private fun CollectionContentScreenContent(
             includeImages = includeImages,
         )
     }
-    val environment = rememberPaginationEnvironment(allowGuestAccess = false)
-    val sharedData = environment.articleAnswerSwitchState()
+    val sharedData = collectionEnvironment.articleAnswerSwitchState()
 
     LaunchedEffect(testOverrides) {
         if (testOverrides == null && screenViewModel.allData.isEmpty()) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
@@ -73,7 +73,6 @@ import com.github.zly2006.zhihu.navigation.Notification
 import com.github.zly2006.zhihu.navigation.Search
 import com.github.zly2006.zhihu.shared.data.Feed
 import com.github.zly2006.zhihu.shared.data.RecommendationMode
-import com.github.zly2006.zhihu.shared.data.fetchZhihuUnreadNotificationCount
 import com.github.zly2006.zhihu.shared.data.navDestination
 import com.github.zly2006.zhihu.shared.data.target
 import com.github.zly2006.zhihu.shared.platform.UserMessageDuration
@@ -95,6 +94,7 @@ import com.github.zly2006.zhihu.ui.components.ProgressIndicatorFooter
 import com.github.zly2006.zhihu.ui.components.rememberFeedBlockActions
 import com.github.zly2006.zhihu.viewmodel.feed.BaseFeedViewModel
 import com.github.zly2006.zhihu.viewmodel.feed.HomeFeedInteractionViewModel
+import com.github.zly2006.zhihu.viewmodel.fetchUnreadNotificationCountSigned
 import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
 import kotlinx.serialization.json.Json
 
@@ -175,9 +175,7 @@ fun HomeScreen(scrollToTopTrigger: Int, innerPadding: PaddingValues) {
     var unreadCount by remember { mutableIntStateOf(0) }
     LaunchedEffect(Unit) {
         try {
-            unreadCount = fetchZhihuUnreadNotificationCount(paginationEnvironment.httpClient()) {
-                paginationEnvironment.configureSignedRequest(this)
-            }
+            unreadCount = paginationEnvironment.fetchUnreadNotificationCountSigned()
         } catch (_: Exception) {
             // 忽略错误
         }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
@@ -72,14 +72,10 @@ import com.github.zly2006.zhihu.navigation.LocalNavigator
 import com.github.zly2006.zhihu.navigation.Notification
 import com.github.zly2006.zhihu.navigation.Search
 import com.github.zly2006.zhihu.shared.data.Feed
-import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
 import com.github.zly2006.zhihu.shared.data.RecommendationMode
-import com.github.zly2006.zhihu.shared.data.ZHIHU_LAST_READ_TOUCH_URL
-import com.github.zly2006.zhihu.shared.data.encodeZhihuLastReadTouchItems
 import com.github.zly2006.zhihu.shared.data.fetchZhihuUnreadNotificationCount
 import com.github.zly2006.zhihu.shared.data.navDestination
 import com.github.zly2006.zhihu.shared.data.target
-import com.github.zly2006.zhihu.shared.data.zhihuLastReadTouchItem
 import com.github.zly2006.zhihu.shared.platform.UserMessageDuration
 import com.github.zly2006.zhihu.shared.platform.rememberExternalUrlOpener
 import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
@@ -97,15 +93,9 @@ import com.github.zly2006.zhihu.ui.components.MyModalBottomSheet
 import com.github.zly2006.zhihu.ui.components.PaginatedList
 import com.github.zly2006.zhihu.ui.components.ProgressIndicatorFooter
 import com.github.zly2006.zhihu.ui.components.rememberFeedBlockActions
-import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.feed.BaseFeedViewModel
 import com.github.zly2006.zhihu.viewmodel.feed.HomeFeedInteractionViewModel
 import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
-import io.ktor.client.request.forms.MultiPartFormDataContent
-import io.ktor.client.request.forms.formData
-import io.ktor.client.request.header
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
 import kotlinx.serialization.json.Json
 
 const val PREFERENCE_NAME = "com.github.zly2006.zhihu_preferences"
@@ -117,36 +107,6 @@ const val HOME_NOTIFICATION_BUTTON_TAG = "home_notification_button"
 const val HOME_ACCOUNT_BUTTON_TAG = "home_account_button"
 const val HOME_FEED_LIST_TAG = "home_feed_list"
 const val HOME_REFRESH_BUTTON_TAG = "home_refresh_button"
-
-interface IHomeFeedViewModel {
-    suspend fun recordContentInteraction(environment: PaginationEnvironment, feed: Feed)
-
-    fun onUiContentClick(environment: PaginationEnvironment, feed: Feed, item: FeedDisplayItem)
-
-    /**
-     * 发送"已读"状态到知乎服务器的通用实现
-     */
-    suspend fun sendReadStatusToServer(environment: PaginationEnvironment, feed: Feed) {
-        try {
-            val payloadItem = zhihuLastReadTouchItem(feed, "read") ?: return
-            environment.httpClient().post(ZHIHU_LAST_READ_TOUCH_URL) {
-                environment.configureSignedRequest(this)
-                header("x-requested-with", "fetch")
-                setBody(
-                    MultiPartFormDataContent(
-                        formData {
-                            append(
-                                "items",
-                                encodeZhihuLastReadTouchItems(listOf(payloadItem)),
-                            )
-                        },
-                    ),
-                )
-            }
-        } catch (_: Exception) {
-        }
-    }
-}
 
 /**
  * 首页信息流页面。
@@ -530,7 +490,7 @@ fun HomeScreen(scrollToTopTrigger: Int, innerPadding: PaddingValues) {
                     val destination = navDestination
                     if (feed != null) {
 //                            DataHolder.putFeed(feed)
-                        (viewModel as HomeFeedInteractionViewModel).onUiContentClick(paginationEnvironment, feed, item)
+                        (viewModel as? HomeFeedInteractionViewModel)?.onUiContentClick(paginationEnvironment, feed, item)
                     } else if (item.localContentId != null) {
                         runtime.recordLocalItemOpened(item)
                     }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/NotificationScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/NotificationScreen.kt
@@ -78,13 +78,13 @@ import com.github.zly2006.zhihu.shared.util.formatRelativeTime
 import com.github.zly2006.zhihu.ui.components.DraggableRefreshButton
 import com.github.zly2006.zhihu.ui.components.PaginatedList
 import com.github.zly2006.zhihu.ui.components.ProgressIndicatorFooter
-import com.github.zly2006.zhihu.viewmodel.NotificationPaginationEnvironment
+import com.github.zly2006.zhihu.viewmodel.NotificationEnvironment
 import com.github.zly2006.zhihu.viewmodel.NotificationViewModel
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 
 data class NotificationScreenRuntime(
-    val environment: NotificationPaginationEnvironment,
+    val environment: NotificationEnvironment,
     val showDebugCopy: Boolean,
 )
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PeopleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PeopleScreen.kt
@@ -101,13 +101,11 @@ import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationViewModel
 import com.github.zly2006.zhihu.viewmodel.ProfileLoadEnvironment
 import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
+import com.github.zly2006.zhihu.viewmodel.deleteSigned
 import com.github.zly2006.zhihu.viewmodel.feed.BaseFeedViewModel
+import com.github.zly2006.zhihu.viewmodel.postSigned
 import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
 import io.ktor.client.call.body
-import io.ktor.client.request.delete
-import io.ktor.client.request.get
-import io.ktor.client.request.post
-import io.ktor.client.request.url
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
@@ -363,41 +361,27 @@ class PersonViewModel(
     )
 
     suspend fun toggleFollow(environment: ZhihuApiEnvironment) {
-        val client = environment.httpClient()
-        if (isFollowing) {
-            val jojo = client
-                .delete("https://www.zhihu.com/api/v4/members/${person.urlToken}/followers") {
-                    environment.configureSignedRequest(this)
-                }.raiseForStatus()
-                .body<JsonObject>()
-            followerCount = jojo["follower_count"]?.jsonPrimitive?.int ?: (followerCount - 1)
-            isFollowing = false
+        val followersUrl = "https://www.zhihu.com/api/v4/members/${person.urlToken}/followers"
+        val newFollowingState = !isFollowing
+        val response = if (newFollowingState) {
+            environment.postSigned(followersUrl)
         } else {
-            val jojo = client
-                .post("https://www.zhihu.com/api/v4/members/${person.urlToken}/followers") {
-                    environment.configureSignedRequest(this)
-                }.raiseForStatus()
-                .body<JsonObject>()
-            followerCount = jojo["follower_count"]?.jsonPrimitive?.int ?: (followerCount + 1)
-            isFollowing = true
+            environment.deleteSigned(followersUrl)
         }
+        val jojo = response.raiseForStatus().body<JsonObject>()
+        followerCount = jojo["follower_count"]?.jsonPrimitive?.int ?: (followerCount + if (newFollowingState) 1 else -1)
+        isFollowing = newFollowingState
     }
 
     suspend fun toggleBlock(environment: ZhihuApiEnvironment) {
-        val client = environment.httpClient()
-        if (isBlocking) {
-            client
-                .delete("https://www.zhihu.com/api/v4/members/${person.urlToken}/actions/block") {
-                    environment.configureSignedRequest(this)
-                }.raiseForStatus()
-            isBlocking = false
+        val blockUrl = "https://www.zhihu.com/api/v4/members/${person.urlToken}/actions/block"
+        val newBlockingState = !isBlocking
+        if (newBlockingState) {
+            environment.postSigned(blockUrl)
         } else {
-            client
-                .post("https://www.zhihu.com/api/v4/members/${person.urlToken}/actions/block") {
-                    environment.configureSignedRequest(this)
-                }.raiseForStatus()
-            isBlocking = true
-        }
+            environment.deleteSigned(blockUrl)
+        }.raiseForStatus()
+        isBlocking = newBlockingState
     }
 
     suspend fun toggleRecommendationBlock(environment: ContentBlocklistEnvironment) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PeopleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PeopleScreen.kt
@@ -96,8 +96,11 @@ import com.github.zly2006.zhihu.ui.components.AuthorBadge
 import com.github.zly2006.zhihu.ui.components.FeedCard
 import com.github.zly2006.zhihu.ui.components.PaginatedList
 import com.github.zly2006.zhihu.ui.components.ProgressIndicatorFooter
+import com.github.zly2006.zhihu.viewmodel.ContentBlocklistEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationViewModel
+import com.github.zly2006.zhihu.viewmodel.ProfileLoadEnvironment
+import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
 import com.github.zly2006.zhihu.viewmodel.feed.BaseFeedViewModel
 import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
 import io.ktor.client.call.body
@@ -359,7 +362,7 @@ class PersonViewModel(
         followingFeedModel,
     )
 
-    suspend fun toggleFollow(environment: PaginationEnvironment) {
+    suspend fun toggleFollow(environment: ZhihuApiEnvironment) {
         val client = environment.httpClient()
         if (isFollowing) {
             val jojo = client
@@ -380,7 +383,7 @@ class PersonViewModel(
         }
     }
 
-    suspend fun toggleBlock(environment: PaginationEnvironment) {
+    suspend fun toggleBlock(environment: ZhihuApiEnvironment) {
         val client = environment.httpClient()
         if (isBlocking) {
             client
@@ -397,7 +400,7 @@ class PersonViewModel(
         }
     }
 
-    suspend fun toggleRecommendationBlock(environment: PaginationEnvironment) {
+    suspend fun toggleRecommendationBlock(environment: ContentBlocklistEnvironment) {
         if (isBlockedInRecommendations) {
             environment.removeBlockedUser(person.id)
             isBlockedInRecommendations = false
@@ -412,7 +415,7 @@ class PersonViewModel(
         }
     }
 
-    suspend fun load(environment: PaginationEnvironment) {
+    suspend fun load(environment: ProfileLoadEnvironment) {
         environment.addReadHistory(person.id, "profile")
 
         val jojo = environment

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PeopleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PeopleScreen.kt
@@ -418,14 +418,8 @@ class PersonViewModel(
     suspend fun load(environment: ProfileLoadEnvironment) {
         environment.addReadHistory(person.id, "profile")
 
-        val jojo = environment
-            .httpClient()
-            .get(peopleProfileUrl(person)) {
-                url {
-                    parameters["include"] = PEOPLE_PROFILE_INCLUDE_PATH
-                }
-                environment.configureSignedRequest(this)
-            }.body<JsonObject>()
+        val jojo = environment.fetchJson(peopleProfileUrl(person), PEOPLE_PROFILE_INCLUDE_PATH)
+            ?: error("用户资料为空")
 
         val loadedPerson = ZhihuJson.decodeJson<DataHolder.People>(jojo)
         val urlToken = loadedPerson.urlToken

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PinScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PinScreen.kt
@@ -97,7 +97,6 @@ import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.replaceOrAppendUniqueVoters
 import io.ktor.client.call.body
 import io.ktor.client.request.delete
-import io.ktor.client.request.get
 import io.ktor.client.request.post
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
@@ -137,11 +136,8 @@ private suspend fun loadPinDetail(
     pin: Pin,
 ): PinScreenUiState {
     environment.addReadHistory(pin.id.toString(), "pin")
-    val jsonObject = environment
-        .httpClient()
-        .get("https://www.zhihu.com/api/v4/pins/${pin.id}") {
-            environment.configureSignedRequest(this)
-        }.body<JsonObject>()
+    val jsonObject = environment.fetchJson("https://www.zhihu.com/api/v4/pins/${pin.id}", "")
+        ?: error("想法详情为空")
     val content = decodePinContentDetail(jsonObject)
     environment.postHistoryDestination(pin)
     environment.recordContentOpenEvent(destination = pin)
@@ -224,7 +220,6 @@ fun PinScreen(
             votersError = null
             try {
                 val page = loadVotersPage(
-                    client = paginationEnvironment.httpClient(),
                     environment = paginationEnvironment,
                     initialUrl = "https://www.zhihu.com/api/v4/pins/${pin.id}/upvoters?limit=10&offset=0",
                     nextUrl = votersNextUrl,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PinScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PinScreen.kt
@@ -91,13 +91,13 @@ import com.github.zly2006.zhihu.ui.components.handleShareAction
 import com.github.zly2006.zhihu.ui.components.rememberShareDialogRuntime
 import com.github.zly2006.zhihu.viewmodel.ContentLoadEnvironment
 import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
+import com.github.zly2006.zhihu.viewmodel.deleteSigned
 import com.github.zly2006.zhihu.viewmodel.loadVotersPage
 import com.github.zly2006.zhihu.viewmodel.nextUrlOrNull
+import com.github.zly2006.zhihu.viewmodel.postSigned
 import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.replaceOrAppendUniqueVoters
 import io.ktor.client.call.body
-import io.ktor.client.request.delete
-import io.ktor.client.request.post
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
@@ -119,11 +119,10 @@ private suspend fun togglePinLike(
     isLiked: Boolean,
 ): PinLikeResult {
     val endpoint = "https://www.zhihu.com/api/v4/pins/${pin.id}/voters/up"
-    val client = environment.httpClient()
     val jojo = if (isLiked) {
-        client.delete(endpoint) { environment.configureSignedRequest(this) }.body<JsonObject>()
+        environment.deleteSigned(endpoint).body<JsonObject>()
     } else {
-        client.post(endpoint) { environment.configureSignedRequest(this) }.body<JsonObject>()
+        environment.postSigned(endpoint).body<JsonObject>()
     }
     return PinLikeResult(
         isLiked = !isLiked,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PinScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PinScreen.kt
@@ -89,7 +89,8 @@ import com.github.zly2006.zhihu.ui.components.VotersSheet
 import com.github.zly2006.zhihu.ui.components.getShareText
 import com.github.zly2006.zhihu.ui.components.handleShareAction
 import com.github.zly2006.zhihu.ui.components.rememberShareDialogRuntime
-import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
+import com.github.zly2006.zhihu.viewmodel.ContentLoadEnvironment
+import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
 import com.github.zly2006.zhihu.viewmodel.loadVotersPage
 import com.github.zly2006.zhihu.viewmodel.nextUrlOrNull
 import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
@@ -114,7 +115,7 @@ const val PIN_SCREEN_ERROR_TAG = "pin_screen_error"
 const val PIN_SCREEN_SCROLL_TAG = "pin_screen_scroll"
 
 private suspend fun togglePinLike(
-    environment: PaginationEnvironment,
+    environment: ZhihuApiEnvironment,
     pin: Pin,
     isLiked: Boolean,
 ): PinLikeResult {
@@ -132,7 +133,7 @@ private suspend fun togglePinLike(
 }
 
 private suspend fun loadPinDetail(
-    environment: PaginationEnvironment,
+    environment: ContentLoadEnvironment,
     pin: Pin,
 ): PinScreenUiState {
     environment.addReadHistory(pin.id.toString(), "pin")

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/QuestionScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/QuestionScreen.kt
@@ -86,7 +86,7 @@ import com.github.zly2006.zhihu.ui.components.ShareDialog
 import com.github.zly2006.zhihu.ui.components.getShareText
 import com.github.zly2006.zhihu.ui.components.handleShareAction
 import com.github.zly2006.zhihu.ui.components.rememberShareDialogRuntime
-import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
+import com.github.zly2006.zhihu.viewmodel.ContentLoadEnvironment
 import com.github.zly2006.zhihu.viewmodel.feed.QuestionFeedViewModel
 import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
 import io.ktor.client.call.body
@@ -129,7 +129,7 @@ const val QUESTION_STATS_TAG = "question_stats"
 fun questionFeedItemTag(stableKey: String) = "question_feed_item_$stableKey"
 
 private suspend fun loadQuestion(
-    environment: PaginationEnvironment,
+    environment: ContentLoadEnvironment,
     question: Question,
 ): LoadedQuestionScreenData? {
     environment.addReadHistory(question.questionId.toString(), "question")

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/QuestionScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/QuestionScreen.kt
@@ -89,10 +89,7 @@ import com.github.zly2006.zhihu.ui.components.rememberShareDialogRuntime
 import com.github.zly2006.zhihu.viewmodel.ContentLoadEnvironment
 import com.github.zly2006.zhihu.viewmodel.feed.QuestionFeedViewModel
 import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
-import io.ktor.client.call.body
-import io.ktor.client.request.get
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.JsonObject
 
 /**
  * 问题页的测试替身配置。
@@ -134,12 +131,8 @@ private suspend fun loadQuestion(
 ): LoadedQuestionScreenData? {
     environment.addReadHistory(question.questionId.toString(), "question")
     val include = "read_count,visit_count,answer_count,voteup_count,comment_count,follower_count,detail,excerpt,author,relationship.is_following,topics"
-    val url = "https://www.zhihu.com/api/v4/questions/${question.questionId}?include=$include"
-    val jsonObject = environment
-        .httpClient()
-        .get(url) {
-            environment.configureSignedRequest(this)
-        }.body<JsonObject>()
+    val jsonObject = environment.fetchJson("https://www.zhihu.com/api/v4/questions/${question.questionId}", include)
+        ?: return null
     val questionData = decodeQuestionContentDetail(jsonObject)
     val loadedData = loadedQuestionScreenData(question, questionData)
     environment.postHistoryDestination(loadedData.historyDestination)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
@@ -57,6 +57,7 @@ import com.github.zly2006.zhihu.ui.QuestionScreenUiState
 import com.github.zly2006.zhihu.ui.components.CommentScreenComponent
 import com.github.zly2006.zhihu.ui.components.ShareDialogRuntime
 import com.github.zly2006.zhihu.viewmodel.ArticleViewModel.CachedAnswerContent
+import com.github.zly2006.zhihu.viewmodel.HistoryEnvironment
 import com.github.zly2006.zhihu.viewmodel.feed.BaseFeedViewModel
 import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
 import io.ktor.client.HttpClient
@@ -760,7 +761,7 @@ fun interface ArticleReadHistoryRecorder {
 
 @Composable
 fun rememberArticleReadHistoryRecorder(): ArticleReadHistoryRecorder {
-    val environment = rememberPaginationEnvironment(false)
+    val environment: HistoryEnvironment = rememberPaginationEnvironment(false)
     return remember(environment) {
         ArticleReadHistoryRecorder { article ->
             environment.addReadHistory(

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
@@ -481,10 +481,7 @@ class ArticleViewModel(
                         ArticleType.Article -> "article"
                     }
                     val collectionsUrl = "https://api.zhihu.com/collections/contents/$contentType/${article.id}?limit=50"
-                    val jojo = httpClient!!
-                        .get(collectionsUrl) {
-                            environment.configureSignedRequest(this)
-                        }.body<JsonObject>()
+                    val jojo = environment.fetchJson(collectionsUrl, "") ?: return@withContext
                     val collectionsData = ZhihuJson.decodeJson<CollectionResponse>(jojo)
                     collections.clear()
                     collections.addAll(
@@ -516,9 +513,9 @@ class ArticleViewModel(
         description: String = "",
         isPublic: Boolean = false,
     ) {
-        if (httpClient == null) return
+        val client = httpClient ?: return
         viewModelScope.launch {
-            httpClient!!.post("https://www.zhihu.com/api/v4/collections") {
+            client.post("https://www.zhihu.com/api/v4/collections") {
                 contentType(ContentType.Application.Json)
                 setBody(
                     buildJsonObject {
@@ -566,14 +563,12 @@ class ArticleViewModel(
     }
 
     fun loadMoreVoters(environment: ZhihuApiEnvironment, reset: Boolean = false) {
-        val client = httpClient ?: return
         if (article.type != ArticleType.Answer || votersLoading) return
         viewModelScope.launch {
             votersLoading = true
             votersError = null
             try {
                 val page = loadVotersPage(
-                    client = client,
                     environment = environment,
                     initialUrl = "https://www.zhihu.com/api/v4/answers/${article.id}/upvoters?limit=10&offset=0",
                     nextUrl = votersNextUrl,
@@ -592,14 +587,11 @@ class ArticleViewModel(
     }
 
     fun loadAnswerRelationshipEndorsement(environment: ZhihuApiEnvironment) {
-        val client = httpClient ?: return
         if (article.type != ArticleType.Answer) return
         viewModelScope.launch {
             try {
-                val response = client
-                    .get("https://www.zhihu.com/api/v4/answers/${article.id}/relationship?desktop=true") {
-                        environment.configureSignedRequest(this)
-                    }.body<JsonObject>()
+                val response = environment.fetchJson("https://www.zhihu.com/api/v4/answers/${article.id}/relationship?desktop=true", "")
+                    ?: return@launch
                 val endorsement = ZhihuJson.decodeJson<AnswerRelationshipEndorsement>(response)
                 votersSocialText = endorsement.text
             } catch (e: Exception) {
@@ -826,15 +818,14 @@ class ArticleViewModel(
         val safeRequestedCount = requestedCount.coerceAtLeast(0)
         if (safeRequestedCount == 0) return emptyList()
 
-        val client = httpClient ?: environment.accountHttpClient()
         val url = when (article.type) {
             ArticleType.Answer -> "https://www.zhihu.com/api/v4/comment_v5/answers/${article.id}/root_comment"
             ArticleType.Article -> "https://www.zhihu.com/api/v4/comment_v5/articles/${article.id}/root_comment"
         }
-        val json = client
-            .get("${'$'}url?order=score&limit=${'$'}{safeRequestedCount.coerceAtMost(20)}&include=data[*].content,excerpt,headline") {
-                environment.configureSignedRequest(this)
-            }.body<JsonObject>()
+        val json = environment.fetchJson(
+            url = "$url?order=score&limit=${safeRequestedCount.coerceAtMost(20)}",
+            include = "data[*].content,excerpt,headline",
+        ) ?: return emptyList()
         return decodeZhihuCommentData(json, safeRequestedCount)
             .map(::mapExportComment)
     }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
@@ -59,7 +59,6 @@ import io.ktor.client.call.body
 import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.client.request.header
-import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsChannel
@@ -368,12 +367,11 @@ class ArticleViewModel(
                     contentType = contentType,
                     title = title.ifBlank { "知乎内容" },
                 )
-                val response = httpClient.post("https://www.zhihu.com/ai_ingress/stream/completion") {
+                val response = environment.postSigned("https://www.zhihu.com/ai_ingress/stream/completion") {
                     accept(ContentType.Text.EventStream)
                     contentType(ContentType.Application.Json)
                     header("x-xsrftoken", environment.xsrfToken())
                     setBody(request)
-                    environment.configureSignedRequest(this)
                 }
                 if (!response.status.isSuccess()) {
                     val errorBody = response.bodyAsText()
@@ -513,9 +511,9 @@ class ArticleViewModel(
         description: String = "",
         isPublic: Boolean = false,
     ) {
-        val client = httpClient ?: return
+        if (httpClient == null) return
         viewModelScope.launch {
-            client.post("https://www.zhihu.com/api/v4/collections") {
+            environment.postSigned("https://www.zhihu.com/api/v4/collections") {
                 contentType(ContentType.Application.Json)
                 setBody(
                     buildJsonObject {
@@ -524,7 +522,6 @@ class ArticleViewModel(
                         put("is_public", isPublic)
                     },
                 )
-                environment.configureSignedRequest(this)
             }
             loadCollections(environment)
         }
@@ -538,14 +535,13 @@ class ArticleViewModel(
                     ArticleType.Article -> "https://www.zhihu.com/api/v4/articles/${article.id}/voters"
                 }
 
-                val response = httpClient!!
-                    .post(endpoint) {
+                val response = environment
+                    .postSigned(endpoint) {
                         when (article.type) {
                             ArticleType.Answer -> setBody(mapOf("type" to newState.key))
                             ArticleType.Article -> setBody(mapOf("voting" to if (newState == VoteUpState.Up) 1 else 0))
                         }
                         contentType(ContentType.Application.Json)
-                        environment.configureSignedRequest(this)
                     }.body<JsonObject>()
 
                 voteUpState = newState

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
@@ -182,7 +182,7 @@ class ArticleViewModel(
     open class ArticlesSharedData : ArticleAnswerSwitchData()
 
     @OptIn(ExperimentalStdlibApi::class)
-    fun loadArticle(environment: PaginationEnvironment) {
+    fun loadArticle(environment: ArticleLoadEnvironment) {
         if (httpClient == null) return
         viewModelScope.launch {
             withContext(Dispatchers.Default) {
@@ -318,7 +318,7 @@ class ArticleViewModel(
         }
     }
 
-    fun toggleFavorite(collectionId: String, remove: Boolean, environment: PaginationEnvironment) {
+    fun toggleFavorite(collectionId: String, remove: Boolean, environment: ZhihuApiEnvironment) {
         if (httpClient == null) return
         viewModelScope.launch {
             try {
@@ -348,7 +348,7 @@ class ArticleViewModel(
         }
     }
 
-    fun requestAiSummary(environment: PaginationEnvironment) {
+    fun requestAiSummary(environment: ZhihuApiEnvironment) {
         if (httpClient == null) {
             aiSummaryError = "未初始化网络客户端"
             return
@@ -471,7 +471,7 @@ class ArticleViewModel(
 
     private val collectionOrder = mutableListOf<String>()
 
-    fun loadCollections(environment: PaginationEnvironment) {
+    fun loadCollections(environment: ZhihuApiEnvironment) {
         if (httpClient == null) return
         viewModelScope.launch {
             withContext(Dispatchers.Default) {
@@ -511,7 +511,7 @@ class ArticleViewModel(
     }
 
     fun createNewCollection(
-        environment: PaginationEnvironment,
+        environment: ZhihuApiEnvironment,
         title: String,
         description: String = "",
         isPublic: Boolean = false,
@@ -533,7 +533,7 @@ class ArticleViewModel(
         }
     }
 
-    fun toggleVoteUp(environment: PaginationEnvironment, newState: VoteUpState) {
+    fun toggleVoteUp(environment: ZhihuApiEnvironment, newState: VoteUpState) {
         viewModelScope.launch {
             try {
                 val endpoint = when (article.type) {
@@ -565,7 +565,7 @@ class ArticleViewModel(
         }
     }
 
-    fun loadMoreVoters(environment: PaginationEnvironment, reset: Boolean = false) {
+    fun loadMoreVoters(environment: ZhihuApiEnvironment, reset: Boolean = false) {
         val client = httpClient ?: return
         if (article.type != ArticleType.Answer || votersLoading) return
         viewModelScope.launch {
@@ -591,7 +591,7 @@ class ArticleViewModel(
         }
     }
 
-    fun loadAnswerRelationshipEndorsement(environment: PaginationEnvironment) {
+    fun loadAnswerRelationshipEndorsement(environment: ZhihuApiEnvironment) {
         val client = httpClient ?: return
         if (article.type != ArticleType.Answer) return
         viewModelScope.launch {
@@ -611,7 +611,7 @@ class ArticleViewModel(
 
     // 导出为图片 - 使用WebView渲染
     suspend fun exportToImage(
-        environment: PaginationEnvironment,
+        environment: ArticleExportContentEnvironment,
         includeAppAttribution: Boolean,
         onComplete: (Boolean) -> Unit,
     ) {
@@ -627,7 +627,7 @@ class ArticleViewModel(
 
     // 导出为带评论的图片 - 使用WebView渲染
     suspend fun exportToImageWithComments(
-        environment: PaginationEnvironment,
+        environment: ArticleExportContentEnvironment,
         commentCount: Int,
         includeAppAttribution: Boolean,
         onComplete: (Boolean) -> Unit,
@@ -643,7 +643,7 @@ class ArticleViewModel(
     }
 
     suspend fun exportToHtml(
-        environment: PaginationEnvironment,
+        environment: ArticleExportContentEnvironment,
         includeAppAttribution: Boolean,
         onComplete: (Boolean) -> Unit,
     ) {
@@ -683,18 +683,18 @@ class ArticleViewModel(
         }
     }
 
-    private fun requiresHtmlExportPermission(environment: PaginationEnvironment): Boolean =
+    private fun requiresHtmlExportPermission(environment: ArticleExportEnvironment): Boolean =
         environment.requiresHtmlExportPermission()
 
-    private fun hasStoragePermission(environment: PaginationEnvironment): Boolean =
+    private fun hasStoragePermission(environment: ArticleExportEnvironment): Boolean =
         environment.hasImageExportPermission()
 
-    private fun requestStoragePermission(environment: PaginationEnvironment) {
+    private fun requestStoragePermission(environment: ArticleExportEnvironment) {
         environment.requestImageExportPermission()
     }
 
     private suspend fun exportToImageInternal(
-        environment: PaginationEnvironment,
+        environment: ArticleExportContentEnvironment,
         includeComments: Boolean,
         commentCount: Int,
         includeAppAttribution: Boolean,
@@ -760,7 +760,7 @@ class ArticleViewModel(
         timeoutMs: Long,
     ): PreparedArticleExportContent = renderer.prepareExportWebView(htmlContent, timeoutMs)
 
-    private fun loadExportAssetText(environment: PaginationEnvironment, fileName: String): String = try {
+    private fun loadExportAssetText(environment: ArticleExportEnvironment, fileName: String): String = try {
         environment.loadExportAssetText(fileName)
     } catch (e: Exception) {
         Log.e("ArticleViewModel", "Failed to load export asset: $fileName", e)
@@ -780,14 +780,14 @@ class ArticleViewModel(
     private fun recycleExportBitmap(renderer: ArticleImageExportRenderer, bitmap: Any) =
         renderer.recycleExportBitmap(bitmap)
 
-    private fun articleImageExportRenderer(environment: PaginationEnvironment): ArticleImageExportRenderer? =
+    private fun articleImageExportRenderer(environment: ArticleExportEnvironment): ArticleImageExportRenderer? =
         environment.articleImageExportRenderer { fileName ->
             loadExportAssetText(environment, fileName)
         }
 
     // 创建HTML内容
     private suspend fun createHtmlContent(
-        environment: PaginationEnvironment,
+        environment: ArticleExportContentEnvironment,
         includeComments: Boolean,
         commentCount: Int,
         includeAppAttribution: Boolean,
@@ -809,7 +809,7 @@ class ArticleViewModel(
     }
 
     private suspend fun createOfflineHtmlContent(
-        environment: PaginationEnvironment,
+        environment: ArticleExportContentEnvironment,
         includeAppAttribution: Boolean,
     ): String = withContext(Dispatchers.Default) {
         environment.buildOfflineArticleExportHtml(
@@ -820,7 +820,7 @@ class ArticleViewModel(
     }
 
     private suspend fun fetchExportComments(
-        environment: PaginationEnvironment,
+        environment: ArticleExportContentEnvironment,
         requestedCount: Int,
     ): List<ArticleExportComment> {
         val safeRequestedCount = requestedCount.coerceAtLeast(0)
@@ -854,12 +854,12 @@ class ArticleViewModel(
         ?: throw IllegalStateException("内容未加载完成")
 
     // 使用MediaStore保存图片到公共目录
-    private fun saveImageToMediaStore(environment: PaginationEnvironment, bitmap: Any) {
+    private fun saveImageToMediaStore(environment: ArticleExportEnvironment, bitmap: Any) {
         val displayName = buildExportFileName("jpg")
         environment.saveImageToMediaStore(displayName, bitmap)
     }
 
-    private fun saveHtmlToDownloads(environment: PaginationEnvironment, htmlContent: String): String {
+    private fun saveHtmlToDownloads(environment: ArticleExportEnvironment, htmlContent: String): String {
         val displayName = buildExportFileName("html")
         return environment.saveHtmlToDownloads(displayName, htmlContent)
     }
@@ -1018,7 +1018,7 @@ class ArticleViewModel(
     }
 
     // 导出到剪贴板
-    fun exportToClipboard(environment: PaginationEnvironment) {
+    fun exportToClipboard(environment: ClipboardEnvironment) {
         val markdown = convertToMarkdown()
 
         // 将Markdown文本复制到剪贴板

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/CollectionContentViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/CollectionContentViewModel.kt
@@ -31,10 +31,13 @@ import com.github.zly2006.zhihu.shared.data.ZhihuPaging
 import com.github.zly2006.zhihu.shared.data.navDestination
 import com.github.zly2006.zhihu.shared.data.toFeedDisplayItemNavDestinationJson
 import com.github.zly2006.zhihu.ui.Collection
+import io.ktor.client.call.body
+import io.ktor.client.request.get
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
 import kotlin.reflect.typeOf
 
 data class CollectionHtmlExportProgress(
@@ -54,13 +57,7 @@ data class CollectionHtmlExportResult(
     val zipFilePath: String?,
 )
 
-interface CollectionContentEnvironment : PaginationEnvironment {
-    suspend fun fetchCollection(collectionId: String): Collection {
-        val json = fetchJson("https://www.zhihu.com/api/v4/collections/$collectionId", "")
-            ?: throw IllegalStateException("收藏夹信息加载失败")
-        return ZhihuJson.decodeJson<Collection>(json["collection"] ?: throw IllegalStateException("收藏夹信息为空"))
-    }
-
+interface CollectionExportEnvironment {
     suspend fun exportCollectionItemsToHtmlZip(
         collectionTitle: String,
         items: List<CollectionItem>,
@@ -69,6 +66,18 @@ interface CollectionContentEnvironment : PaginationEnvironment {
     ): CollectionHtmlExportResult
 
     suspend fun handleCollectionExportFailure(error: Exception)
+}
+
+interface CollectionContentEnvironment :
+    PaginationEnvironment,
+    CollectionExportEnvironment
+
+suspend fun ZhihuApiEnvironment.fetchCollection(collectionId: String): Collection {
+    val json = httpClient()
+        .get("https://www.zhihu.com/api/v4/collections/$collectionId") {
+            configureSignedRequest(this)
+        }.body<JsonObject>()
+    return ZhihuJson.decodeJson<Collection>(json["collection"] ?: throw IllegalStateException("收藏夹信息为空"))
 }
 
 class CollectionContentViewModel(
@@ -111,10 +120,8 @@ class CollectionContentViewModel(
     override fun refresh(environment: PaginationEnvironment) {
         if (isLoading) return
         displayItems.clear()
-        if (environment is CollectionContentEnvironment) {
-            viewModelScope.launch {
-                loadCollectionInfo(environment)
-            }
+        viewModelScope.launch {
+            loadCollectionInfo(environment)
         }
         super.refresh(environment)
     }
@@ -205,7 +212,7 @@ class CollectionContentViewModel(
         }
     }
 
-    private suspend fun loadCollectionInfo(environment: CollectionContentEnvironment) {
+    private suspend fun loadCollectionInfo(environment: ZhihuApiEnvironment) {
         collection = environment.fetchCollection(collectionId)
     }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/CollectionContentViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/CollectionContentViewModel.kt
@@ -31,13 +31,10 @@ import com.github.zly2006.zhihu.shared.data.ZhihuPaging
 import com.github.zly2006.zhihu.shared.data.navDestination
 import com.github.zly2006.zhihu.shared.data.toFeedDisplayItemNavDestinationJson
 import com.github.zly2006.zhihu.ui.Collection
-import io.ktor.client.call.body
-import io.ktor.client.request.get
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonObject
 import kotlin.reflect.typeOf
 
 data class CollectionHtmlExportProgress(
@@ -73,10 +70,7 @@ interface CollectionContentEnvironment :
     CollectionExportEnvironment
 
 suspend fun ZhihuApiEnvironment.fetchCollection(collectionId: String): Collection {
-    val json = httpClient()
-        .get("https://www.zhihu.com/api/v4/collections/$collectionId") {
-            configureSignedRequest(this)
-        }.body<JsonObject>()
+    val json = fetchJson("https://www.zhihu.com/api/v4/collections/$collectionId", "") ?: error("收藏夹信息为空")
     return ZhihuJson.decodeJson<Collection>(json["collection"] ?: throw IllegalStateException("收藏夹信息为空"))
 }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/NotificationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/NotificationViewModel.kt
@@ -22,8 +22,6 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewModelScope
 import com.github.zly2006.zhihu.shared.data.NotificationItem
-import com.github.zly2006.zhihu.shared.data.fetchZhihuUnreadNotificationCount
-import com.github.zly2006.zhihu.shared.data.markAllZhihuNotificationsAsRead
 import com.github.zly2006.zhihu.shared.data.zhihuNotificationRecentUrl
 import com.github.zly2006.zhihu.shared.notification.NotificationSettingsStore
 import com.github.zly2006.zhihu.shared.notification.matchNotificationType
@@ -67,9 +65,7 @@ class NotificationViewModel :
      */
     private suspend fun getUnreadCount(environment: ZhihuApiEnvironment): Int {
         try {
-            return fetchZhihuUnreadNotificationCount(environment.httpClient()) {
-                environment.configureSignedRequest(this)
-            }
+            return environment.fetchUnreadNotificationCountSigned()
         } catch (_: Exception) {
             // 忽略错误
             return 0
@@ -124,9 +120,7 @@ class NotificationViewModel :
      */
     @OptIn(DelicateCoroutinesApi::class)
     suspend fun markAllAsRead(environment: ZhihuApiEnvironment) {
-        markAllZhihuNotificationsAsRead(environment.httpClient()) {
-            environment.configureSignedRequest(this)
-        }
+        environment.markAllNotificationsAsReadSigned()
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/NotificationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/NotificationViewModel.kt
@@ -31,9 +31,13 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlin.reflect.typeOf
 
-interface NotificationPaginationEnvironment : PaginationEnvironment {
+interface NotificationSettingsEnvironment {
     val notificationSettingsStore: NotificationSettingsStore
 }
+
+interface NotificationEnvironment :
+    PaginationEnvironment,
+    NotificationSettingsEnvironment
 
 class NotificationViewModel :
     PaginationViewModel<NotificationItem>(
@@ -47,7 +51,7 @@ class NotificationViewModel :
 
     @Suppress("HttpUrlsUsage")
     override suspend fun fetchFeeds(environment: PaginationEnvironment) {
-        val notificationEnvironment = environment.requireNotificationEnvironment()
+        val notificationSettingsEnvironment = environment.requireNotificationSettingsEnvironment()
         super.fetchFeeds(environment)
         if (lastPaging?.next?.startsWith("http://") == true) {
             lastPaging = lastPaging!!.copy(next = lastPaging!!.next.replace("http://", "https://"))
@@ -55,13 +59,13 @@ class NotificationViewModel :
 
         // 获取未读消息数量
         unreadCount = getUnreadCount(environment)
-        checkAndMarkAllAsRead(notificationEnvironment)
+        checkAndMarkAllAsRead(environment, notificationSettingsEnvironment)
     }
 
     /**
      * 更新未读消息数量
      */
-    private suspend fun getUnreadCount(environment: PaginationEnvironment): Int {
+    private suspend fun getUnreadCount(environment: ZhihuApiEnvironment): Int {
         try {
             return fetchZhihuUnreadNotificationCount(environment.httpClient()) {
                 environment.configureSignedRequest(this)
@@ -88,17 +92,20 @@ class NotificationViewModel :
     /**
      * 检查如果所有消息都被屏蔽了，且unreadCount>=0，则主动调用一次readall
      */
-    private suspend fun checkAndMarkAllAsRead(environment: NotificationPaginationEnvironment) {
+    private suspend fun checkAndMarkAllAsRead(
+        apiEnvironment: ZhihuApiEnvironment,
+        settingsEnvironment: NotificationSettingsEnvironment,
+    ) {
         if (unreadCount >= 0 && allData.isNotEmpty()) {
             val hasVisibleNotification = allData.any {
-                shouldShowNotification(environment.notificationSettingsStore, it)
+                shouldShowNotification(settingsEnvironment.notificationSettingsStore, it)
             }
             if (!hasVisibleNotification) {
-                markAllAsRead(environment)
+                markAllAsRead(apiEnvironment)
             }
         }
-        if (environment.notificationSettingsStore.getAutoMarkAsReadEnabled()) {
-            markAllAsRead(environment)
+        if (settingsEnvironment.notificationSettingsStore.getAutoMarkAsReadEnabled()) {
+            markAllAsRead(apiEnvironment)
             unreadCount = 0
         }
     }
@@ -116,13 +123,13 @@ class NotificationViewModel :
      * 标记所有消息为已读
      */
     @OptIn(DelicateCoroutinesApi::class)
-    suspend fun markAllAsRead(environment: PaginationEnvironment) {
+    suspend fun markAllAsRead(environment: ZhihuApiEnvironment) {
         markAllZhihuNotificationsAsRead(environment.httpClient()) {
             environment.configureSignedRequest(this)
         }
     }
 }
 
-private fun PaginationEnvironment.requireNotificationEnvironment(): NotificationPaginationEnvironment =
-    this as? NotificationPaginationEnvironment
+private fun PaginationEnvironment.requireNotificationSettingsEnvironment(): NotificationSettingsEnvironment =
+    this as? NotificationSettingsEnvironment
         ?: error("NotificationSettingsStore is required for notification pagination")

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -86,8 +86,6 @@ abstract class PaginationViewModel<T : Any>(
         loadMore(environment)
     }
 
-    open fun httpClient(environment: PaginationEnvironment): HttpClient = environment.httpClient()
-
     protected open fun processResponse(environment: PaginationEnvironment, data: List<T>, rawData: JsonArray) {
         debugData.addAll(rawData) // 保存原始JSON
         allData.addAll(data) // 保存未flatten的数据
@@ -201,15 +199,22 @@ interface ArticleImageExportRenderer {
     fun recycleExportBitmap(bitmap: Any)
 }
 
-interface PaginationEnvironment {
+interface ZhihuApiEnvironment {
     fun httpClient(): HttpClient
-
-    fun mobileHomeFeedHttpClient(): HttpClient = httpClient()
 
     suspend fun fetchJson(
         url: String,
         include: String,
     ): JsonObject?
+
+    suspend fun handleFetchFailure(
+        tag: String?,
+        error: Exception,
+    )
+
+    fun configureSignedRequest(builder: HttpRequestBuilder) = Unit
+
+    fun xsrfToken(): String = ""
 
     fun logDecodeFailure(
         tag: String?,
@@ -218,33 +223,18 @@ interface PaginationEnvironment {
     ) {
         Log.e(tag ?: "PaginationViewModel", "Failed to decode item: $item", error)
     }
+}
 
-    suspend fun handleFetchFailure(
-        tag: String?,
-        error: Exception,
-    )
+interface MobileHomeFeedEnvironment : ZhihuApiEnvironment {
+    fun mobileHomeFeedHttpClient(): HttpClient = httpClient()
 
     suspend fun handleMobileHomeFeedFailure(error: Exception) {
         handleFetchFailure("AndroidHomeFeedViewModel", error)
     }
+}
 
-    fun configureSignedRequest(builder: HttpRequestBuilder) = Unit
-
-    fun xsrfToken(): String = ""
-
+interface FeedDisplayEnvironment {
     fun feedDisplaySettings(): FeedDisplaySettings = FeedDisplaySettings()
-
-    fun localHistory(): List<NavDestination> = emptyList()
-
-    suspend fun addReadHistory(
-        contentToken: String,
-        contentTypeName: String,
-    ) = Unit
-
-    suspend fun followQuestion(
-        questionId: Long,
-        follow: Boolean,
-    ) = Unit
 
     suspend fun applyHomeFeedFilters(items: List<FeedDisplayItem>): HomeFeedFilterResult =
         HomeFeedFilterResult(
@@ -252,26 +242,51 @@ interface PaginationEnvironment {
             filteredItems = items,
             reverseBlock = feedDisplaySettings().reverseBlock,
         )
+}
+
+interface HistoryEnvironment {
+    fun localHistory(): List<NavDestination> = emptyList()
+
+    suspend fun addReadHistory(
+        contentToken: String,
+        contentTypeName: String,
+    ) = Unit
+
+    suspend fun clearAllHistory() = Unit
+
+    suspend fun postHistoryDestination(destination: NavDestination) = Unit
+}
+
+interface ContentInteractionEnvironment : ZhihuApiEnvironment {
+    suspend fun followQuestion(
+        questionId: Long,
+        follow: Boolean,
+    ) = Unit
 
     suspend fun sendFeedReadStatus(feed: Feed) = Unit
 
     suspend fun recordContentInteraction(feed: Feed) = Unit
 
     suspend fun markItemsAsTouched(items: Set<Pair<String, String>>): Set<Pair<String, String>> = emptySet()
+}
 
-    suspend fun clearAllHistory() = Unit
-
-    suspend fun postHistoryDestination(destination: NavDestination) = Unit
-
-    suspend fun isUserBlocked(userId: String): Boolean = false
-
-    fun blockedUserIds(): Set<String> = emptySet()
-
+interface ContentOpenEnvironment {
     suspend fun recordContentOpenEvent(
         destination: NavDestination,
         questionId: Long? = null,
         openFrom: String = "",
     ) = Unit
+
+    suspend fun recordOpenEvent(
+        destination: Article,
+        questionId: Long?,
+    ) = Unit
+}
+
+interface ContentBlocklistEnvironment {
+    suspend fun isUserBlocked(userId: String): Boolean = false
+
+    fun blockedUserIds(): Set<String> = emptySet()
 
     suspend fun addBlockedUser(
         userId: String,
@@ -286,18 +301,26 @@ interface PaginationEnvironment {
     ) = Unit
 
     suspend fun removeBlockedUser(userId: String) = Unit
+}
 
+interface LocalRecommendationEnvironment : ZhihuApiEnvironment {
     fun localRecommendationEngine(): LocalRecommendationEngine? = null
 
     suspend fun handleLocalRecommendationFailure(error: Exception) {
         handleFetchFailure("LocalHomeFeedViewModel", error)
     }
 
+    suspend fun showLocalRecommendationDatabaseError() = Unit
+}
+
+interface ClipboardEnvironment {
     fun setPlainTextClipboard(
         label: String,
         text: String,
     ) = Unit
+}
 
+interface ArticleExportEnvironment {
     fun hasImageExportPermission(): Boolean = false
 
     fun requiresHtmlExportPermission(): Boolean = false
@@ -329,22 +352,48 @@ interface PaginationEnvironment {
     ) = Unit
 
     fun articleImageExportRenderer(loadAssetText: (String) -> String): ArticleImageExportRenderer? = null
+}
 
-    suspend fun showLocalRecommendationDatabaseError() = Unit
-
-    fun answerNavigatorRepository(): AnswerNavigatorRepository? = null
-
+interface ArticleContentEnvironment : ZhihuApiEnvironment {
     fun accountHttpClient(): HttpClient = httpClient()
 
-    fun articleAnswerSwitchState(): ArticleAnswerSwitchState? = null
-
     suspend fun getContentDetail(article: Article): DataHolder.Content? = null
-
-    suspend fun recordOpenEvent(
-        destination: Article,
-        questionId: Long?,
-    ) = Unit
 }
+
+interface ArticleExportContentEnvironment :
+    ArticleExportEnvironment,
+    ArticleContentEnvironment
+
+interface ArticleNavigationEnvironment {
+    fun answerNavigatorRepository(): AnswerNavigatorRepository? = null
+
+    fun articleAnswerSwitchState(): ArticleAnswerSwitchState? = null
+}
+
+interface ContentLoadEnvironment :
+    ZhihuApiEnvironment,
+    HistoryEnvironment,
+    ContentOpenEnvironment
+
+interface ProfileLoadEnvironment :
+    ContentLoadEnvironment,
+    ContentBlocklistEnvironment
+
+interface ArticleLoadEnvironment :
+    ArticleContentEnvironment,
+    ContentLoadEnvironment,
+    ArticleNavigationEnvironment
+
+interface PaginationEnvironment :
+    ZhihuApiEnvironment,
+    MobileHomeFeedEnvironment,
+    FeedDisplayEnvironment,
+    ContentInteractionEnvironment,
+    LocalRecommendationEnvironment,
+    ClipboardEnvironment,
+    ProfileLoadEnvironment,
+    ArticleLoadEnvironment,
+    ArticleExportContentEnvironment
 
 data class FeedDisplaySettings(
     val enableQualityFilter: Boolean = true,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -32,6 +32,8 @@ import com.github.zly2006.zhihu.shared.data.Feed
 import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
 import com.github.zly2006.zhihu.shared.data.ZhihuJson
 import com.github.zly2006.zhihu.shared.data.ZhihuPaging
+import com.github.zly2006.zhihu.shared.data.fetchZhihuUnreadNotificationCount
+import com.github.zly2006.zhihu.shared.data.markAllZhihuNotificationsAsRead
 import com.github.zly2006.zhihu.shared.util.Log
 import com.github.zly2006.zhihu.ui.ArticleAnswerSwitchState
 import com.github.zly2006.zhihu.ui.ArticleAnswerTransitionDirection
@@ -40,8 +42,11 @@ import com.github.zly2006.zhihu.viewmodel.local.LocalRecommendationEngine
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.statement.HttpResponse
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Job
@@ -232,6 +237,35 @@ interface ZhihuApiEnvironment {
         error: Exception,
     ) {
         Log.e(tag ?: "PaginationViewModel", "Failed to decode item: $item", error)
+    }
+}
+
+suspend fun ZhihuApiEnvironment.postSigned(
+    url: String,
+    block: HttpRequestBuilder.() -> Unit = {},
+): HttpResponse =
+    httpClient().post(url) {
+        block()
+        configureSignedRequest(this)
+    }
+
+suspend fun ZhihuApiEnvironment.deleteSigned(
+    url: String,
+    block: HttpRequestBuilder.() -> Unit = {},
+): HttpResponse =
+    httpClient().delete(url) {
+        block()
+        configureSignedRequest(this)
+    }
+
+suspend fun ZhihuApiEnvironment.fetchUnreadNotificationCountSigned(): Int =
+    fetchZhihuUnreadNotificationCount(httpClient()) {
+        configureSignedRequest(this)
+    }
+
+suspend fun ZhihuApiEnvironment.markAllNotificationsAsReadSigned() {
+    markAllZhihuNotificationsAsRead(httpClient()) {
+        configureSignedRequest(this)
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -38,7 +38,10 @@ import com.github.zly2006.zhihu.ui.ArticleAnswerTransitionDirection
 import com.github.zly2006.zhihu.viewmodel.ArticleViewModel.CachedAnswerContent
 import com.github.zly2006.zhihu.viewmodel.local.LocalRecommendationEngine
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Job
@@ -205,7 +208,14 @@ interface ZhihuApiEnvironment {
     suspend fun fetchJson(
         url: String,
         include: String,
-    ): JsonObject?
+    ): JsonObject? =
+        httpClient()
+            .get(url.replace("http://", "https://")) {
+                if (include.isNotEmpty()) {
+                    parameter("include", include)
+                }
+                configureSignedRequest(this)
+            }.body<JsonObject>()
 
     suspend fun handleFetchFailure(
         tag: String?,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/VotersSupport.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/VotersSupport.kt
@@ -27,7 +27,7 @@ import kotlinx.serialization.json.JsonObject
 
 suspend fun loadVotersPage(
     client: HttpClient,
-    environment: PaginationEnvironment,
+    environment: ZhihuApiEnvironment,
     initialUrl: String,
     nextUrl: String?,
     reset: Boolean,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/VotersSupport.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/VotersSupport.kt
@@ -20,23 +20,15 @@ package com.github.zly2006.zhihu.viewmodel
 import com.github.zly2006.zhihu.shared.data.DataHolder
 import com.github.zly2006.zhihu.shared.data.ZhihuJson
 import com.github.zly2006.zhihu.shared.data.ZhihuVotersResponse
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.get
-import kotlinx.serialization.json.JsonObject
 
 suspend fun loadVotersPage(
-    client: HttpClient,
     environment: ZhihuApiEnvironment,
     initialUrl: String,
     nextUrl: String?,
     reset: Boolean,
 ): ZhihuVotersResponse {
     val url = (if (reset || nextUrl == null) initialUrl else nextUrl).toHttps()
-    val response = client
-        .get(url) {
-            environment.configureSignedRequest(this)
-        }.body<JsonObject>()
+    val response = environment.fetchJson(url, "") ?: error("赞同者信息为空")
     return ZhihuJson.decodeJson(response)
 }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/BaseCommentViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/BaseCommentViewModel.kt
@@ -28,9 +28,9 @@ import com.github.zly2006.zhihu.viewmodel.ContentBlocklistEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationViewModel
 import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
+import com.github.zly2006.zhihu.viewmodel.deleteSigned
 import com.github.zly2006.zhihu.viewmodel.filter.fetchBlockedUserIds
-import io.ktor.client.request.delete
-import io.ktor.client.request.post
+import com.github.zly2006.zhihu.viewmodel.postSigned
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonArray
@@ -114,17 +114,11 @@ abstract class BaseCommentViewModel(
         val newLikeState = !commentData.liked
         viewModelScope.launch {
             try {
-                val httpClient = environment.httpClient()
+                val likeUrl = "https://www.zhihu.com/api/v4/comments/$commentId/like"
                 val response = if (newLikeState) {
-                    // 点赞
-                    httpClient.post("https://www.zhihu.com/api/v4/comments/$commentId/like") {
-                        environment.configureSignedRequest(this)
-                    }
+                    environment.postSigned(likeUrl)
                 } else {
-                    // 取消点赞
-                    httpClient.delete("https://www.zhihu.com/api/v4/comments/$commentId/like") {
-                        environment.configureSignedRequest(this)
-                    }
+                    environment.deleteSigned(likeUrl)
                 }
 
                 if (response.status.isSuccess()) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/BaseCommentViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/BaseCommentViewModel.kt
@@ -24,8 +24,10 @@ import androidx.lifecycle.viewModelScope
 import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.shared.data.DataHolder
 import com.github.zly2006.zhihu.shared.viewmodel.CommentItem
+import com.github.zly2006.zhihu.viewmodel.ContentBlocklistEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationViewModel
+import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
 import com.github.zly2006.zhihu.viewmodel.filter.fetchBlockedUserIds
 import io.ktor.client.request.delete
 import io.ktor.client.request.post
@@ -63,7 +65,7 @@ abstract class BaseCommentViewModel(
     }
 
     private fun filterBlockedComments(
-        environment: PaginationEnvironment,
+        environment: ContentBlocklistEnvironment,
         comments: List<DataHolder.Comment>,
     ): List<DataHolder.Comment> {
         val blockedUserIds = environment.fetchBlockedUserIds()
@@ -93,7 +95,7 @@ abstract class BaseCommentViewModel(
     abstract fun submitComment(
         content: NavDestination,
         commentText: String,
-        environment: PaginationEnvironment,
+        environment: ZhihuApiEnvironment,
         replyToCommentId: String? = null,
         onSuccess: () -> Unit,
     )
@@ -102,7 +104,7 @@ abstract class BaseCommentViewModel(
 
     fun toggleLikeComment(
         commentData: DataHolder.Comment,
-        environment: PaginationEnvironment,
+        environment: ZhihuApiEnvironment,
         onSuccess: () -> Unit,
     ) {
         if (isLikeLoading) return

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/ChildCommentViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/ChildCommentViewModel.kt
@@ -23,7 +23,7 @@ import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.shared.data.DataHolder
 import com.github.zly2006.zhihu.shared.data.ZhihuJson
 import com.github.zly2006.zhihu.shared.viewmodel.CommentItem
-import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
+import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
 import com.github.zly2006.zhihu.viewmodel.comment.RootCommentViewModel.Companion.submitCommentUrl
 import io.ktor.client.call.body
 import io.ktor.client.request.post
@@ -58,7 +58,7 @@ class ChildCommentViewModel(
     override fun submitComment(
         content: NavDestination,
         commentText: String,
-        environment: PaginationEnvironment,
+        environment: ZhihuApiEnvironment,
         replyToCommentId: String?,
         onSuccess: () -> Unit,
     ) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/ChildCommentViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/ChildCommentViewModel.kt
@@ -25,8 +25,8 @@ import com.github.zly2006.zhihu.shared.data.ZhihuJson
 import com.github.zly2006.zhihu.shared.viewmodel.CommentItem
 import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
 import com.github.zly2006.zhihu.viewmodel.comment.RootCommentViewModel.Companion.submitCommentUrl
+import com.github.zly2006.zhihu.viewmodel.postSigned
 import io.ktor.client.call.body
-import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
@@ -76,8 +76,7 @@ class ChildCommentViewModel(
                     put("reply_comment_id", replyToCommentId ?: commentHolder.commentId)
                 }
 
-                val response = environment.httpClient().post(commentHolder.article.submitCommentUrl) {
-                    environment.configureSignedRequest(this)
+                val response = environment.postSigned(commentHolder.article.submitCommentUrl) {
                     contentType(ContentType.Application.Json)
                     setBody(requestBody)
                 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/RootCommentViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/RootCommentViewModel.kt
@@ -29,8 +29,8 @@ import com.github.zly2006.zhihu.shared.data.DataHolder
 import com.github.zly2006.zhihu.shared.data.ZhihuJson
 import com.github.zly2006.zhihu.shared.viewmodel.CommentItem
 import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
+import com.github.zly2006.zhihu.viewmodel.postSigned
 import io.ktor.client.call.body
-import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
@@ -136,8 +136,7 @@ class RootCommentViewModel(
                     replyToCommentId?.let { put("reply_comment_id", it) }
                 }
 
-                val response = environment.httpClient().post(content.submitCommentUrl) {
-                    environment.configureSignedRequest(this)
+                val response = environment.postSigned(content.submitCommentUrl) {
                     contentType(ContentType.Application.Json)
                     setBody(requestBody)
                 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/RootCommentViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/RootCommentViewModel.kt
@@ -28,7 +28,7 @@ import com.github.zly2006.zhihu.navigation.SegmentCommentHolder
 import com.github.zly2006.zhihu.shared.data.DataHolder
 import com.github.zly2006.zhihu.shared.data.ZhihuJson
 import com.github.zly2006.zhihu.shared.viewmodel.CommentItem
-import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
+import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
 import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -119,7 +119,7 @@ class RootCommentViewModel(
     override fun submitComment(
         content: NavDestination,
         commentText: String,
-        environment: PaginationEnvironment,
+        environment: ZhihuApiEnvironment,
         replyToCommentId: String?,
         onSuccess: () -> Unit,
     ) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/BaseFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/BaseFeedViewModel.kt
@@ -24,6 +24,7 @@ import com.github.zly2006.zhihu.shared.data.Feed
 import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
 import com.github.zly2006.zhihu.shared.data.GroupFeed
 import com.github.zly2006.zhihu.shared.data.toDisplayItem
+import com.github.zly2006.zhihu.viewmodel.FeedDisplayEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationViewModel
 import kotlinx.serialization.json.JsonArray
@@ -62,7 +63,7 @@ abstract class BaseFeedViewModel : PaginationViewModel<Feed>(typeOf<Feed>()) {
         isPullToRefresh = false
     }
 
-    open fun createDisplayItem(environment: PaginationEnvironment, feed: Feed): FeedDisplayItem {
+    open fun createDisplayItem(environment: FeedDisplayEnvironment, feed: Feed): FeedDisplayItem {
         val settings = environment.feedDisplaySettings()
         return feed.toDisplayItem(
             enableQualityFilter = settings.enableQualityFilter,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/FollowViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/FollowViewModel.kt
@@ -28,7 +28,8 @@ import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
 import com.github.zly2006.zhihu.shared.data.ZhihuJson
 import com.github.zly2006.zhihu.shared.data.sourceLabel
 import com.github.zly2006.zhihu.shared.data.target
-import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
+import com.github.zly2006.zhihu.viewmodel.FeedDisplayEnvironment
+import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.jsonArray
@@ -37,7 +38,7 @@ class FollowViewModel : BaseFeedViewModel() {
     override val initialUrl: String
         get() = "https://www.zhihu.com/api/v3/moments?limit=10&desktop=true"
 
-    override fun createDisplayItem(environment: PaginationEnvironment, feed: Feed): FeedDisplayItem =
+    override fun createDisplayItem(environment: FeedDisplayEnvironment, feed: Feed): FeedDisplayItem =
         super.createDisplayItem(environment, feed).withFollowSourceLabel(feed)
 }
 
@@ -74,7 +75,7 @@ class RecentMomentsViewModel : ViewModel() {
     var isLoading by mutableStateOf(false)
     var errorMessage by mutableStateOf<String?>(null)
 
-    fun load(environment: PaginationEnvironment) {
+    fun load(environment: ZhihuApiEnvironment) {
         if (isLoading || users.isNotEmpty()) return
         isLoading = true
         viewModelScope.launch {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
@@ -25,6 +25,7 @@ import com.github.zly2006.zhihu.shared.data.Feed
 import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
 import com.github.zly2006.zhihu.shared.data.navDestination
 import com.github.zly2006.zhihu.shared.data.target
+import com.github.zly2006.zhihu.viewmodel.ContentInteractionEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.filter.ContentDetailProvider
 import com.github.zly2006.zhihu.viewmodel.filter.extractTopicIds
@@ -96,9 +97,9 @@ private suspend fun resolveFeedBlockContentDetail(
 }
 
 interface HomeFeedInteractionViewModel {
-    suspend fun recordContentInteraction(environment: PaginationEnvironment, feed: Feed)
+    suspend fun recordContentInteraction(environment: ContentInteractionEnvironment, feed: Feed)
 
-    fun onUiContentClick(environment: PaginationEnvironment, feed: Feed, item: FeedDisplayItem)
+    fun onUiContentClick(environment: ContentInteractionEnvironment, feed: Feed, item: FeedDisplayItem)
 }
 
 class HomeFeedViewModel :
@@ -159,7 +160,7 @@ class HomeFeedViewModel :
      * 记录用户与内容的交互行为
      * 应该在用户点击、点赞等操作时调用
      */
-    override suspend fun recordContentInteraction(environment: PaginationEnvironment, feed: Feed) {
+    override suspend fun recordContentInteraction(environment: ContentInteractionEnvironment, feed: Feed) {
         try {
             environment.recordContentInteraction(feed)
         } catch (e: Exception) {
@@ -171,7 +172,7 @@ class HomeFeedViewModel :
      * 记录用户点击内容
      * 在viewModelScope中运行，使用viewModelScope代替GlobalScope
      */
-    override fun onUiContentClick(environment: PaginationEnvironment, feed: Feed, item: FeedDisplayItem) {
+    override fun onUiContentClick(environment: ContentInteractionEnvironment, feed: Feed, item: FeedDisplayItem) {
         viewModelScope.launch(Dispatchers.Default) {
             environment.sendFeedReadStatus(feed)
             recordContentInteraction(environment, feed)
@@ -179,7 +180,7 @@ class HomeFeedViewModel :
     }
 
     private suspend fun markItemsAsTouched(
-        environment: PaginationEnvironment,
+        environment: ContentInteractionEnvironment,
     ) {
         try {
             val currentTouchItems = displayItems

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HotListViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HotListViewModel.kt
@@ -20,7 +20,7 @@ package com.github.zly2006.zhihu.viewmodel.feed
 import com.github.zly2006.zhihu.shared.data.Feed
 import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
 import com.github.zly2006.zhihu.shared.data.zhihuHotListUrl
-import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
+import com.github.zly2006.zhihu.viewmodel.FeedDisplayEnvironment
 
 class HotListViewModel : BaseFeedViewModel() {
     override val initialUrl: String
@@ -30,7 +30,7 @@ class HotListViewModel : BaseFeedViewModel() {
         allowGuestAccess = true
     }
 
-    override fun createDisplayItem(environment: PaginationEnvironment, feed: Feed): FeedDisplayItem = super.createDisplayItem(environment, feed).copy(
+    override fun createDisplayItem(environment: FeedDisplayEnvironment, feed: Feed): FeedDisplayItem = super.createDisplayItem(environment, feed).copy(
         authorName = null,
         avatarSrc = null,
     )

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/QuestionFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/QuestionFeedViewModel.kt
@@ -24,6 +24,9 @@ import com.github.zly2006.zhihu.navigation.zhihuQuestionFeedsUrl
 import com.github.zly2006.zhihu.shared.data.Feed
 import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
 import com.github.zly2006.zhihu.shared.data.target
+import com.github.zly2006.zhihu.viewmodel.ContentBlocklistEnvironment
+import com.github.zly2006.zhihu.viewmodel.ContentInteractionEnvironment
+import com.github.zly2006.zhihu.viewmodel.FeedDisplayEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.filter.fetchBlockedUserIds
 
@@ -42,7 +45,7 @@ open class QuestionFeedViewModel(
         }
     }
 
-    override fun createDisplayItem(environment: PaginationEnvironment, feed: Feed): FeedDisplayItem {
+    override fun createDisplayItem(environment: FeedDisplayEnvironment, feed: Feed): FeedDisplayItem {
         val target = feed.target
         if (target is Feed.AnswerTarget) {
             return FeedDisplayItem(
@@ -57,7 +60,7 @@ open class QuestionFeedViewModel(
         return super.createDisplayItem(environment, feed)
     }
 
-    suspend fun followQuestion(environment: PaginationEnvironment, questionId: Long, follow: Boolean) {
+    suspend fun followQuestion(environment: ContentInteractionEnvironment, questionId: Long, follow: Boolean) {
         try {
             environment.followQuestion(questionId, follow)
         } catch (e: Exception) {
@@ -70,7 +73,7 @@ open class QuestionFeedViewModel(
         super.processResponse(environment, filtered, rawData)
     }
 
-    private fun filterBlockedAnswers(environment: PaginationEnvironment, data: List<Feed>): List<Feed> {
+    private fun filterBlockedAnswers(environment: ContentBlocklistEnvironment, data: List<Feed>): List<Feed> {
         val blockedUserIds = environment.fetchBlockedUserIds()
         if (blockedUserIds.isEmpty()) return data
         return data.filterNot { feed ->

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterManager.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterManager.kt
@@ -19,7 +19,7 @@ package com.github.zly2006.zhihu.viewmodel.filter
 import androidx.compose.runtime.Composable
 import com.github.zly2006.zhihu.shared.filter.ContentFilterStats
 import com.github.zly2006.zhihu.shared.filter.createContentFilterMaintenance
-import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
+import com.github.zly2006.zhihu.viewmodel.ContentBlocklistEnvironment
 
 typealias FilterStats = ContentFilterStats
 
@@ -92,7 +92,7 @@ class ContentFilterManager(
     }
 }
 
-fun PaginationEnvironment.fetchBlockedUserIds(): Set<String> = blockedUserIds()
+fun ContentBlocklistEnvironment.fetchBlockedUserIds(): Set<String> = blockedUserIds()
 
 @Composable
 expect fun rememberBlockedFeedRecordDao(): BlockedFeedRecordDao

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/local/LocalHomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/local/LocalHomeFeedViewModel.kt
@@ -20,6 +20,8 @@ package com.github.zly2006.zhihu.viewmodel.local
 import androidx.lifecycle.viewModelScope
 import com.github.zly2006.zhihu.shared.data.Feed
 import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
+import com.github.zly2006.zhihu.viewmodel.ContentInteractionEnvironment
+import com.github.zly2006.zhihu.viewmodel.LocalRecommendationEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.feed.BaseFeedViewModel
 import com.github.zly2006.zhihu.viewmodel.feed.HomeFeedInteractionViewModel
@@ -95,7 +97,7 @@ class LocalHomeFeedViewModel :
         }
     }
 
-    private suspend fun ensureEngine(environment: PaginationEnvironment): LocalRecommendationEngine {
+    private suspend fun ensureEngine(environment: LocalRecommendationEnvironment): LocalRecommendationEngine {
         if (!::recommendationEngine.isInitialized) {
             recommendationEngine = environment.localRecommendationEngine()
                 ?: error("LocalRecommendationEngine is required for local home feed")
@@ -131,9 +133,9 @@ class LocalHomeFeedViewModel :
     }
 
     override suspend fun recordContentInteraction(
-        environment: PaginationEnvironment,
+        environment: ContentInteractionEnvironment,
         feed: Feed,
     ) = Unit
 
-    override fun onUiContentClick(environment: PaginationEnvironment, feed: Feed, item: FeedDisplayItem) = Unit
+    override fun onUiContentClick(environment: ContentInteractionEnvironment, feed: Feed, item: FeedDisplayItem) = Unit
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/AndroidHomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/AndroidHomeFeedViewModel.kt
@@ -24,6 +24,7 @@ import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
 import com.github.zly2006.zhihu.shared.data.ZhihuJson
 import com.github.zly2006.zhihu.shared.data.navDestination
 import com.github.zly2006.zhihu.shared.data.toFeedDisplayItemNavDestinationJson
+import com.github.zly2006.zhihu.viewmodel.ContentInteractionEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.feed.BaseFeedViewModel
 import com.github.zly2006.zhihu.viewmodel.feed.HomeFeedInteractionViewModel
@@ -47,11 +48,9 @@ class AndroidHomeFeedViewModel :
     override val initialUrl: String
         get() = "https://api.zhihu.com/topstory/recommend"
 
-    override fun httpClient(environment: PaginationEnvironment) = environment.mobileHomeFeedHttpClient()
-
     public override suspend fun fetchFeeds(environment: PaginationEnvironment) {
         try {
-            val response = httpClient(environment).get(lastPaging?.next ?: initialUrl)
+            val response = environment.mobileHomeFeedHttpClient().get(lastPaging?.next ?: initialUrl)
             if (response.status.isSuccess()) {
                 val jojo = response.body<JsonObject>()
                 val data = jojo["data"]?.jsonArray ?: throw IllegalStateException("No data found in response")
@@ -112,11 +111,11 @@ class AndroidHomeFeedViewModel :
         }
     }
 
-    override suspend fun recordContentInteraction(environment: PaginationEnvironment, feed: Feed) {
+    override suspend fun recordContentInteraction(environment: ContentInteractionEnvironment, feed: Feed) {
         // Android 版本暂不记录交互
     }
 
-    override fun onUiContentClick(environment: PaginationEnvironment, feed: Feed, item: FeedDisplayItem) {
+    override fun onUiContentClick(environment: ContentInteractionEnvironment, feed: Feed, item: FeedDisplayItem) {
         viewModelScope.launch(Dispatchers.Default) {
             environment.sendFeedReadStatus(feed)
         }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/MixedHomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/MixedHomeFeedViewModel.kt
@@ -19,6 +19,7 @@ package com.github.zly2006.zhihu.viewmodel.za
 
 import com.github.zly2006.zhihu.shared.data.Feed
 import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
+import com.github.zly2006.zhihu.viewmodel.ContentInteractionEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.feed.BaseFeedViewModel
 import com.github.zly2006.zhihu.viewmodel.feed.HomeFeedInteractionViewModel
@@ -50,11 +51,11 @@ class MixedHomeFeedViewModel :
         isLoading = false
     }
 
-    override suspend fun recordContentInteraction(environment: PaginationEnvironment, feed: Feed) {
+    override suspend fun recordContentInteraction(environment: ContentInteractionEnvironment, feed: Feed) {
         web.recordContentInteraction(environment, feed)
     }
 
-    override fun onUiContentClick(environment: PaginationEnvironment, feed: Feed, item: FeedDisplayItem) {
+    override fun onUiContentClick(environment: ContentInteractionEnvironment, feed: Feed, item: FeedDisplayItem) {
         web.onUiContentClick(environment, feed, item)
     }
 }

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
@@ -146,7 +146,7 @@ class DesktopPaginationEnvironment(
     private val showFetchFailureMessage: ((String) -> Unit)? = null,
 ) : PaginationEnvironment,
     CollectionContentEnvironment,
-    NotificationPaginationEnvironment {
+    NotificationEnvironment {
     private val settingsStore = desktopSettingsStore()
     private val historyStorage = DesktopHistoryStorage()
     private val contentFilterDatabase = getContentFilterDatabase(desktopContentFilterDatabaseFile())

--- a/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/ui/NativeUiRuntimes.kt
+++ b/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/ui/NativeUiRuntimes.kt
@@ -31,7 +31,7 @@ import com.github.zly2006.zhihu.shared.notification.NotificationSettingsStore
 import com.github.zly2006.zhihu.shared.platform.UserMessageSink
 import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
 import com.github.zly2006.zhihu.ui.components.rememberShareDialogRuntime
-import com.github.zly2006.zhihu.viewmodel.NotificationPaginationEnvironment
+import com.github.zly2006.zhihu.viewmodel.NotificationEnvironment
 import com.github.zly2006.zhihu.viewmodel.NotificationViewModel
 import com.github.zly2006.zhihu.viewmodel.feed.HomeFeedViewModel
 import io.ktor.client.HttpClient
@@ -65,14 +65,14 @@ actual fun rememberNotificationScreenRuntime(
     settingsStore: NotificationSettingsStore,
 ): NotificationScreenRuntime = remember(settingsStore) {
     NotificationScreenRuntime(
-        environment = IosNotificationPaginationEnvironment(settingsStore),
+        environment = IosNotificationEnvironment(settingsStore),
         showDebugCopy = false,
     )
 }
 
-private class IosNotificationPaginationEnvironment(
+private class IosNotificationEnvironment(
     override val notificationSettingsStore: NotificationSettingsStore,
-) : NotificationPaginationEnvironment {
+) : NotificationEnvironment {
     override fun httpClient() = error("HTTP client not available on iOS yet") // TODO: iOS HTTP 客户端
 
     override suspend fun fetchJson(url: String, include: String): JsonObject = error("fetchJson not available on iOS yet") // TODO: iOS 通知数据获取


### PR DESCRIPTION
## 变更内容

- 将 `PaginationEnvironment` 拆分为更细的能力接口，保留其作为分页生命周期的总环境。
- 将知乎 API、内容展示、历史记录、内容交互、内容打开记录、文章加载/导出、收藏夹导出、通知设置等能力重新划分。
- 将 `fetchCollection` 改为基于 `ZhihuApiEnvironment` 的扩展，直接使用 `httpClient` 发起请求。
- 将通知环境改为 `NotificationEnvironment` / `NotificationSettingsEnvironment`，暂不合并 `NotificationSettingsStore` 和 `SettingsStore`。
- 移除 UI 层重复的首页交互接口，复用已有 ViewModel 交互接口。

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `./gradlew assembleLiteDebug`
- `git diff --check`