### PR TITLE
feat: 支持屏蔽 MCN 机构推荐

### DIFF
--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
@@ -69,6 +69,7 @@ import com.github.zly2006.zhihu.viewmodel.CollectionItem
 import com.github.zly2006.zhihu.viewmodel.filter.AndroidContentFilterRuntime
 import com.github.zly2006.zhihu.viewmodel.filter.ContentDetailProvider
 import com.github.zly2006.zhihu.viewmodel.filter.ContentFilterExtensions
+import com.github.zly2006.zhihu.viewmodel.filter.ZhihuMcnCompanyProvider
 import com.github.zly2006.zhihu.viewmodel.filter.contentFilterSettings
 import com.github.zly2006.zhihu.viewmodel.filter.createBlocklistManager
 import com.github.zly2006.zhihu.viewmodel.filter.getContentFilterDatabase
@@ -297,6 +298,9 @@ open class SharedAndroidPaginationEnvironment(
             },
             onDetailsKeywordFiltered = { item, keyword ->
                 Log.e("ContentFilterExtensions", "Filtered item '${item.title}' due to keyword '$keyword' in details: ${item.content}")
+            },
+            mcnCompanyProvider = ZhihuMcnCompanyProvider(httpClient()) { request ->
+                configureSignedRequest(request)
             },
         )
         return HomeFeedFilterResult(

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/BlocklistSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/BlocklistSettingsScreen.kt
@@ -72,6 +72,7 @@ import com.github.zly2006.zhihu.navigation.Person
 import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
 import com.github.zly2006.zhihu.shared.util.Log
 import com.github.zly2006.zhihu.viewmodel.filter.BlockedKeyword
+import com.github.zly2006.zhihu.viewmodel.filter.BlockedMcnOrganization
 import com.github.zly2006.zhihu.viewmodel.filter.BlockedTopic
 import com.github.zly2006.zhihu.viewmodel.filter.BlockedUser
 import com.github.zly2006.zhihu.viewmodel.filter.BlocklistStats
@@ -94,6 +95,8 @@ object BlocklistSettingsTestTags {
     const val USER_CLEAR_BUTTON = "blocklistSettings:users:clear"
     const val TOPIC_LIST = "blocklistSettings:topics:list"
     const val TOPIC_CLEAR_BUTTON = "blocklistSettings:topics:clear"
+    const val MCN_LIST = "blocklistSettings:mcn:list"
+    const val MCN_CLEAR_BUTTON = "blocklistSettings:mcn:clear"
     const val TOPIC_CLEAR_CONFIRM = "blocklistSettings:topics:clearConfirm"
     const val TOPIC_CLEAR_DISMISS = "blocklistSettings:topics:clearDismiss"
     const val KEYWORD_DIALOG_INPUT = "blocklistSettings:keywordDialog:input"
@@ -109,6 +112,9 @@ object BlocklistSettingsTestTags {
     const val TOPIC_DIALOG_NAME_INPUT = "blocklistSettings:topicDialog:topicName"
     const val TOPIC_DIALOG_CONFIRM = "blocklistSettings:topicDialog:confirm"
     const val TOPIC_DIALOG_DISMISS = "blocklistSettings:topicDialog:dismiss"
+    const val MCN_DIALOG_INPUT = "blocklistSettings:mcnDialog:organizationName"
+    const val MCN_DIALOG_CONFIRM = "blocklistSettings:mcnDialog:confirm"
+    const val MCN_DIALOG_DISMISS = "blocklistSettings:mcnDialog:dismiss"
 
     fun tab(index: Int) = "blocklistSettings:tab:$index"
 
@@ -123,12 +129,17 @@ object BlocklistSettingsTestTags {
     fun topicItem(topicId: String) = "blocklistSettings:topics:item:$topicId"
 
     fun topicDelete(topicId: String) = "blocklistSettings:topics:delete:$topicId"
+
+    fun mcnItem(organizationName: String) = "blocklistSettings:mcn:item:$organizationName"
+
+    fun mcnDelete(organizationName: String) = "blocklistSettings:mcn:delete:$organizationName"
 }
 
 data class BlocklistSettingsTestConfig(
     val blockedKeywords: List<BlockedKeyword> = emptyList(),
     val blockedUsers: List<BlockedUser> = emptyList(),
     val blockedTopics: List<BlockedTopic> = emptyList(),
+    val blockedMcnOrganizations: List<BlockedMcnOrganization> = emptyList(),
     val stats: BlocklistStats? = null,
     val onImportRequested: (() -> Unit)? = null,
     val onExportRequested: (() -> Unit)? = null,
@@ -141,6 +152,9 @@ data class BlocklistSettingsTestConfig(
     val onAddTopic: ((String, String) -> Unit)? = null,
     val onDeleteTopic: ((BlockedTopic) -> Unit)? = null,
     val onClearTopics: (() -> Unit)? = null,
+    val onAddMcnOrganization: ((String) -> Unit)? = null,
+    val onDeleteMcnOrganization: ((BlockedMcnOrganization) -> Unit)? = null,
+    val onClearMcnOrganizations: (() -> Unit)? = null,
     val nlpContent: BlocklistSettingsNlpContent? = null,
 )
 
@@ -156,21 +170,24 @@ fun BlocklistSettingsScreen(
     val coroutineScope = rememberCoroutineScope()
 
     var selectedTab by remember { mutableIntStateOf(0) }
-    val tabs = listOf("屏蔽关键词", "NLP智能屏蔽", "屏蔽用户", "屏蔽主题")
+    val tabs = listOf("屏蔽关键词", "NLP智能屏蔽", "屏蔽用户", "屏蔽主题", "屏蔽MCN")
 
     var loadedBlockedKeywords by remember { mutableStateOf<List<BlockedKeyword>>(emptyList()) }
     var loadedBlockedUsers by remember { mutableStateOf<List<BlockedUser>>(emptyList()) }
     var loadedBlockedTopics by remember { mutableStateOf<List<BlockedTopic>>(emptyList()) }
+    var loadedBlockedMcnOrganizations by remember { mutableStateOf<List<BlockedMcnOrganization>>(emptyList()) }
     var loadedStats by remember { mutableStateOf<BlocklistStats?>(null) }
 
     val blockedKeywords = testConfig?.blockedKeywords ?: loadedBlockedKeywords
     val blockedUsers = testConfig?.blockedUsers ?: loadedBlockedUsers
     val blockedTopics = testConfig?.blockedTopics ?: loadedBlockedTopics
+    val blockedMcnOrganizations = testConfig?.blockedMcnOrganizations ?: loadedBlockedMcnOrganizations
     val stats = testConfig?.stats ?: loadedStats
 
     var showAddKeywordDialog by remember { mutableStateOf(false) }
     var showAddUserDialog by remember { mutableStateOf(false) }
     var showAddTopicDialog by remember { mutableStateOf(false) }
+    var showAddMcnDialog by remember { mutableStateOf(false) }
 
     // 加载数据
     fun loadData() {
@@ -182,6 +199,7 @@ fun BlocklistSettingsScreen(
                     .filter { it.getKeywordTypeEnum() == KeywordType.EXACT_MATCH }
                 loadedBlockedUsers = blocklistManager.getAllBlockedUsers()
                 loadedBlockedTopics = blocklistManager.getAllBlockedTopics()
+                loadedBlockedMcnOrganizations = blocklistManager.getAllBlockedMcnOrganizations()
                 loadedStats = blocklistManager.getBlocklistStats()
             } catch (e: Exception) {
                 Log.e("BlocklistSettingsScreen", "Blocklist settings action failed", e)
@@ -199,8 +217,8 @@ fun BlocklistSettingsScreen(
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         floatingActionButton = {
-            // 只在传统关键词、用户屏蔽和主题屏蔽标签页显示添加按钮
-            if (selectedTab == 0 || selectedTab == 2 || selectedTab == 3) {
+            // 只在可手动添加规则的标签页显示添加按钮
+            if (selectedTab == 0 || selectedTab == 2 || selectedTab == 3 || selectedTab == 4) {
                 FloatingActionButton(
                     modifier = Modifier.testTag(BlocklistSettingsTestTags.FAB),
                     onClick = {
@@ -208,6 +226,7 @@ fun BlocklistSettingsScreen(
                             0 -> showAddKeywordDialog = true
                             2 -> showAddUserDialog = true
                             3 -> showAddTopicDialog = true
+                            4 -> showAddMcnDialog = true
                         }
                     },
                 ) {
@@ -275,6 +294,17 @@ fun BlocklistSettingsScreen(
                                 )
                                 Text(
                                     "${statsData.topicCount}",
+                                    style = MaterialTheme.typography.headlineMedium,
+                                    color = MaterialTheme.colorScheme.primary,
+                                )
+                            }
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Text(
+                                    "屏蔽MCN",
+                                    style = MaterialTheme.typography.bodySmall,
+                                )
+                                Text(
+                                    "${statsData.mcnOrganizationCount}",
                                     style = MaterialTheme.typography.headlineMedium,
                                     color = MaterialTheme.colorScheme.primary,
                                 )
@@ -474,6 +504,43 @@ fun BlocklistSettingsScreen(
                         }
                     },
                 )
+                4 -> BlockedMcnOrganizationsList(
+                    organizations = blockedMcnOrganizations,
+                    onDeleteOrganization = { organization ->
+                        val onDeleteOrganization = testConfig?.onDeleteMcnOrganization
+                        if (onDeleteOrganization != null) {
+                            onDeleteOrganization(organization)
+                        } else {
+                            coroutineScope.launch {
+                                try {
+                                    blocklistManager.removeBlockedMcnOrganization(organization.organizationName)
+                                    userMessages.showShortMessage("已删除MCN机构")
+                                    loadData()
+                                } catch (e: Exception) {
+                                    Log.e("BlocklistSettingsScreen", "Blocklist settings action failed", e)
+                                    userMessages.showShortMessage("删除失败: ${e.message}")
+                                }
+                            }
+                        }
+                    },
+                    onClearAll = {
+                        val onClearOrganizations = testConfig?.onClearMcnOrganizations
+                        if (onClearOrganizations != null) {
+                            onClearOrganizations()
+                        } else {
+                            coroutineScope.launch {
+                                try {
+                                    blocklistManager.clearAllBlockedMcnOrganizations()
+                                    userMessages.showShortMessage("已清空所有MCN机构")
+                                    loadData()
+                                } catch (e: Exception) {
+                                    Log.e("BlocklistSettingsScreen", "Blocklist settings action failed", e)
+                                    userMessages.showShortMessage("清空失败: ${e.message}")
+                                }
+                            }
+                        }
+                    },
+                )
             }
         }
     }
@@ -546,6 +613,31 @@ fun BlocklistSettingsScreen(
                             userMessages.showShortMessage("已添加用户")
                             loadData()
                             showAddUserDialog = false
+                        } catch (e: Exception) {
+                            Log.e("BlocklistSettingsScreen", "Blocklist settings action failed", e)
+                            userMessages.showShortMessage("添加失败: ${e.message}")
+                        }
+                    }
+                }
+            },
+        )
+    }
+
+    if (showAddMcnDialog) {
+        AddMcnOrganizationDialog(
+            onDismiss = { showAddMcnDialog = false },
+            onConfirm = { organizationName ->
+                val onAddOrganization = testConfig?.onAddMcnOrganization
+                if (onAddOrganization != null) {
+                    onAddOrganization(organizationName)
+                    showAddMcnDialog = false
+                } else {
+                    coroutineScope.launch {
+                        try {
+                            blocklistManager.addBlockedMcnOrganization(organizationName)
+                            userMessages.showShortMessage("已添加MCN机构")
+                            loadData()
+                            showAddMcnDialog = false
                         } catch (e: Exception) {
                             Log.e("BlocklistSettingsScreen", "Blocklist settings action failed", e)
                             userMessages.showShortMessage("添加失败: ${e.message}")
@@ -868,6 +960,137 @@ fun AddUserDialog(
         dismissButton = {
             TextButton(
                 modifier = Modifier.testTag(BlocklistSettingsTestTags.USER_DIALOG_DISMISS),
+                onClick = onDismiss,
+            ) {
+                Text("取消")
+            }
+        },
+    )
+}
+
+@Composable
+fun BlockedMcnOrganizationsList(
+    organizations: List<BlockedMcnOrganization>,
+    onDeleteOrganization: (BlockedMcnOrganization) -> Unit,
+    onClearAll: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        if (organizations.isNotEmpty()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                Button(
+                    modifier = Modifier.testTag(BlocklistSettingsTestTags.MCN_CLEAR_BUTTON),
+                    onClick = onClearAll,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error,
+                    ),
+                ) {
+                    Text("清空全部")
+                }
+            }
+        }
+
+        if (organizations.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    "暂无屏蔽MCN机构",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    "点击右下角的 + 按钮添加要屏蔽的机构名称",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.testTag(BlocklistSettingsTestTags.MCN_LIST),
+            ) {
+                items(organizations, key = { it.organizationName }) { organization ->
+                    ListItem(
+                        modifier = Modifier.testTag(BlocklistSettingsTestTags.mcnItem(organization.organizationName)),
+                        headlineContent = { Text(organization.organizationName) },
+                        supportingContent = { Text("屏蔽该 MCN 机构旗下用户发布的内容") },
+                        trailingContent = {
+                            IconButton(
+                                modifier = Modifier.testTag(
+                                    BlocklistSettingsTestTags.mcnDelete(organization.organizationName),
+                                ),
+                                onClick = { onDeleteOrganization(organization) },
+                            ) {
+                                Icon(
+                                    Icons.Default.Delete,
+                                    contentDescription = "删除",
+                                    tint = MaterialTheme.colorScheme.error,
+                                )
+                            }
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun AddMcnOrganizationDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    var organizationName by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("添加屏蔽MCN机构") },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = organizationName,
+                    onValueChange = { organizationName = it },
+                    label = { Text("机构名称") },
+                    placeholder = { Text("例如：杭州亚序") },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(BlocklistSettingsTestTags.MCN_DIALOG_INPUT),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    "提示：机构名称需与知乎用户主页显示的 MCN 机构名称一致。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                modifier = Modifier.testTag(BlocklistSettingsTestTags.MCN_DIALOG_CONFIRM),
+                onClick = {
+                    if (organizationName.isNotBlank()) {
+                        onConfirm(organizationName.trim())
+                    }
+                },
+                enabled = organizationName.isNotBlank(),
+            ) {
+                Text("添加")
+            }
+        },
+        dismissButton = {
+            TextButton(
+                modifier = Modifier.testTag(BlocklistSettingsTestTags.MCN_DIALOG_DISMISS),
                 onClick = onDismiss,
             ) {
                 Text("取消")

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PeopleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PeopleScreen.kt
@@ -88,12 +88,16 @@ import com.github.zly2006.zhihu.ui.PeopleListUiState
 import com.github.zly2006.zhihu.ui.PeopleProfileUiState
 import com.github.zly2006.zhihu.ui.PeopleSortedListUiState
 import com.github.zly2006.zhihu.ui.components.AuthorBadge
+import com.github.zly2006.zhihu.ui.components.BlockRecommendationSourceDialog
 import com.github.zly2006.zhihu.ui.components.FeedCard
 import com.github.zly2006.zhihu.ui.components.PaginatedList
 import com.github.zly2006.zhihu.ui.components.ProgressIndicatorFooter
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationViewModel
 import com.github.zly2006.zhihu.viewmodel.feed.BaseFeedViewModel
+import com.github.zly2006.zhihu.viewmodel.filter.ZhihuMcnCompanyProvider
+import com.github.zly2006.zhihu.viewmodel.filter.normalizeMcnCompany
+import com.github.zly2006.zhihu.viewmodel.filter.rememberBlocklistManager
 import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
 import io.ktor.client.call.body
 import io.ktor.client.request.delete
@@ -659,6 +663,13 @@ private fun PeopleScreenContent(
     val paginationEnvironment = rememberPaginationEnvironment(allowGuestAccess = false)
     val viewModel = viewModel { PersonViewModel(person) }
     val coroutineScope = rememberCoroutineScope()
+    val blocklistManager = rememberBlocklistManager()
+    val mcnCompanyProvider = remember(paginationEnvironment) {
+        ZhihuMcnCompanyProvider(paginationEnvironment.httpClient()) { request ->
+            paginationEnvironment.configureSignedRequest(request)
+        }
+    }
+    var mcnCompanyToBlock by remember(person.urlToken) { mutableStateOf<String?>(null) }
     var testUiState by remember(person.id, person.urlToken, testOverrides?.initialUiState) {
         mutableStateOf(testOverrides?.initialUiState ?: PeopleScreenUiState())
     }
@@ -773,8 +784,21 @@ private fun PeopleScreenContent(
                             } else {
                                 coroutineScope.launch {
                                     try {
-                                        viewModel.toggleRecommendationBlock(paginationEnvironment)
-                                        userMessages.showShortMessage(if (viewModel.isBlockedInRecommendations) "已屏蔽推荐" else "已取消屏蔽推荐")
+                                        if (viewModel.isBlockedInRecommendations) {
+                                            viewModel.toggleRecommendationBlock(paginationEnvironment)
+                                            userMessages.showShortMessage("已取消屏蔽推荐")
+                                            return@launch
+                                        }
+
+                                        val resolvedMcn = mcnCompanyProvider.getMcnCompany(person.urlToken).normalizeMcnCompany().also { company ->
+                                            blocklistManager.cacheMcnCompany(person.urlToken, viewModel.name, company)
+                                        }
+                                        if (resolvedMcn.isNullOrBlank()) {
+                                            viewModel.toggleRecommendationBlock(paginationEnvironment)
+                                            userMessages.showShortMessage("已屏蔽推荐")
+                                        } else {
+                                            mcnCompanyToBlock = resolvedMcn
+                                        }
                                     } catch (e: Exception) {
                                         userMessages.showShortMessage("操作失败: ${e.message}")
                                     }
@@ -1106,6 +1130,37 @@ private fun PeopleScreenContent(
                 }
             }
         }
+    }
+
+    val resolvedMcnCompanyToBlock = mcnCompanyToBlock
+    if (resolvedMcnCompanyToBlock != null) {
+        BlockRecommendationSourceDialog(
+            authorName = viewModel.name.ifBlank { person.name },
+            mcnCompany = resolvedMcnCompanyToBlock,
+            onDismiss = { mcnCompanyToBlock = null },
+            onBlockUser = {
+                coroutineScope.launch {
+                    try {
+                        viewModel.toggleRecommendationBlock(paginationEnvironment)
+                        mcnCompanyToBlock = null
+                        userMessages.showShortMessage("已屏蔽推荐")
+                    } catch (e: Exception) {
+                        userMessages.showShortMessage("操作失败: ${e.message}")
+                    }
+                }
+            },
+            onBlockMcn = {
+                coroutineScope.launch {
+                    try {
+                        blocklistManager.addBlockedMcnOrganization(resolvedMcnCompanyToBlock)
+                        mcnCompanyToBlock = null
+                        userMessages.showShortMessage("已屏蔽MCN机构：$resolvedMcnCompanyToBlock")
+                    } catch (e: Exception) {
+                        userMessages.showShortMessage("操作失败: ${e.message}")
+                    }
+                }
+            },
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/BlockUserDialog.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/BlockUserDialog.kt
@@ -17,19 +17,44 @@
 
 package com.github.zly2006.zhihu.ui.components
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Business
+import androidx.compose.material.icons.filled.PersonOff
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
 import com.github.zly2006.zhihu.shared.data.target
+import com.github.zly2006.zhihu.viewmodel.filter.ZhihuMcnCompanyProvider
+import com.github.zly2006.zhihu.viewmodel.filter.normalizeMcnCompany
+import com.github.zly2006.zhihu.viewmodel.filter.rememberBlocklistManager
+import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
 
 @Composable
 fun BlockUserConfirmDialogContent(
@@ -38,8 +63,93 @@ fun BlockUserConfirmDialogContent(
     displayItems: List<FeedDisplayItem>,
     onDismiss: () -> Unit,
     onConfirmBlock: (BlockedFeedAuthor) -> Unit,
+    onConfirmBlockMcn: (String) -> Unit = {},
 ) {
     if (showDialog && userToBlock != null) {
+        val author = remember(userToBlock, displayItems) {
+            userToBlock.let { (userId, userName) ->
+                val resolvedAuthor = displayItems
+                    .find { item ->
+                        item.feed
+                            ?.target
+                            ?.author
+                            ?.id == userId
+                    }?.feed
+                    ?.target
+                    ?.author
+                BlockedFeedAuthor(
+                    id = resolvedAuthor?.id ?: userId,
+                    name = resolvedAuthor?.name ?: userName,
+                    urlToken = resolvedAuthor?.urlToken,
+                    avatarUrl = resolvedAuthor?.avatarUrl,
+                )
+            }
+        }
+        val blocklistManager = rememberBlocklistManager()
+        val paginationEnvironment = rememberPaginationEnvironment(allowGuestAccess = false)
+        val mcnProvider = remember(paginationEnvironment) {
+            ZhihuMcnCompanyProvider(paginationEnvironment.httpClient()) { request ->
+                paginationEnvironment.configureSignedRequest(request)
+            }
+        }
+        var isResolvingMcn by remember(author.urlToken) { mutableStateOf(true) }
+        var mcnCompany by remember(author.urlToken) { mutableStateOf<String?>(null) }
+
+        LaunchedEffect(author) {
+            val urlToken = author.urlToken
+            if (urlToken.isNullOrBlank()) {
+                isResolvingMcn = false
+                return@LaunchedEffect
+            }
+            val lookupResult = runCatching { mcnProvider.getMcnCompany(urlToken).normalizeMcnCompany() }
+            val resolvedCompany = lookupResult.getOrNull()
+            if (lookupResult.isSuccess) {
+                blocklistManager.cacheMcnCompany(urlToken, author.name, resolvedCompany)
+            }
+            if (resolvedCompany.isNullOrBlank()) {
+                isResolvingMcn = false
+            } else {
+                mcnCompany = resolvedCompany
+                isResolvingMcn = false
+            }
+        }
+
+        if (isResolvingMcn) {
+            AlertDialog(
+                onDismissRequest = onDismiss,
+                title = { Text("识别推荐来源") },
+                text = {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Text("正在检查该作者是否属于 MCN 机构...")
+                    }
+                },
+                confirmButton = {},
+                dismissButton = {
+                    TextButton(onClick = onDismiss) {
+                        Text("取消")
+                    }
+                },
+            )
+            return
+        }
+
+        val resolvedMcnCompany = mcnCompany
+        if (!resolvedMcnCompany.isNullOrBlank()) {
+            BlockRecommendationSourceDialog(
+                authorName = author.name,
+                mcnCompany = resolvedMcnCompany,
+                onDismiss = onDismiss,
+                onBlockUser = { onConfirmBlock(author) },
+                onBlockMcn = { onConfirmBlockMcn(resolvedMcnCompany) },
+            )
+            return
+        }
+
         AlertDialog(
             onDismissRequest = onDismiss,
             title = { Text("屏蔽用户") },
@@ -57,25 +167,7 @@ fun BlockUserConfirmDialogContent(
             confirmButton = {
                 Button(
                     onClick = {
-                        userToBlock.let { (userId, userName) ->
-                            val author = displayItems
-                                .find { item ->
-                                    item.feed
-                                        ?.target
-                                        ?.author
-                                        ?.id == userId
-                                }?.feed
-                                ?.target
-                                ?.author
-                            onConfirmBlock(
-                                BlockedFeedAuthor(
-                                    id = author?.id ?: userId,
-                                    name = author?.name ?: userName,
-                                    urlToken = author?.urlToken,
-                                    avatarUrl = author?.avatarUrl,
-                                ),
-                            )
-                        }
+                        onConfirmBlock(author)
                     },
                 ) {
                     Text("确定屏蔽")
@@ -87,6 +179,82 @@ fun BlockUserConfirmDialogContent(
                 }
             },
         )
+    }
+}
+
+@Composable
+fun BlockRecommendationSourceDialog(
+    authorName: String,
+    mcnCompany: String,
+    onDismiss: () -> Unit,
+    onBlockUser: () -> Unit,
+    onBlockMcn: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("屏蔽推荐来源") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    "检测到该作者属于 MCN 机构，你想屏蔽哪一类内容？",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                BlockSourceChoiceCard(
+                    icon = { Icon(Icons.Default.PersonOff, contentDescription = null) },
+                    title = "屏蔽该用户",
+                    description = "仅隐藏「$authorName」的后续内容",
+                    onClick = onBlockUser,
+                )
+                BlockSourceChoiceCard(
+                    icon = { Icon(Icons.Default.Business, contentDescription = null) },
+                    title = "屏蔽 MCN 机构",
+                    description = "隐藏「$mcnCompany」旗下作者内容",
+                    onClick = onBlockMcn,
+                )
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("取消")
+            }
+        },
+    )
+}
+
+@Composable
+private fun BlockSourceChoiceCard(
+    icon: @Composable () -> Unit,
+    title: String,
+    description: String,
+    onClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            icon()
+            Spacer(modifier = Modifier.width(16.dp))
+            Column {
+                Text(title, style = MaterialTheme.typography.titleMedium)
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/UiComponentSupport.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/UiComponentSupport.kt
@@ -112,6 +112,18 @@ fun BlockUserConfirmDialog(
                 }
             }
         },
+        onConfirmBlockMcn = { organizationName ->
+            coroutineScope.launch {
+                try {
+                    blocklistManager.addBlockedMcnOrganization(organizationName)
+                    onConfirm()
+                    userMessages.showShortMessage("已屏蔽MCN机构：$organizationName")
+                } catch (e: Exception) {
+                    Log.e("FeedBlockActions", "Failed to block MCN organization", e)
+                    userMessages.showShortMessage("屏蔽MCN机构失败: ${e.message}")
+                }
+            }
+        },
     )
 }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/ContentFilterSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/ContentFilterSettingsScreen.kt
@@ -274,6 +274,34 @@ fun ContentFilterSettingsScreen(
                     highlightedKey = highlightedSetting,
                 )
 
+                val enableMcnBlocking = remember { mutableStateOf(settings.getBoolean("enableMcnBlocking", true)) }
+                SettingItemWithSwitch(
+                    title = { Text("启用MCN机构屏蔽") },
+                    description = { Text("按作者所属MCN机构屏蔽内容") },
+                    checked = enableMcnBlocking.value,
+                    onCheckedChange = {
+                        enableMcnBlocking.value = it
+                        settings.putBoolean("enableMcnBlocking", it)
+                    },
+                    settingKey = "enableMcnBlocking",
+                    highlightedKey = highlightedSetting,
+                )
+
+                AnimatedVisibility(visible = enableMcnBlocking.value) {
+                    val blockAllMcnAuthors = remember { mutableStateOf(settings.getBoolean("blockAllMcnAuthors", false)) }
+                    SettingItemWithSwitch(
+                        title = { Text("屏蔽所有MCN机构用户") },
+                        description = { Text("开启后，所有检测到MCN机构的作者内容都会被屏蔽") },
+                        checked = blockAllMcnAuthors.value,
+                        onCheckedChange = {
+                            blockAllMcnAuthors.value = it
+                            settings.putBoolean("blockAllMcnAuthors", it)
+                        },
+                        settingKey = "blockAllMcnAuthors",
+                        highlightedKey = highlightedSetting,
+                    )
+                }
+
                 val enableTopicBlocking = remember { mutableStateOf(settings.getBoolean("enableTopicBlocking", true)) }
                 SettingItemWithSwitch(
                     title = { Text("启用主题屏蔽") },

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/BlockedMcnOrganization.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/BlockedMcnOrganization.kt
@@ -1,0 +1,34 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for Android.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.viewmodel.filter
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import kotlin.time.Clock
+
+@Entity(tableName = BlockedMcnOrganization.TABLE_NAME)
+data class BlockedMcnOrganization(
+    @PrimaryKey val organizationName: String,
+    val addedTime: Long = currentEpochMillis(),
+) {
+    companion object {
+        const val TABLE_NAME = "blocked_mcn_organizations"
+    }
+}
+
+private fun currentEpochMillis(): Long = Clock.System.now().toEpochMilliseconds()

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/BlockedMcnOrganizationDao.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/BlockedMcnOrganizationDao.kt
@@ -1,0 +1,47 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for Android.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.viewmodel.filter
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface BlockedMcnOrganizationDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertOrganization(organization: BlockedMcnOrganization)
+
+    @Query("DELETE FROM ${BlockedMcnOrganization.TABLE_NAME} WHERE organizationName = :organizationName")
+    suspend fun deleteOrganizationByName(organizationName: String)
+
+    @Query("SELECT * FROM ${BlockedMcnOrganization.TABLE_NAME} ORDER BY addedTime DESC")
+    suspend fun getAllOrganizations(): List<BlockedMcnOrganization>
+
+    @Query("SELECT COUNT(*) FROM ${BlockedMcnOrganization.TABLE_NAME}")
+    suspend fun getOrganizationCount(): Int
+
+    @Query("SELECT EXISTS(SELECT 1 FROM ${BlockedMcnOrganization.TABLE_NAME})")
+    suspend fun hasOrganizations(): Boolean
+
+    @Query("SELECT EXISTS(SELECT 1 FROM ${BlockedMcnOrganization.TABLE_NAME} WHERE organizationName = :organizationName)")
+    suspend fun isOrganizationBlocked(organizationName: String): Boolean
+
+    @Query("DELETE FROM ${BlockedMcnOrganization.TABLE_NAME}")
+    suspend fun clearAllOrganizations()
+}

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/BlocklistBackup.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/BlocklistBackup.kt
@@ -28,6 +28,7 @@ data class BlocklistBackup(
     val nlpKeywords: List<NlpKeywordBackup> = emptyList(),
     val users: List<UserBackup> = emptyList(),
     val topics: List<TopicBackup> = emptyList(),
+    val mcnOrganizations: List<McnOrganizationBackup> = emptyList(),
 )
 
 @Serializable
@@ -54,4 +55,9 @@ data class UserBackup(
 data class TopicBackup(
     val topicId: String,
     val topicName: String,
+)
+
+@Serializable
+data class McnOrganizationBackup(
+    val organizationName: String,
 )

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/BlocklistManager.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/BlocklistManager.kt
@@ -36,6 +36,8 @@ class BlocklistService(
     private val keywordDao: BlockedKeywordDao,
     private val userDao: BlockedUserDao,
     private val topicDao: BlockedTopicDao,
+    private val mcnOrganizationDao: BlockedMcnOrganizationDao,
+    private val mcnAuthorCacheDao: McnAuthorCacheDao,
 ) {
     /**
      * 添加屏蔽关键词
@@ -162,6 +164,7 @@ class BlocklistService(
             keywordCount = keywordDao.getKeywordCount(),
             userCount = userDao.getUserCount(),
             topicCount = topicDao.getTopicCount(),
+            mcnOrganizationCount = mcnOrganizationDao.getOrganizationCount(),
         )
 
     /**
@@ -171,6 +174,47 @@ class BlocklistService(
         keywordDao.clearAllKeywords()
         userDao.clearAllUsers()
         topicDao.clearAllTopics()
+        mcnOrganizationDao.clearAllOrganizations()
+    }
+
+    suspend fun addBlockedMcnOrganization(organizationName: String) {
+        val trimmed = organizationName.trim()
+        if (trimmed.isNotEmpty()) {
+            mcnOrganizationDao.insertOrganization(BlockedMcnOrganization(trimmed))
+        }
+    }
+
+    suspend fun removeBlockedMcnOrganization(organizationName: String) {
+        mcnOrganizationDao.deleteOrganizationByName(organizationName)
+    }
+
+    suspend fun getAllBlockedMcnOrganizations(): List<BlockedMcnOrganization> = mcnOrganizationDao.getAllOrganizations()
+
+    suspend fun clearAllBlockedMcnOrganizations() {
+        mcnOrganizationDao.clearAllOrganizations()
+    }
+
+    suspend fun isMcnOrganizationBlocked(organizationName: String?): Boolean {
+        if (organizationName.isNullOrBlank()) return false
+        return mcnOrganizationDao.isOrganizationBlocked(organizationName)
+    }
+
+    suspend fun hasBlockedMcnOrganizations(): Boolean = mcnOrganizationDao.hasOrganizations()
+
+    suspend fun getCachedMcnAuthor(urlToken: String): McnAuthorCache? = mcnAuthorCacheDao.getByUrlToken(urlToken)
+
+    suspend fun cacheMcnCompany(
+        urlToken: String,
+        userName: String?,
+        mcnCompany: String?,
+    ) {
+        mcnAuthorCacheDao.insert(
+            McnAuthorCache(
+                urlToken = urlToken,
+                userName = userName,
+                mcnCompany = mcnCompany.normalizeMcnCompany(),
+            ),
+        )
     }
 
     /**
@@ -241,6 +285,7 @@ class BlocklistService(
                 .map { NlpKeywordBackup(it.keyword) },
             users = users.map { UserBackup(it.userId, it.userName, it.urlToken ?: "", it.avatarUrl ?: "") },
             topics = topics.map { TopicBackup(it.topicId, it.topicName) },
+            mcnOrganizations = mcnOrganizationDao.getAllOrganizations().map { McnOrganizationBackup(it.organizationName) },
         )
 
         return json.encodeToString(BlocklistBackup.serializer(), backup)
@@ -277,8 +322,11 @@ class BlocklistService(
         backup.topics.filter { it.topicId.isNotBlank() }.forEach { t ->
             topicDao.insertTopic(BlockedTopic(topicId = t.topicId, topicName = t.topicName))
         }
+        backup.mcnOrganizations.filter { it.organizationName.isNotBlank() }.forEach { mcn ->
+            mcnOrganizationDao.insertOrganization(BlockedMcnOrganization(mcn.organizationName))
+        }
 
-        return "关键词 ${backup.keywords.size} · NLP ${backup.nlpKeywords.size} · 用户 ${backup.users.size} · 主题 ${backup.topics.size}"
+        return "关键词 ${backup.keywords.size} · NLP ${backup.nlpKeywords.size} · 用户 ${backup.users.size} · 主题 ${backup.topics.size} · MCN ${backup.mcnOrganizations.size}"
     }
 
     suspend fun getTopicName(topicId: String): String = topicDao.getTopicNameById(topicId)
@@ -291,6 +339,7 @@ data class BlocklistStats(
     val keywordCount: Int,
     val userCount: Int,
     val topicCount: Int,
+    val mcnOrganizationCount: Int = 0,
 )
 
 /**
@@ -369,6 +418,42 @@ class BlocklistManager(
         }
     }
 
+    suspend fun addBlockedMcnOrganization(organizationName: String) {
+        withContext(Dispatchers.Default) {
+            service.addBlockedMcnOrganization(organizationName)
+        }
+    }
+
+    suspend fun removeBlockedMcnOrganization(organizationName: String) {
+        withContext(Dispatchers.Default) {
+            service.removeBlockedMcnOrganization(organizationName)
+        }
+    }
+
+    suspend fun getAllBlockedMcnOrganizations(): List<BlockedMcnOrganization> = withContext(Dispatchers.Default) {
+        service.getAllBlockedMcnOrganizations()
+    }
+
+    suspend fun getCachedMcnAuthor(urlToken: String): McnAuthorCache? = withContext(Dispatchers.Default) {
+        service.getCachedMcnAuthor(urlToken)
+    }
+
+    suspend fun cacheMcnCompany(
+        urlToken: String,
+        userName: String?,
+        mcnCompany: String?,
+    ) {
+        withContext(Dispatchers.Default) {
+            service.cacheMcnCompany(urlToken, userName, mcnCompany)
+        }
+    }
+
+    suspend fun clearAllBlockedMcnOrganizations() {
+        withContext(Dispatchers.Default) {
+            service.clearAllBlockedMcnOrganizations()
+        }
+    }
+
     suspend fun addBlockedTopic(
         topicId: String,
         topicName: String,
@@ -418,6 +503,8 @@ fun ContentFilterDatabase.createBlocklistManager(): BlocklistManager = Blocklist
         keywordDao = blockedKeywordDao(),
         userDao = blockedUserDao(),
         topicDao = blockedTopicDao(),
+        mcnOrganizationDao = blockedMcnOrganizationDao(),
+        mcnAuthorCacheDao = mcnAuthorCacheDao(),
     ),
 )
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterDatabase.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterDatabase.kt
@@ -29,8 +29,8 @@ import com.github.zly2006.zhihu.data.applyPlatformDriver
 import kotlinx.coroutines.Dispatchers
 
 @Database(
-    entities = [ContentViewRecord::class, BlockedKeyword::class, BlockedUser::class, BlockedContentRecord::class, BlockedTopic::class, BlockedFeedRecord::class, ContentOpenEvent::class],
-    version = 6,
+    entities = [ContentViewRecord::class, BlockedKeyword::class, BlockedUser::class, BlockedContentRecord::class, BlockedTopic::class, BlockedFeedRecord::class, ContentOpenEvent::class, BlockedMcnOrganization::class, McnAuthorCache::class],
+    version = 7,
     exportSchema = false,
 )
 @ConstructedBy(ContentFilterDatabaseConstructor::class)
@@ -48,6 +48,10 @@ abstract class ContentFilterDatabase : RoomDatabase() {
     abstract fun blockedTopicDao(): BlockedTopicDao
 
     abstract fun blockedFeedRecordDao(): BlockedFeedRecordDao
+
+    abstract fun blockedMcnOrganizationDao(): BlockedMcnOrganizationDao
+
+    abstract fun mcnAuthorCacheDao(): McnAuthorCacheDao
 }
 
 @Suppress("NO_ACTUAL_FOR_EXPECT")
@@ -147,10 +151,33 @@ private val migration5To6 = object : Migration(5, 6) {
     }
 }
 
+private val migration6To7 = object : Migration(6, 7) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `${BlockedMcnOrganization.TABLE_NAME}` (
+                `organizationName` TEXT NOT NULL PRIMARY KEY,
+                `addedTime` INTEGER NOT NULL
+            )
+            """.trimIndent(),
+        )
+        connection.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `${McnAuthorCache.TABLE_NAME}` (
+                `urlToken` TEXT NOT NULL PRIMARY KEY,
+                `userName` TEXT,
+                `mcnCompany` TEXT,
+                `checkedTime` INTEGER NOT NULL
+            )
+            """.trimIndent(),
+        )
+    }
+}
+
 fun buildContentFilterDatabase(
     builder: Builder<ContentFilterDatabase>,
 ): ContentFilterDatabase = builder
-    .addMigrations(migration2To3, migration3To4, migration4To5, migration5To6)
+    .addMigrations(migration2To3, migration3To4, migration4To5, migration5To6, migration6To7)
     .fallbackToDestructiveMigration(true)
     .applyPlatformDriver()
     .setQueryCoroutineContext(Dispatchers.Default)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
@@ -147,6 +147,7 @@ class FeedContentFilterPipeline(
     private val blockedKeywordService: BlockedKeywordService,
     private val htmlToText: (String) -> String = ::htmlToPlainText,
     private val onNlpBlocked: suspend (List<FilterableContent>) -> Unit = {},
+    private val mcnCompanyProvider: McnCompanyProvider = NoopMcnCompanyProvider,
 ) {
     suspend fun filter(contents: List<FilterableContent>): FeedContentFilterResult {
         val blocked = mutableListOf<Pair<FilterableContent, String>>()
@@ -205,6 +206,38 @@ class FeedContentFilterPipeline(
             filteredContents = finalFilteredContents
         }
 
+        if (settings.enableMcnBlocking && (settings.blockAllMcnAuthors || blocklistService.hasBlockedMcnOrganizations())) {
+            val kept = mutableListOf<FilterableContent>()
+            for (content in filteredContents) {
+                val urlToken = content.authorUrlToken
+                val mcnCompany = if (urlToken.isNullOrBlank()) {
+                    null
+                } else {
+                    val cachedAuthor = blocklistService.getCachedMcnAuthor(urlToken)
+                    if (cachedAuthor != null) {
+                        cachedAuthor.mcnCompany.normalizeMcnCompany()
+                    } else {
+                        runCatching {
+                            mcnCompanyProvider
+                                .getMcnCompany(urlToken)
+                                .normalizeMcnCompany()
+                                .also { company ->
+                                    blocklistService.cacheMcnCompany(urlToken, content.authorName, company)
+                                }
+                        }.getOrNull()
+                    }
+                }
+                val shouldBlock = !mcnCompany.isNullOrBlank() &&
+                    (settings.blockAllMcnAuthors || blocklistService.isMcnOrganizationBlocked(mcnCompany))
+                if (shouldBlock) {
+                    blocked.add(content to "屏蔽MCN机构：$mcnCompany")
+                } else {
+                    kept.add(content)
+                }
+            }
+            filteredContents = kept
+        }
+
         if (settings.enableTopicBlocking) {
             filteredContents = filteredContents.filter { content ->
                 val topicIds = extractTopicIds(content.raw)
@@ -254,6 +287,7 @@ fun ContentFilterDatabase.createFeedDisplayFilterPipeline(
     onNlpBlocked: suspend (List<FilterableContent>) -> Unit = {},
     onDetailFetchFailed: (FeedDisplayItem) -> Unit = {},
     onDetailsKeywordFiltered: (FeedDisplayItem, String) -> Unit = { _, _ -> },
+    mcnCompanyProvider: McnCompanyProvider = NoopMcnCompanyProvider,
 ): FeedDisplayFilterPipeline = FeedDisplayFilterPipeline(
     settings = settings,
     contentDetailProvider = contentDetailProvider,
@@ -263,6 +297,8 @@ fun ContentFilterDatabase.createFeedDisplayFilterPipeline(
             keywordDao = blockedKeywordDao(),
             userDao = blockedUserDao(),
             topicDao = blockedTopicDao(),
+            mcnOrganizationDao = blockedMcnOrganizationDao(),
+            mcnAuthorCacheDao = mcnAuthorCacheDao(),
         ),
         blockedKeywordService = BlockedKeywordService(
             keywordDao = blockedKeywordDao(),
@@ -270,6 +306,7 @@ fun ContentFilterDatabase.createFeedDisplayFilterPipeline(
             semanticMatcher = semanticMatcher,
         ),
         onNlpBlocked = onNlpBlocked,
+        mcnCompanyProvider = mcnCompanyProvider,
     ),
     blockedFeedRecordDao = blockedFeedRecordDao(),
     onDetailFetchFailed = onDetailFetchFailed,
@@ -284,6 +321,7 @@ suspend fun ContentFilterDatabase.filterFeedDisplayItems(
     onNlpBlocked: suspend (List<FilterableContent>) -> Unit = {},
     onDetailFetchFailed: (FeedDisplayItem) -> Unit = {},
     onDetailsKeywordFiltered: (FeedDisplayItem, String) -> Unit = { _, _ -> },
+    mcnCompanyProvider: McnCompanyProvider = NoopMcnCompanyProvider,
 ): List<FeedDisplayItem> = createFeedDisplayFilterPipeline(
     settings = settings,
     contentDetailProvider = contentDetailProvider,
@@ -291,6 +329,7 @@ suspend fun ContentFilterDatabase.filterFeedDisplayItems(
     onNlpBlocked = onNlpBlocked,
     onDetailFetchFailed = onDetailFetchFailed,
     onDetailsKeywordFiltered = onDetailsKeywordFiltered,
+    mcnCompanyProvider = mcnCompanyProvider,
 ).filter(items)
 
 class FeedDisplayFilterPipeline(
@@ -435,6 +474,7 @@ data class FilterableContent(
     val content: String?,
     val authorName: String?,
     val authorId: String?,
+    val authorUrlToken: String? = null,
     val contentId: String,
     val contentType: String,
     val raw: DataHolder.Content,
@@ -473,6 +513,7 @@ fun FeedDisplayItem.toFilterableContent(
     } ?: content ?: summary,
     authorName = authorName,
     authorId = rawContent.author?.id,
+    authorUrlToken = rawContent.author?.urlToken,
     contentId = identity.id,
     contentType = identity.type,
     raw = rawContent,
@@ -554,6 +595,8 @@ data class FeedFilterSettings(
     val enableNlpBlocking: Boolean = true,
     val nlpSimilarityThreshold: Double = 0.8,
     val enableUserBlocking: Boolean = true,
+    val enableMcnBlocking: Boolean = true,
+    val blockAllMcnAuthors: Boolean = false,
     val enableTopicBlocking: Boolean = true,
     val topicBlockingThreshold: Int = 1,
     val adBlockSettings: FeedAdBlockSettings = FeedAdBlockSettings(),
@@ -567,6 +610,8 @@ fun SettingsStore.toFeedFilterSettings(): FeedFilterSettings = FeedFilterSetting
     enableNlpBlocking = getBoolean("enableNLPBlocking", true),
     nlpSimilarityThreshold = getFloat("nlpSimilarityThreshold", 0.8f).toDouble(),
     enableUserBlocking = getBoolean("enableUserBlocking", true),
+    enableMcnBlocking = getBoolean("enableMcnBlocking", true),
+    blockAllMcnAuthors = getBoolean("blockAllMcnAuthors", false),
     enableTopicBlocking = getBoolean("enableTopicBlocking", true),
     topicBlockingThreshold = getInt("topicBlockingThreshold", 1),
     adBlockSettings = FeedAdBlockSettings(
@@ -639,6 +684,7 @@ suspend fun applyContentFilterToDisplayItems(
     onNlpBlocked: suspend (List<FilterableContent>) -> Unit = {},
     onDetailFetchFailed: (FeedDisplayItem) -> Unit = {},
     onDetailsKeywordFiltered: (FeedDisplayItem, String) -> Unit = { _, _ -> },
+    mcnCompanyProvider: McnCompanyProvider = NoopMcnCompanyProvider,
 ): List<FeedDisplayItem> = database.filterFeedDisplayItems(
     settings = settings,
     items = items,
@@ -647,6 +693,7 @@ suspend fun applyContentFilterToDisplayItems(
     onNlpBlocked = onNlpBlocked,
     onDetailFetchFailed = onDetailFetchFailed,
     onDetailsKeywordFiltered = onDetailsKeywordFiltered,
+    mcnCompanyProvider = mcnCompanyProvider,
 )
 
 fun isContentFilterEnabled(settings: FeedFilterSettings): Boolean = settings.enableContentFilter
@@ -800,6 +847,7 @@ object ContentFilterExtensions {
         onNlpBlocked: suspend (List<FilterableContent>) -> Unit = {},
         onDetailFetchFailed: (FeedDisplayItem) -> Unit = {},
         onDetailsKeywordFiltered: (FeedDisplayItem, String) -> Unit = { _, _ -> },
+        mcnCompanyProvider: McnCompanyProvider = NoopMcnCompanyProvider,
     ): List<FeedDisplayItem> = database.filterFeedDisplayItems(
         settings = settings,
         items = items,
@@ -808,5 +856,6 @@ object ContentFilterExtensions {
         onNlpBlocked = onNlpBlocked,
         onDetailFetchFailed = onDetailFetchFailed,
         onDetailsKeywordFiltered = onDetailsKeywordFiltered,
+        mcnCompanyProvider = mcnCompanyProvider,
     )
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/McnAuthorCache.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/McnAuthorCache.kt
@@ -1,0 +1,39 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for Android.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.viewmodel.filter
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import kotlin.time.Clock
+
+@Entity(tableName = McnAuthorCache.TABLE_NAME)
+data class McnAuthorCache(
+    @PrimaryKey val urlToken: String,
+    val userName: String? = null,
+    val mcnCompany: String? = null,
+    val checkedTime: Long = currentEpochMillis(),
+) {
+    val hasMcn: Boolean
+        get() = !mcnCompany.isNullOrBlank()
+
+    companion object {
+        const val TABLE_NAME = "mcn_author_cache"
+    }
+}
+
+private fun currentEpochMillis(): Long = Clock.System.now().toEpochMilliseconds()

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/McnAuthorCacheDao.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/McnAuthorCacheDao.kt
@@ -1,0 +1,35 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for Android.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.viewmodel.filter
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface McnAuthorCacheDao {
+    @Query("SELECT * FROM ${McnAuthorCache.TABLE_NAME} WHERE urlToken = :urlToken")
+    suspend fun getByUrlToken(urlToken: String): McnAuthorCache?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(cache: McnAuthorCache)
+
+    @Query("DELETE FROM ${McnAuthorCache.TABLE_NAME}")
+    suspend fun clearAll()
+}

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/McnCompanyProvider.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/McnCompanyProvider.kt
@@ -1,0 +1,24 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for Android.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.viewmodel.filter
+
+fun interface McnCompanyProvider {
+    suspend fun getMcnCompany(urlToken: String): String?
+}
+
+val NoopMcnCompanyProvider = McnCompanyProvider { null }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ZhihuMcnCompanyProvider.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ZhihuMcnCompanyProvider.kt
@@ -1,0 +1,154 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for Android.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.viewmodel.filter
+
+import com.github.zly2006.zhihu.shared.util.Log
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.get
+import io.ktor.client.request.url
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class ZhihuMcnCompanyProvider(
+    private val httpClient: HttpClient,
+    private val configureRequest: (HttpRequestBuilder) -> Unit = {},
+) : McnCompanyProvider {
+    override suspend fun getMcnCompany(urlToken: String): String? {
+        var hasSuccessfulResponse = false
+        var lastError: Throwable? = null
+        listOf<suspend () -> String?>(
+            {
+                fetchMcnCompanyFromPeopleApi(urlToken)
+            },
+            {
+                fetchMcnCompanyFromMembersApi(urlToken)
+            },
+        ).forEach { fetch ->
+            runCatching { fetch() }
+                .onSuccess { company ->
+                    hasSuccessfulResponse = true
+                    company.normalizeMcnCompany()?.let { return it }
+                }.onFailure { error ->
+                    lastError = error
+                    Log.e("ZhihuMcnCompanyProvider", "Failed to fetch MCN company for $urlToken", error)
+                }
+        }
+        if (hasSuccessfulResponse) return null
+        throw lastError ?: IllegalStateException("Failed to fetch MCN company for $urlToken")
+    }
+
+    private suspend fun fetchMcnCompanyFromPeopleApi(urlToken: String): String? {
+        val user = httpClient
+            .get("https://api.zhihu.com/people/$urlToken") {
+                url {
+                    parameters["include"] = "badge_v2,mcn_company,mcnCompany"
+                }
+                configureRequest(this)
+            }.body<JsonElement>()
+        return extractMcnCompanyFromPeopleApi(user)
+    }
+
+    private suspend fun fetchMcnCompanyFromMembersApi(urlToken: String): String? {
+        val user = httpClient
+            .get("https://www.zhihu.com/api/v4/members/$urlToken") {
+                url {
+                    parameters["include"] = "badge_v2,mcn_company,mcnCompany,mcn_user_info"
+                }
+                configureRequest(this)
+            }.body<JsonElement>()
+        return extractMcnCompanyFromPeopleApi(user)
+    }
+}
+
+internal fun extractMcnCompanyFromPeopleApi(user: JsonElement): String? {
+    val root = user.jsonObject
+    findMcnCompanyString(root)?.let { return it }
+
+    val badgeV2 = root["badge_v2"]?.jsonObject ?: root["badgeV2"]?.jsonObject
+    if (badgeV2 == null) {
+        return null
+    }
+    val badges = listOfNotNull(
+        badgeV2["detail_badges"]?.jsonArray,
+        badgeV2["detailBadges"]?.jsonArray,
+        badgeV2["merged_badges"]?.jsonArray,
+        badgeV2["mergedBadges"]?.jsonArray,
+    ).flatten()
+
+    return badges.firstNotNullOfOrNull { badge ->
+        val badgeObject = badge as? JsonObject ?: return@firstNotNullOfOrNull null
+        val isMcnBadge = listOf("type", "detail_type", "detailType", "title")
+            .mapNotNull { key -> findString(badgeObject, key) }
+            .any { it.contains("mcn", ignoreCase = true) || it.contains("MCN", ignoreCase = true) }
+        if (!isMcnBadge) return@firstNotNullOfOrNull null
+
+        badgeObject["sources"]
+            ?.takeIf { it is JsonArray }
+            ?.jsonArray
+            ?.firstNotNullOfOrNull { source ->
+                (source as? JsonObject)?.let { findString(it, "name") }
+            }
+            ?: findString(badgeObject, "description")?.takeUnless { it.equals("MCN", ignoreCase = true) }
+    }
+}
+
+private fun findMcnCompanyString(jsonObject: JsonObject): String? {
+    findString(jsonObject, "mcnCompany", "mcn_company")?.let { return it }
+    jsonObject.forEach { (key, value) ->
+        if (key.contains("mcn", ignoreCase = true)) {
+            when (value) {
+                is JsonObject -> {
+                    findString(value, "company", "companyName", "organization", "organizationName", "name")?.let { return it }
+                    findMcnCompanyString(value)?.let { return it }
+                }
+                is JsonArray ->
+                    value
+                        .firstNotNullOfOrNull { item ->
+                            (item as? JsonObject)?.let { itemObject ->
+                                findString(itemObject, "company", "companyName", "organization", "organizationName", "name")
+                                    ?: findMcnCompanyString(itemObject)
+                            }
+                        }?.let { return it }
+                else -> Unit
+            }
+        }
+    }
+    return null
+}
+
+private fun findString(
+    jsonObject: JsonObject,
+    vararg keys: String,
+): String? = keys.firstNotNullOfOrNull { key ->
+    jsonObject[key]
+        ?.jsonPrimitive
+        ?.contentOrNull
+        ?.takeIf { it.isNotBlank() }
+}
+
+internal fun String?.normalizeMcnCompany(): String? {
+    val value = this?.trim()?.takeIf { it.isNotBlank() } ?: return null
+    return value.takeUnless { it.equals("false", ignoreCase = true) || it.equals("true", ignoreCase = true) }
+}

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/shared/filter/BlocklistBackupTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/shared/filter/BlocklistBackupTest.kt
@@ -17,6 +17,12 @@
 
 package com.github.zly2006.zhihu.shared.filter
 
+import com.github.zly2006.zhihu.viewmodel.filter.BlocklistBackup
+import com.github.zly2006.zhihu.viewmodel.filter.KeywordBackup
+import com.github.zly2006.zhihu.viewmodel.filter.McnOrganizationBackup
+import com.github.zly2006.zhihu.viewmodel.filter.NlpKeywordBackup
+import com.github.zly2006.zhihu.viewmodel.filter.TopicBackup
+import com.github.zly2006.zhihu.viewmodel.filter.UserBackup
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlin.test.Test
@@ -51,6 +57,7 @@ class BlocklistBackupTest {
                 ),
             ),
             topics = listOf(TopicBackup(topicId = "topic-1", topicName = "主题")),
+            mcnOrganizations = listOf(McnOrganizationBackup("杭州亚序科技有限公司")),
         )
 
         val encoded = json.encodeToString(BlocklistBackup.serializer(), backup)
@@ -58,6 +65,7 @@ class BlocklistBackupTest {
         val element = json.parseToJsonElement(encoded).jsonObject
 
         assertTrue("keywords" in element)
+        assertTrue("mcnOrganizations" in element)
         assertEquals(backup, decoded)
     }
 

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
@@ -64,6 +64,7 @@ import com.github.zly2006.zhihu.util.sanitizeArticleExportFileNamePart
 import com.github.zly2006.zhihu.viewmodel.CollectionItem
 import com.github.zly2006.zhihu.viewmodel.filter.ContentDetailProvider
 import com.github.zly2006.zhihu.viewmodel.filter.ContentType
+import com.github.zly2006.zhihu.viewmodel.filter.ZhihuMcnCompanyProvider
 import com.github.zly2006.zhihu.viewmodel.filter.applyContentFilterToDisplayItems
 import com.github.zly2006.zhihu.viewmodel.filter.applyForegroundReadFilterToDisplayItems
 import com.github.zly2006.zhihu.viewmodel.filter.createBlocklistManager
@@ -337,6 +338,9 @@ class DesktopPaginationEnvironment(
             items = foregroundItems,
             contentDetailProvider = ContentDetailProvider(::fetchContentDetail),
             semanticMatcher = desktopKeywordSemanticMatcher,
+            mcnCompanyProvider = ZhihuMcnCompanyProvider(httpClient()) { request ->
+                configureSignedRequest(request)
+            },
         )
         return HomeFeedFilterResult(
             foregroundItems = foregroundItems,

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedContentFilterPipelineTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedContentFilterPipelineTest.kt
@@ -33,6 +33,8 @@ class FeedContentFilterPipelineTest {
             keywordDao = database.blockedKeywordDao(),
             userDao = database.blockedUserDao(),
             topicDao = database.blockedTopicDao(),
+            mcnOrganizationDao = database.blockedMcnOrganizationDao(),
+            mcnAuthorCacheDao = database.mcnAuthorCacheDao(),
         )
         blocklistService.addBlockedUser(userId = "blocked-user", userName = "Blocked")
         blocklistService.addBlockedKeyword("blocked keyword")
@@ -100,6 +102,8 @@ class FeedContentFilterPipelineTest {
                 keywordDao = database.blockedKeywordDao(),
                 userDao = database.blockedUserDao(),
                 topicDao = database.blockedTopicDao(),
+                mcnOrganizationDao = database.blockedMcnOrganizationDao(),
+                mcnAuthorCacheDao = database.mcnAuthorCacheDao(),
             ),
             blockedKeywordService = keywordService,
         ).filter(
@@ -117,10 +121,276 @@ class FeedContentFilterPipelineTest {
         database.close()
     }
 
+    @Test
+    fun filtersByBlockedMcnOrganization() = runTest {
+        val database = getContentFilterDatabase(
+            createTempDirectory("feed-content-filter-mcn").resolve("content-filter.db").toFile(),
+        )
+        val blocklistService = BlocklistService(
+            keywordDao = database.blockedKeywordDao(),
+            userDao = database.blockedUserDao(),
+            topicDao = database.blockedTopicDao(),
+            mcnOrganizationDao = database.blockedMcnOrganizationDao(),
+            mcnAuthorCacheDao = database.mcnAuthorCacheDao(),
+        )
+        blocklistService.addBlockedMcnOrganization("杭州亚序")
+
+        val result = FeedContentFilterPipeline(
+            settings = FeedFilterSettings(),
+            blocklistService = blocklistService,
+            blockedKeywordService = BlockedKeywordService(
+                keywordDao = database.blockedKeywordDao(),
+                recordDao = database.blockedContentRecordDao(),
+                semanticMatcher = KeywordSemanticMatcher { _, _, _ -> emptyList() },
+            ),
+            mcnCompanyProvider = McnCompanyProvider { token ->
+                when (token) {
+                    "blocked-token" -> "杭州亚序"
+                    "ok-token" -> "其他机构"
+                    else -> null
+                }
+            },
+        ).filter(
+            listOf(
+                filterable("blocked mcn", authorId = "blocked-user", authorUrlToken = "blocked-token"),
+                filterable("other mcn", authorId = "ok-user", authorUrlToken = "ok-token"),
+                filterable("no token", authorId = "missing-token", authorUrlToken = null),
+            ),
+        )
+
+        assertEquals(listOf("other mcn", "no token"), result.kept.map { it.title })
+        assertEquals(listOf("屏蔽MCN机构：杭州亚序"), result.blocked.map { it.second })
+        database.close()
+    }
+
+    @Test
+    fun keepsBlockedMcnOrganizationWhenMcnBlockingDisabled() = runTest {
+        val database = getContentFilterDatabase(
+            createTempDirectory("feed-content-filter-mcn-disabled").resolve("content-filter.db").toFile(),
+        )
+        val blocklistService = BlocklistService(
+            keywordDao = database.blockedKeywordDao(),
+            userDao = database.blockedUserDao(),
+            topicDao = database.blockedTopicDao(),
+            mcnOrganizationDao = database.blockedMcnOrganizationDao(),
+            mcnAuthorCacheDao = database.mcnAuthorCacheDao(),
+        )
+        blocklistService.addBlockedMcnOrganization("杭州亚序")
+
+        val result = FeedContentFilterPipeline(
+            settings = FeedFilterSettings(enableMcnBlocking = false),
+            blocklistService = blocklistService,
+            blockedKeywordService = BlockedKeywordService(
+                keywordDao = database.blockedKeywordDao(),
+                recordDao = database.blockedContentRecordDao(),
+                semanticMatcher = KeywordSemanticMatcher { _, _, _ -> emptyList() },
+            ),
+            mcnCompanyProvider = McnCompanyProvider { "杭州亚序" },
+        ).filter(
+            listOf(
+                filterable("blocked mcn", authorId = "blocked-user", authorUrlToken = "blocked-token"),
+            ),
+        )
+
+        assertEquals(listOf("blocked mcn"), result.kept.map { it.title })
+        assertEquals(emptyList(), result.blocked)
+        database.close()
+    }
+
+    @Test
+    fun skipsMcnLookupWhenNoMcnRuleIsEnabled() = runTest {
+        val database = getContentFilterDatabase(
+            createTempDirectory("feed-content-filter-no-mcn-rules").resolve("content-filter.db").toFile(),
+        )
+        var calls = 0
+        val result = FeedContentFilterPipeline(
+            settings = FeedFilterSettings(),
+            blocklistService = BlocklistService(
+                keywordDao = database.blockedKeywordDao(),
+                userDao = database.blockedUserDao(),
+                topicDao = database.blockedTopicDao(),
+                mcnOrganizationDao = database.blockedMcnOrganizationDao(),
+                mcnAuthorCacheDao = database.mcnAuthorCacheDao(),
+            ),
+            blockedKeywordService = BlockedKeywordService(
+                keywordDao = database.blockedKeywordDao(),
+                recordDao = database.blockedContentRecordDao(),
+                semanticMatcher = KeywordSemanticMatcher { _, _, _ -> emptyList() },
+            ),
+            mcnCompanyProvider = McnCompanyProvider {
+                calls += 1
+                "杭州亚序"
+            },
+        ).filter(
+            listOf(filterable("normal", authorId = "normal-user", authorUrlToken = "normal-token")),
+        )
+
+        assertEquals(listOf("normal"), result.kept.map { it.title })
+        assertEquals(emptyList(), result.blocked)
+        assertEquals(0, calls)
+        database.close()
+    }
+
+    @Test
+    fun filtersKnownMcnAuthorsByTheirOrganizations() = runTest {
+        val knownAuthors = mapOf(
+            "jiang-nan-mao-mao-chong" to "知加传媒（深圳）有限公司",
+            "lihuawei" to "杭州亚序科技有限公司",
+            "qbtu-zi" to "杭州亚序科技有限公司",
+            "allen-xu-3" to "杭州亚序科技有限公司",
+            "dao-shu-43" to "杭州亚序科技有限公司",
+            "wang-yu-ting-29-74" to "杭州亚序科技有限公司",
+            "xin-yuan-jia-de-xiao-ling-lai" to "杭州亚序科技有限公司",
+            "duncanzhang" to "杭州亚序科技有限公司",
+            "dream-boy-60-5" to "杭州亚序科技有限公司",
+            "ju-bei-yao-jiu-jing-gu-du-81-39" to "知加传媒（深圳）有限公司",
+            "yuan-bei-bei-14" to "杭州含章文化传播有限公司",
+            "yang-xi-yu-25-5" to "知加传媒（深圳）有限公司",
+            "jin-xiao-cun-wei-yi-bao-49" to "上海友芝士文化传播有限公司",
+            "allen-63-88" to "深圳知外文化传播有限公司",
+            "mu-cun-shang-chun-shu" to "极合（北京）科技有限公司",
+            "lee-lee-1998" to "杭州亚序科技有限公司",
+        )
+        val database = getContentFilterDatabase(
+            createTempDirectory("feed-content-filter-known-mcn").resolve("content-filter.db").toFile(),
+        )
+        val blocklistService = BlocklistService(
+            keywordDao = database.blockedKeywordDao(),
+            userDao = database.blockedUserDao(),
+            topicDao = database.blockedTopicDao(),
+            mcnOrganizationDao = database.blockedMcnOrganizationDao(),
+            mcnAuthorCacheDao = database.mcnAuthorCacheDao(),
+        )
+        knownAuthors.values.distinct().forEach { organization ->
+            blocklistService.addBlockedMcnOrganization(organization)
+        }
+
+        val result = FeedContentFilterPipeline(
+            settings = FeedFilterSettings(),
+            blocklistService = blocklistService,
+            blockedKeywordService = BlockedKeywordService(
+                keywordDao = database.blockedKeywordDao(),
+                recordDao = database.blockedContentRecordDao(),
+                semanticMatcher = KeywordSemanticMatcher { _, _, _ -> emptyList() },
+            ),
+            mcnCompanyProvider = McnCompanyProvider { token -> knownAuthors[token] },
+        ).filter(
+            knownAuthors.keys.map { token ->
+                filterable(token, authorId = token, authorUrlToken = token)
+            },
+        )
+
+        assertEquals(emptyList(), result.kept)
+        assertEquals(knownAuthors.size, result.blocked.size)
+        assertEquals(
+            knownAuthors.values.map { organization -> "屏蔽MCN机构：$organization" }.toSet(),
+            result.blocked.map { it.second }.toSet(),
+        )
+        database.close()
+    }
+
+    @Test
+    fun filtersAllMcnAuthorsWhenEnabled() = runTest {
+        val database = getContentFilterDatabase(
+            createTempDirectory("feed-content-filter-all-mcn").resolve("content-filter.db").toFile(),
+        )
+        val result = FeedContentFilterPipeline(
+            settings = FeedFilterSettings(blockAllMcnAuthors = true),
+            blocklistService = BlocklistService(
+                keywordDao = database.blockedKeywordDao(),
+                userDao = database.blockedUserDao(),
+                topicDao = database.blockedTopicDao(),
+                mcnOrganizationDao = database.blockedMcnOrganizationDao(),
+                mcnAuthorCacheDao = database.mcnAuthorCacheDao(),
+            ),
+            blockedKeywordService = BlockedKeywordService(
+                keywordDao = database.blockedKeywordDao(),
+                recordDao = database.blockedContentRecordDao(),
+                semanticMatcher = KeywordSemanticMatcher { _, _, _ -> emptyList() },
+            ),
+            mcnCompanyProvider = McnCompanyProvider { token ->
+                if (token == "mcn-token") "任意机构" else null
+            },
+        ).filter(
+            listOf(
+                filterable("mcn", authorId = "mcn-user", authorUrlToken = "mcn-token"),
+                filterable("normal", authorId = "normal-user", authorUrlToken = "normal-token"),
+            ),
+        )
+
+        assertEquals(listOf("normal"), result.kept.map { it.title })
+        assertEquals(listOf("屏蔽MCN机构：任意机构"), result.blocked.map { it.second })
+        database.close()
+    }
+
+    @Test
+    fun ignoresInvalidMcnCompanyValues() = runTest {
+        val database = getContentFilterDatabase(
+            createTempDirectory("feed-content-filter-invalid-mcn").resolve("content-filter.db").toFile(),
+        )
+        val result = FeedContentFilterPipeline(
+            settings = FeedFilterSettings(blockAllMcnAuthors = true),
+            blocklistService = BlocklistService(
+                keywordDao = database.blockedKeywordDao(),
+                userDao = database.blockedUserDao(),
+                topicDao = database.blockedTopicDao(),
+                mcnOrganizationDao = database.blockedMcnOrganizationDao(),
+                mcnAuthorCacheDao = database.mcnAuthorCacheDao(),
+            ),
+            blockedKeywordService = BlockedKeywordService(
+                keywordDao = database.blockedKeywordDao(),
+                recordDao = database.blockedContentRecordDao(),
+                semanticMatcher = KeywordSemanticMatcher { _, _, _ -> emptyList() },
+            ),
+            mcnCompanyProvider = McnCompanyProvider { "false" },
+        ).filter(
+            listOf(filterable("normal", authorId = "normal-user", authorUrlToken = "normal-token")),
+        )
+
+        assertEquals(listOf("normal"), result.kept.map { it.title })
+        assertEquals(emptyList(), result.blocked)
+        database.close()
+    }
+
+    @Test
+    fun cachesAuthorsWithoutMcnCompany() = runTest {
+        val database = getContentFilterDatabase(
+            createTempDirectory("feed-content-filter-no-mcn-cache").resolve("content-filter.db").toFile(),
+        )
+        var calls = 0
+        val blocklistService = BlocklistService(
+            keywordDao = database.blockedKeywordDao(),
+            userDao = database.blockedUserDao(),
+            topicDao = database.blockedTopicDao(),
+            mcnOrganizationDao = database.blockedMcnOrganizationDao(),
+            mcnAuthorCacheDao = database.mcnAuthorCacheDao(),
+        )
+        val pipeline = FeedContentFilterPipeline(
+            settings = FeedFilterSettings(blockAllMcnAuthors = true),
+            blocklistService = blocklistService,
+            blockedKeywordService = BlockedKeywordService(
+                keywordDao = database.blockedKeywordDao(),
+                recordDao = database.blockedContentRecordDao(),
+                semanticMatcher = KeywordSemanticMatcher { _, _, _ -> emptyList() },
+            ),
+            mcnCompanyProvider = McnCompanyProvider {
+                calls += 1
+                null
+            },
+        )
+
+        pipeline.filter(listOf(filterable("first", authorId = "normal-user", authorUrlToken = "normal-token")))
+        pipeline.filter(listOf(filterable("second", authorId = "normal-user", authorUrlToken = "normal-token")))
+
+        assertEquals(1, calls)
+        database.close()
+    }
+
     private fun filterable(
         title: String,
         content: String = title,
         authorId: String,
+        authorUrlToken: String? = "author",
         topicId: String? = null,
     ): FilterableContent = FilterableContent(
         title = title,
@@ -128,6 +398,7 @@ class FeedContentFilterPipelineTest {
         content = content,
         authorName = "author",
         authorId = authorId,
+        authorUrlToken = authorUrlToken,
         contentId = title,
         contentType = "article",
         raw = article(title, content, topicId),

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedDisplayFilterPipelineTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedDisplayFilterPipelineTest.kt
@@ -194,6 +194,8 @@ class FeedDisplayFilterPipelineTest {
                     keywordDao = database.blockedKeywordDao(),
                     userDao = database.blockedUserDao(),
                     topicDao = database.blockedTopicDao(),
+                    mcnOrganizationDao = database.blockedMcnOrganizationDao(),
+                    mcnAuthorCacheDao = database.mcnAuthorCacheDao(),
                 ),
                 blockedKeywordService = BlockedKeywordService(
                     keywordDao = database.blockedKeywordDao(),

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedFilterSettingsTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedFilterSettingsTest.kt
@@ -32,6 +32,8 @@ class FeedFilterSettingsTest {
             "enableNLPBlocking" to false,
             "nlpSimilarityThreshold" to 0.65f,
             "enableUserBlocking" to false,
+            "enableMcnBlocking" to false,
+            "blockAllMcnAuthors" to true,
             "enableTopicBlocking" to false,
             "topicBlockingThreshold" to 3,
             "blockZhihuAdPlatform" to false,
@@ -47,6 +49,8 @@ class FeedFilterSettingsTest {
         assertEquals(false, settings.enableNlpBlocking)
         assertEquals(0.65, settings.nlpSimilarityThreshold, 0.0001)
         assertEquals(false, settings.enableUserBlocking)
+        assertEquals(false, settings.enableMcnBlocking)
+        assertEquals(true, settings.blockAllMcnAuthors)
         assertEquals(false, settings.enableTopicBlocking)
         assertEquals(3, settings.topicBlockingThreshold)
         assertEquals(false, settings.adBlockSettings.blockZhihuAdPlatform)

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ZhihuMcnCompanyProviderTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ZhihuMcnCompanyProviderTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for Android.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.viewmodel.filter
+
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ZhihuMcnCompanyProviderTest {
+    @Test
+    fun parsesMcnCompanyFromPeopleApiBadgeSources() = runTest {
+        val json =
+            """
+            {
+              "id": "user-id",
+              "url_token": "lihuawei",
+              "name": "李明殊",
+              "badge_v2": {
+                "detail_badges": [
+                  {
+                    "type": "mcn",
+                    "title": "MCN",
+                    "description": "知加传媒（深圳）有限公司",
+                    "sources": [
+                      { "name": "知加传媒（深圳）有限公司", "type": "mcn" }
+                    ]
+                  }
+                ]
+              }
+            }
+            """.trimIndent()
+
+        assertEquals(
+            "知加传媒（深圳）有限公司",
+            extractMcnCompanyFromPeopleApi(Json.parseToJsonElement(json)),
+        )
+    }
+
+    @Test
+    fun parsesMcnCompanyFromNestedPeopleApiField() = runTest {
+        val json =
+            """
+            {
+              "id": "user-id",
+              "url_token": "lihuawei",
+              "name": "李明殊",
+              "mcn_user_info": {
+                "company": "知加传媒（深圳）有限公司"
+              }
+            }
+            """.trimIndent()
+
+        assertEquals(
+            "知加传媒（深圳）有限公司",
+            extractMcnCompanyFromPeopleApi(Json.parseToJsonElement(json)),
+        )
+    }
+
+    @Test
+    fun returnsNullWhenPeopleApiHasNoMcnCompany() = runTest {
+        val json =
+            """
+            {
+              "id": "user-id",
+              "url_token": "plain-author",
+              "name": "普通作者",
+              "is_org": false,
+              "badge_v2": {
+                "detail_badges": [],
+                "merged_badges": []
+              }
+            }
+            """.trimIndent()
+
+        assertNull(extractMcnCompanyFromPeopleApi(Json.parseToJsonElement(json)))
+    }
+}

--- a/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/NativeFilterSupport.kt
+++ b/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/NativeFilterSupport.kt
@@ -77,6 +77,28 @@ actual fun rememberBlocklistManager(): BlocklistManager = remember {
 
                 override suspend fun getTopicNameById(topicId: String): String = ""
             },
+            mcnOrganizationDao = object : BlockedMcnOrganizationDao {
+                override suspend fun insertOrganization(organization: BlockedMcnOrganization) = Unit
+
+                override suspend fun deleteOrganizationByName(organizationName: String) = Unit
+
+                override suspend fun getAllOrganizations(): List<BlockedMcnOrganization> = emptyList()
+
+                override suspend fun getOrganizationCount(): Int = 0
+
+                override suspend fun hasOrganizations(): Boolean = false
+
+                override suspend fun isOrganizationBlocked(organizationName: String): Boolean = false
+
+                override suspend fun clearAllOrganizations() = Unit
+            },
+            mcnAuthorCacheDao = object : McnAuthorCacheDao {
+                override suspend fun getByUrlToken(urlToken: String): McnAuthorCache? = null
+
+                override suspend fun insert(cache: McnAuthorCache) = Unit
+
+                override suspend fun clearAll() = Unit
+            },
         ),
     )
 }


### PR DESCRIPTION
# feat: 支持屏蔽 MCN 机构推荐

Resolves #388

## 新增能力

本 PR 只处理 issue #388 中的 MCN 机构屏蔽需求，不混入其他功能。

- 新增 MCN 机构屏蔽规则：用户可以按机构名称添加、删除、清空屏蔽规则。
- 新增作者 MCN 缓存：推荐流过滤时缓存 `authorUrlToken -> mcnCompany` 查询结果，减少重复请求。
- 新增知乎 MCN 机构识别 provider：通过知乎 API 查询作者资料中的 MCN 信息，不解析 HTML 页面。
- 推荐流过滤支持 MCN 机构规则：命中后过滤该推荐内容，并给出 `屏蔽MCN机构：<机构名>` 的屏蔽原因。
- 设置页新增 MCN 相关开关：支持启用/关闭 MCN 机构屏蔽，并支持屏蔽所有有效 MCN 作者。
- 黑名单页新增 `屏蔽MCN` tab：集中管理已屏蔽的 MCN 机构。
- 导入/导出支持 MCN 机构规则，避免用户迁移配置时丢失 MCN 屏蔽项。

## 预期行为

- 用户在推荐卡片现有的 `屏蔽用户` 入口操作时，如果作者能识别出有效 MCN 机构，会弹出 `屏蔽推荐来源`，允许选择：
  - `屏蔽该用户`
  - `屏蔽 MCN 机构`
- 用户在个人主页的 `屏蔽推荐` 入口操作时，如果作者能识别出有效 MCN 机构，也会弹出同样的选择框。
- 用户选择 `屏蔽 MCN 机构` 后，后续推荐流中属于该机构的作者内容会被过滤。
- 作者没有 MCN、没有 `urlToken`、接口查询失败、或返回无效 MCN 值时，保持原有屏蔽用户流程，不误弹 MCN 选择框。
- 当未启用 `屏蔽所有MCN机构用户` 且没有任何 MCN 机构规则时，推荐流过滤不会额外发起 MCN 查询，避免默认状态下引入不必要网络开销。

## UI 一致性人工核查

已在 AVD 环境人工核查 MCN 相关入口和弹窗：

- 测试设备：`Medium_Phone_2` / `emulator-5554`
- 测试包名：`com.github.zly2006.zhplus.lite`
- 推荐卡片继续复用现有 `屏蔽用户` 菜单入口，没有新增突兀入口。
- MCN 作者触发的选择弹窗标题、按钮、间距和现有 Compose UI 风格保持一致。
- 用户主页 `屏蔽推荐` 入口与推荐卡片入口交互一致。
- 普通非 MCN 用户不会误弹 `屏蔽推荐来源`，会回到原有用户屏蔽确认流程。
- 设置页和黑名单页新增项与现有列表、tab、按钮样式保持一致。

## 屏蔽有效性检验

已通过确定性测试数据验证 MCN 识别和过滤行为真实生效，而不是依赖首页随机刷到内容：

- 构造真实知乎作者 token 与机构名映射，覆盖多个 MCN 机构。
- 验证推荐流过滤 pipeline 会按作者 `authorUrlToken -> mcnCompany` 命中机构规则。
- 验证命中后的屏蔽原因包含 `屏蔽MCN机构：<机构名>`。
- 验证普通用户、无效 MCN 值、接口失败等场景不会误屏蔽。
- 验证空 MCN 规则时不会触发 provider 查询，避免影响默认推荐流性能。
- 验证 provider 两个 API 都失败时不会把失败结果缓存成“无 MCN”，避免临时网络或登录问题导致后续永久漏屏蔽。

覆盖的真实机构包括：

- `知加传媒（深圳）有限公司`
- `杭州亚序科技有限公司`
- `杭州含章文化传播有限公司`
- `上海友芝士文化传播有限公司`
- `深圳知外文化传播有限公司`
- `极合（北京）科技有限公司`

## 自动化验证

已运行完整验证命令：

```powershell
.\gradlew.bat :shared:jvmTest --tests "com.github.zly2006.zhihu.viewmodel.filter.FeedContentFilterPipelineTest" --tests "com.github.zly2006.zhihu.viewmodel.filter.ZhihuMcnCompanyProviderTest" --tests "com.github.zly2006.zhihu.viewmodel.filter.FeedFilterSettingsTest" --tests "com.github.zly2006.zhihu.shared.filter.BlocklistBackupTest" :shared:compileKotlinJvm :shared:compileAndroidMain ktlintFormat assembleLiteDebug --no-daemon --max-workers=2 --no-configuration-cache
```

验证项包括：

- JVM 过滤 pipeline 测试通过。
- MCN provider 解析测试通过。
- MCN 设置读取测试通过。
- 黑名单导入/导出序列化测试通过。
- Kotlin JVM 编译通过。
- Android main 编译通过。
- `ktlintFormat` 已执行。
- `assembleLiteDebug` 构建通过。
- `git diff --cached --check` 无 whitespace error。

## 数据库与导入导出

- `ContentFilterDatabase` 升级到 version 7。
- 新增 `blocked_mcn_organizations` 表保存 MCN 机构屏蔽规则。
- 新增 `mcn_author_cache` 表保存作者 MCN 查询缓存。
- 新增 6 -> 7 migration。
- backup JSON 新增 `mcnOrganizations` 字段，用于导出和恢复 MCN 机构屏蔽规则。

## 已知限制

- MCN 识别依赖知乎作者资料 API 返回的 MCN 字段或 badge 信息。
- 如果接口临时失败，本次推荐内容会保留，不会写入空缓存；后续请求成功后再按规则过滤。
- 选择 `屏蔽 MCN 机构` 只添加机构规则，不额外添加该具体用户到用户屏蔽列表，避免产生超出用户预期的双重规则。
