### PR TITLE
feat: 为MCN用户添加标识

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/shared/data/ZhihuDataCore.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/shared/data/ZhihuDataCore.kt
@@ -25,6 +25,7 @@ data class FeedDisplayItem(
     val navDestinationJson: String? = null,
     val avatarSrc: String? = null,
     val authorName: String? = null,
+    val authorUrlToken: String? = null,
     val authorBadgeV2: DataHolder.BadgeV2? = null,
     val isFiltered: Boolean = false,
     val content: String? = null,
@@ -95,6 +96,7 @@ fun Feed.toDisplayItem(
         details = listOfNotNull(target.detailsText, actionText).joinToString(" · "),
         avatarSrc = target.author?.avatarUrl,
         authorName = target.author?.name,
+        authorUrlToken = target.author?.urlToken,
         authorBadgeV2 = target.author?.badgeV2,
         feed = this,
     )
@@ -127,6 +129,7 @@ private fun Feed.toTargetDisplayItem(
             details = listOfNotNull(target.detailsText, actionText).joinToString(" · "),
             avatarSrc = target.author?.avatarUrl,
             authorName = target.author?.name,
+            authorUrlToken = target.author?.urlToken,
             authorBadgeV2 = target.author?.badgeV2,
             feed = this,
             segmentInfos = when (target) {
@@ -147,6 +150,7 @@ private fun Feed.toTargetDisplayItem(
             details = target.detailsText,
             avatarSrc = target.author.avatarUrl,
             authorName = target.author.name,
+            authorUrlToken = target.author.urlToken,
             authorBadgeV2 = target.author.badgeV2,
             feed = this,
         )

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
@@ -131,6 +131,7 @@ import com.github.zly2006.zhihu.theme.ThemeManager
 import com.github.zly2006.zhihu.ui.components.AnswerHorizontalOverscroll
 import com.github.zly2006.zhihu.ui.components.AnswerVerticalOverscroll
 import com.github.zly2006.zhihu.ui.components.AuthorBadge
+import com.github.zly2006.zhihu.ui.components.McnBadge
 import com.github.zly2006.zhihu.ui.components.CollectionDialogComponent
 import com.github.zly2006.zhihu.ui.components.CommentScreenComponent
 import com.github.zly2006.zhihu.ui.components.DraggableRefreshButton
@@ -144,6 +145,9 @@ import com.github.zly2006.zhihu.viewmodel.ArticleViewModel
 import com.github.zly2006.zhihu.viewmodel.ArticleViewModel.CachedAnswerContent
 import com.github.zly2006.zhihu.viewmodel.formatArticleDateTime
 import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
+import com.github.zly2006.zhihu.viewmodel.filter.ZhihuMcnCompanyProvider
+import com.github.zly2006.zhihu.viewmodel.filter.normalizeMcnCompany
+import com.github.zly2006.zhihu.viewmodel.filter.rememberBlocklistManager
 import com.materialkolor.ktx.harmonize
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -562,6 +566,12 @@ fun ArticleScreen(
     val navigator = LocalNavigator.current
     val articleScreenRuntime = rememberArticleScreenRuntime()
     val environment = rememberPaginationEnvironment(allowGuestAccess = false)
+    val blocklistManager = rememberBlocklistManager()
+    val mcnProvider = remember(environment) {
+        ZhihuMcnCompanyProvider(environment.httpClient()) { request ->
+            environment.configureSignedRequest(request)
+        }
+    }
     val articleHost = articleScreenRuntime.articleHost
     val previewPreloader = articleScreenRuntime.previewPreloader
     val backStackEntry by articleHost?.articleNavController?.currentBackStackEntryAsState()
@@ -593,6 +603,7 @@ fun ArticleScreen(
     var showSummaryDialog by remember { mutableStateOf(false) }
     var showExportDialog by remember { mutableStateOf(false) }
     var showDoubleTapActionDialog by remember { mutableStateOf(false) }
+    var authorMcnCompany by remember(viewModel.authorUrlToken) { mutableStateOf<String?>(null) }
     val coroutineScope = rememberCoroutineScope()
     val hapticFeedback = LocalHapticFeedback.current
 
@@ -616,6 +627,23 @@ fun ArticleScreen(
 
     LaunchedEffect(Unit) {
         readHistoryRecorder.addReadHistory(article)
+    }
+    LaunchedEffect(viewModel.authorUrlToken, viewModel.authorName) {
+        val urlToken = viewModel.authorUrlToken
+        if (urlToken.isBlank()) {
+            authorMcnCompany = null
+            return@LaunchedEffect
+        }
+        blocklistManager.getCachedMcnAuthor(urlToken)?.mcnCompany.normalizeMcnCompany()?.let {
+            authorMcnCompany = it
+            return@LaunchedEffect
+        }
+        runCatching {
+            mcnProvider.getMcnCompany(urlToken).normalizeMcnCompany()
+        }.onSuccess { resolvedMcn ->
+            blocklistManager.cacheMcnCompany(urlToken, viewModel.authorName, resolvedMcn)
+            authorMcnCompany = resolvedMcn
+        }
     }
 
     fun upVoteFromDoubleTap() {
@@ -1091,6 +1119,11 @@ fun ArticleScreen(
                                                 badge = viewModel.authorBadge,
                                                 compact = !expanded,
                                             )
+                                        }
+                                        val resolvedAuthorMcnCompany = authorMcnCompany
+                                        if (resolvedAuthorMcnCompany != null) {
+                                            Spacer(modifier = Modifier.width(4.dp))
+                                            McnBadge(mcnCompany = resolvedAuthorMcnCompany)
                                         }
                                     }
                                     if (viewModel.authorBio.isNotEmpty() && expanded) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PeopleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PeopleScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -89,6 +90,7 @@ import com.github.zly2006.zhihu.ui.PeopleProfileUiState
 import com.github.zly2006.zhihu.ui.PeopleSortedListUiState
 import com.github.zly2006.zhihu.ui.components.AuthorBadge
 import com.github.zly2006.zhihu.ui.components.FeedCard
+import com.github.zly2006.zhihu.ui.components.McnBadge
 import com.github.zly2006.zhihu.ui.components.PaginatedList
 import com.github.zly2006.zhihu.ui.components.ProgressIndicatorFooter
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
@@ -318,6 +320,7 @@ class PersonViewModel(
     var headline by mutableStateOf("")
     var officialBadge by mutableStateOf<OfficialBadge?>(null)
     var officialBadgeDetails by mutableStateOf<List<OfficialBadge>>(emptyList())
+    var mcnCompany by mutableStateOf<String?>(null)
     var followerCount by mutableIntStateOf(0)
     var followingCount by mutableIntStateOf(0)
     var answerCount by mutableIntStateOf(0)
@@ -436,6 +439,7 @@ class PersonViewModel(
         this.headline = profile.headline
         this.officialBadge = profile.officialBadge
         this.officialBadgeDetails = profile.officialBadgeDetails
+        this.mcnCompany = profile.mcnCompany
         this.followerCount = profile.followerCount
         this.followingCount = profile.followingCount
         this.answerCount = profile.answerCount
@@ -497,6 +501,7 @@ const val PEOPLE_SCREEN_ANSWER_SORT_TIME_TAG = "people_screen_answer_sort_create
 const val PEOPLE_SCREEN_ARTICLE_SORT_HOT_TAG = "people_screen_article_sort_voteups"
 const val PEOPLE_SCREEN_ARTICLE_SORT_TIME_TAG = "people_screen_article_sort_created"
 const val PEOPLE_SCREEN_OFFICIAL_BADGE_TAG = "people_screen_official_badge"
+const val PEOPLE_SCREEN_MCN_BADGE_TAG = "people_screen_mcn_badge"
 
 fun peopleScreenTabTag(index: Int): String = "people_screen_tab_$index"
 
@@ -572,6 +577,7 @@ private fun PersonViewModel.toUiState(): PeopleScreenUiState = PeopleScreenUiSta
         headline = headline,
         officialBadge = officialBadge,
         officialBadgeDetails = officialBadgeDetails,
+        mcnCompany = mcnCompany,
         followerCount = followerCount,
         followingCount = followingCount,
         answerCount = answerCount,
@@ -677,6 +683,17 @@ private fun PeopleScreenContent(
             viewModel.load(paginationEnvironment)
         } catch (e: Exception) {
             userMessages.showShortMessage("加载用户信息失败: ${e.message}")
+        }
+    }
+    LaunchedEffect(person.urlToken, uiState.profile.name, testOverrides) {
+        if (testOverrides != null || person.urlToken.isBlank()) {
+            return@LaunchedEffect
+        }
+        runCatching {
+            mcnCompanyProvider.getMcnCompany(person.urlToken).normalizeMcnCompany()
+        }.onSuccess { resolvedMcn ->
+            blocklistManager.cacheMcnCompany(person.urlToken, uiState.profile.name, resolvedMcn)
+            viewModel.mcnCompany = resolvedMcn
         }
     }
     LaunchedEffect(pagerState.currentPage, testOverrides) {
@@ -1646,6 +1663,14 @@ private fun UserInfoHeader(
                                 .testTag(PEOPLE_SCREEN_OFFICIAL_BADGE_TAG),
                         )
                     }
+                    if (profile.mcnCompany != null) {
+                        McnBadge(
+                            mcnCompany = profile.mcnCompany,
+                            modifier = Modifier
+                                .padding(start = 6.dp)
+                                .testTag(PEOPLE_SCREEN_MCN_BADGE_TAG),
+                        )
+                    }
                 }
                 Text(
                     profile.headline,
@@ -1653,6 +1678,16 @@ private fun UserInfoHeader(
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )
+                if (profile.mcnCompany != null) {
+                    Text(
+                        text = "MCN机构：${profile.mcnCompany}",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = Color(0xFF7A5200),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
                 OfficialBadgeDetails(
                     badges = profile.officialBadgeDetails,
                     modifier = Modifier.padding(top = 6.dp),
@@ -1720,6 +1755,7 @@ data class PeopleProfileUiState(
     val headline: String = "",
     val officialBadge: OfficialBadge? = null,
     val officialBadgeDetails: List<OfficialBadge> = emptyList(),
+    val mcnCompany: String? = null,
     val followerCount: Int = 0,
     val followingCount: Int = 0,
     val answerCount: Int = 0,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
@@ -53,6 +53,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -86,6 +87,10 @@ import com.github.zly2006.zhihu.shared.platform.rememberIsLiteVariant
 import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
 import com.github.zly2006.zhihu.util.parseHtmlTextWithTheme
+import com.github.zly2006.zhihu.viewmodel.filter.ZhihuMcnCompanyProvider
+import com.github.zly2006.zhihu.viewmodel.filter.normalizeMcnCompany
+import com.github.zly2006.zhihu.viewmodel.filter.rememberBlocklistManager
+import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.max
@@ -114,7 +119,15 @@ fun FeedCard(
     val uriHandler = LocalUriHandler.current
     val userMessages = rememberUserMessageSink()
     val settings = rememberSettingsStore()
+    val paginationEnvironment = rememberPaginationEnvironment(allowGuestAccess = false)
+    val blocklistManager = rememberBlocklistManager()
+    val mcnProvider = remember(paginationEnvironment) {
+        ZhihuMcnCompanyProvider(paginationEnvironment.httpClient()) { request ->
+            paginationEnvironment.configureSignedRequest(request)
+        }
+    }
     val isLiteVariant = rememberIsLiteVariant()
+    var mcnCompany by remember(item.authorUrlToken) { mutableStateOf<String?>(null) }
     var offsetX by remember { mutableFloatStateOf(0f) }
     var currentY by remember { mutableFloatStateOf(0f) } // 当前手指Y位置
     var startY by remember { mutableFloatStateOf(0f) } // 开始滑动时的Y位置
@@ -144,6 +157,24 @@ fun FeedCard(
             } else {
                 userMessages.showMessage("暂不支持打开该内容", UserMessageDuration.Short)
             }
+        }
+    }
+
+    LaunchedEffect(item.authorUrlToken, item.authorName) {
+        val urlToken = item.authorUrlToken
+        if (urlToken.isNullOrBlank()) {
+            mcnCompany = null
+            return@LaunchedEffect
+        }
+        blocklistManager.getCachedMcnAuthor(urlToken)?.mcnCompany.normalizeMcnCompany()?.let {
+            mcnCompany = it
+            return@LaunchedEffect
+        }
+        runCatching {
+            mcnProvider.getMcnCompany(urlToken).normalizeMcnCompany()
+        }.onSuccess { resolvedMcn ->
+            blocklistManager.cacheMcnCompany(urlToken, item.authorName, resolvedMcn)
+            mcnCompany = resolvedMcn
         }
     }
 
@@ -186,6 +217,7 @@ fun FeedCard(
             ) {
                 FeedCardContent(
                     item = item,
+                    mcnCompany = mcnCompany,
                     showFeedThumbnail = showFeedThumbnail,
                     thumbnailUrl = thumbnailUrl,
                     showMenu = showMenu,
@@ -274,6 +306,7 @@ fun FeedCard(
                 ) {
                     FeedCardContent(
                         item = item,
+                        mcnCompany = mcnCompany,
                         showFeedThumbnail = showFeedThumbnail,
                         thumbnailUrl = thumbnailUrl,
                         showMenu = showMenu,
@@ -446,6 +479,7 @@ private fun FeedCardMenuBox(
 @Composable
 private fun FeedCardContent(
     item: FeedDisplayItem,
+    mcnCompany: String?,
     showFeedThumbnail: Boolean,
     thumbnailUrl: String?,
     showMenu: Boolean,
@@ -536,6 +570,11 @@ private fun FeedCardContent(
                                 Spacer(Modifier.width(4.dp))
                                 AuthorBadge(authorBadge, compact = true)
                             }
+                            val resolvedMcnCompany = mcnCompany
+                            if (resolvedMcnCompany != null) {
+                                Spacer(Modifier.width(4.dp))
+                                McnBadge(mcnCompany = resolvedMcnCompany)
+                            }
                         }
                         Spacer(Modifier.width(6.dp))
                     }
@@ -594,6 +633,11 @@ private fun FeedCardContent(
                 if (authorBadge?.isUsefulInList == true) {
                     Spacer(Modifier.width(4.dp))
                     AuthorBadge(authorBadge, compact = true)
+                }
+                val resolvedMcnCompany = mcnCompany
+                if (resolvedMcnCompany != null) {
+                    Spacer(Modifier.width(4.dp))
+                    McnBadge(mcnCompany = resolvedMcnCompany)
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/McnBadge.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/McnBadge.kt
@@ -1,0 +1,66 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for Android.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun McnBadge(
+    mcnCompany: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .padding(horizontal = 2.dp, vertical = 3.dp)
+            .border(
+                width = 1.dp,
+                color = Color(0xFFD6A11D),
+                shape = RoundedCornerShape(3.dp),
+            )
+            .background(
+                color = Color(0xFFFFF4D6),
+                shape = RoundedCornerShape(3.dp),
+            )
+            .padding(horizontal = 4.dp, vertical = 1.dp)
+            .semantics { contentDescription = "MCN机构：$mcnCompany" },
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "MCN",
+            color = Color(0xFF7A5200),
+            fontSize = 9.sp,
+            lineHeight = 9.sp,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+        )
+    }
+}


### PR DESCRIPTION
# feat: 为MCN用户添加标识

Resolves #396

## 新增能力

- 在个人主页作者信息区域显示 MCN 小徽章，并直接展示 `MCN机构：...`。
- 在回答/文章详情页作者名后显示同款 MCN 小徽章。
- 在 Feed Card 作者名后显示同款 MCN 小徽章。
- 新增可复用的 `McnBadge` 组件，统一 MCN 标识的视觉风格。

## 预期行为

- 打开 MCN 用户个人主页时，作者名后显示 `MCN` 徽章，并在头部附近直接显示机构名。
- 浏览回答/文章详情页时，作者名后显示 `MCN` 徽章。
- 浏览推荐流等 Feed Card 时，MCN 作者的人名后显示 `MCN` 徽章。
- 非 MCN 用户、无 `urlToken`、接口失败或返回无效值时，不显示该徽章。

## 实现说明

- 复用已有的 `ZhihuMcnCompanyProvider`、`normalizeMcnCompany()` 和 MCN 作者缓存逻辑。
- `FeedDisplayItem` 新增 `authorUrlToken` 字段，用于在 feed 卡片作者行解析 MCN。
- 个人主页、回答页、Feed Card 都优先读取本地缓存，缓存缺失时再发起 MCN 查询。
- 查询成功后写回 MCN 作者缓存，减少重复请求。

## UI 设计

- MCN 标识使用小金框徽章样式，放在作者名后面，尽量贴近知乎现有徽章系统的视觉密度。
- 徽章文案固定为 `MCN`，避免机构名直接挤占作者行空间。
- 个人主页额外在头部信息区直接展示 `MCN机构：...`，不依赖点击交互。

## 自动化验证

已运行：

```powershell
.\gradlew.bat :shared:compileKotlinJvm :shared:compileAndroidMain assembleLiteDebug --no-daemon --max-workers=2 --no-configuration-cache
```

结果：`BUILD SUCCESSFUL`

## 人工验证

- 已在 `emulator-5554` / `com.github.zly2006.zhplus.lite` 安装并打开验证。
- 已验证已知 MCN 用户 `lihuawei` 个人主页显示 MCN 徽章和机构名。
- 该版本也已接入回答页和 Feed Card 的作者行显示。

## 影响范围

- `shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/McnBadge.kt`
- `shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PeopleScreen.kt`
- `shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt`
- `shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt`
- `shared/src/commonMain/kotlin/com/github/zly2006/zhihu/shared/data/ZhihuDataCore.kt`
