### PR TITLE
fix: 保持评论区返回状态

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
@@ -92,6 +92,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -587,7 +588,7 @@ fun ArticleScreen(
     val density = LocalDensity.current
     val scrollDeltaThreshold = with(density) { ScrollThresholdDp.toPx() }
     var topBarHeight by remember { mutableIntStateOf(0) }
-    var showComments by remember { mutableStateOf(false) }
+    var showComments by rememberSaveable(article.type, article.id) { mutableStateOf(false) }
     var showCollectionDialog by remember { mutableStateOf(false) }
     var showActionsMenu by remember { mutableStateOf(false) }
     var showSummaryDialog by remember { mutableStateOf(false) }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CommentScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CommentScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
@@ -416,6 +417,7 @@ fun CommentScreen(
     content: () -> NavDestination,
     activeCommentItem: CommentModel? = null,
     onChildCommentClick: (CommentModel) -> Unit,
+    listState: LazyListState = rememberLazyListState(),
     testOverrides: CommentScreenTestOverrides? = null,
 ) {
     val paginationEnvironment = rememberPaginationEnvironment(allowGuestAccess = false)
@@ -445,8 +447,6 @@ fun CommentScreen(
     val commentInputBarColor = MaterialTheme.colorScheme.surfaceContainer
     val actionChipColor = MaterialTheme.colorScheme.surfaceContainerHigh
     val actionChipIconColor = MaterialTheme.colorScheme.onSurfaceVariant
-
-    val listState = rememberLazyListState()
 
     // 监控滚动位置以实现加载更多
     val loadMore = remember {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PinScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PinScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -197,7 +198,7 @@ fun PinScreen(
     }
 
     var showShareDialog by remember { mutableStateOf(false) }
-    var showComments by remember { mutableStateOf(false) }
+    var showComments by rememberSaveable(pin.id) { mutableStateOf(false) }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/QuestionScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/QuestionScreen.kt
@@ -179,7 +179,7 @@ fun QuestionScreen(
         mutableIntStateOf(initialUiState.followerCount)
     }
     var title by remember(question.questionId, initialTitle) { mutableStateOf(initialTitle) }
-    var showComments by remember { mutableStateOf(false) }
+    var showComments by rememberSaveable(question.questionId) { mutableStateOf(false) }
     var isFollowing by remember(question.questionId, initialUiState.isFollowing) {
         mutableStateOf(initialUiState.isFollowing)
     }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CommentScreenComponent.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CommentScreenComponent.kt
@@ -20,6 +20,7 @@ package com.github.zly2006.zhihu.ui.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheetProperties
@@ -27,15 +28,22 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.github.zly2006.zhihu.navigation.Article
+import com.github.zly2006.zhihu.navigation.CommentHolder
 import com.github.zly2006.zhihu.navigation.NavDestination
+import com.github.zly2006.zhihu.navigation.Pin
+import com.github.zly2006.zhihu.navigation.Question
+import com.github.zly2006.zhihu.navigation.SegmentCommentHolder
 import com.github.zly2006.zhihu.shared.viewmodel.CommentItem
 import com.github.zly2006.zhihu.theme.Typography
 import com.github.zly2006.zhihu.ui.CommentScreen
@@ -48,6 +56,15 @@ fun CommentScreenComponent(
     content: NavDestination,
 ) {
     var activeChildComment by remember { mutableStateOf<CommentItem?>(null) }
+    val contentStateKey = commentContentStateKey(content)
+    var rootListResetToken by rememberSaveable(contentStateKey) { mutableIntStateOf(0) }
+    val rootListState = rememberSaveable(
+        contentStateKey,
+        rootListResetToken,
+        saver = LazyListState.Saver,
+    ) {
+        LazyListState()
+    }
     val rootSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val childSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val childTarget = activeChildComment?.clickTarget
@@ -69,9 +86,15 @@ fun CommentScreenComponent(
         }
     }
 
+    fun dismissRootComments() {
+        activeChildComment = null
+        rootListResetToken += 1
+        onDismiss()
+    }
+
     if (showComments) {
         MyModalBottomSheet(
-            onDismissRequest = onDismiss,
+            onDismissRequest = { dismissRootComments() },
             sheetState = rootSheetState,
             containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
             properties = ModalBottomSheetProperties(
@@ -83,6 +106,7 @@ fun CommentScreenComponent(
             CommentScreen(
                 content = { content },
                 onChildCommentClick = { activeChildComment = it },
+                listState = rootListState,
             )
         }
     }
@@ -105,4 +129,13 @@ fun CommentScreenComponent(
             )
         }
     }
+}
+
+private fun commentContentStateKey(content: NavDestination): String = when (content) {
+    is Article -> "article:${content.type}:${content.id}"
+    is Question -> "question:${content.questionId}"
+    is Pin -> "pin:${content.id}"
+    is CommentHolder -> "comment:${commentContentStateKey(content.article)}:${content.commentId}"
+    is SegmentCommentHolder -> "segment:${content.contentType}:${content.contentId}:${content.segmentId}"
+    else -> content.toString()
 }


### PR DESCRIPTION
## 变更说明

- 将回答、问题、想法页面的评论弹窗开关改为按内容 ID 保存的 `rememberSaveable` 状态
- 将根评论列表的 `LazyListState` 提升到评论弹层组件，并按内容身份保存滚动位置
- 从评论区点击用户进入个人主页后，返回时恢复评论弹窗和原评论列表位置，而不是回到正文页或评论区顶部
- 关闭评论弹窗后会重置根评论列表状态，下次主动打开仍从顶部开始

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `./gradlew :app:compileLiteDebugAndroidTestKotlin`
- AVD `Medium_Phone_2` 安装 lite 包并验证：回答页打开评论区 -> 滚动到“高兴/陈家/不忘初心/流星的泪珠”附近 -> 点击“不忘初心”进入个人主页 -> 系统返回后仍停留在同一评论列表位置
- AVD 验证：再次按返回关闭评论弹窗 -> 重新打开评论 -> 评论列表回到顶部首项“燃烧我的卡路里”

Resolves #394