### PR TITLE
fix: 缩小下一个回答按钮

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
@@ -20,8 +20,9 @@ package com.github.zly2006.zhihu.ui
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -1603,26 +1604,35 @@ fun ArticleScreen(
         // Keep the skip button above both question and answer regions.
         if (article.type == ArticleType.Answer && buttonSkipAnswer) {
             val showSkipButton = !autoHideSkipAnswerButton || isScrollingUp || scrollState.value == 0
-            val skipButtonAlpha by animateFloatAsState(
-                targetValue = if (showSkipButton) 1f else 0f,
-                animationSpec = tween(200),
-                label = "skipButtonAlpha",
-            )
-            DraggableRefreshButton(
-                modifier = Modifier.graphicsLayer { alpha = skipButtonAlpha },
-                onClick = {
-                    if (showSkipButton) {
-                        navigatingToNextAnswer = true
-                        navigateToNext()
-                        navigatingToNextAnswer = false
-                    }
-                },
-                preferenceName = "buttonSkipAnswer",
+            AnimatedVisibility(
+                visible = showSkipButton,
+                enter = fadeIn(animationSpec = tween(200)),
+                exit = fadeOut(animationSpec = tween(200)),
             ) {
-                if (navigatingToNextAnswer) {
-                    CircularProgressIndicator(modifier = Modifier.size(30.dp))
-                } else {
-                    Icon(Icons.Filled.SkipNext, contentDescription = "下一个回答")
+                DraggableRefreshButton(
+                    modifier = Modifier.graphicsLayer { alpha = 0.82f },
+                    onClick = {
+                        if (showSkipButton) {
+                            navigatingToNextAnswer = true
+                            navigateToNext()
+                            navigatingToNextAnswer = false
+                        }
+                    },
+                    preferenceName = "buttonSkipAnswer",
+                    buttonSize = 40.dp,
+                ) {
+                    if (navigatingToNextAnswer) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(22.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        Icon(
+                            Icons.Filled.SkipNext,
+                            contentDescription = "下一个回答",
+                            modifier = Modifier.size(22.dp),
+                        )
+                    }
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/DraggableRefreshButton.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/DraggableRefreshButton.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -37,6 +38,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.github.zly2006.zhihu.shared.platform.rememberScreenSizeDp
@@ -47,6 +49,7 @@ import kotlin.math.roundToInt
 fun DraggableRefreshButton(
     modifier: Modifier = Modifier,
     preferenceName: String = "fabRefresh",
+    buttonSize: Dp = 56.dp,
     onClick: () -> Unit,
     content: @Composable () -> Unit = {
         Icon(Icons.Default.Refresh, contentDescription = "刷新")
@@ -62,7 +65,8 @@ fun DraggableRefreshButton(
 
     fun adjustFabPosition() {
         with(density) {
-            offsetX = offsetX.coerceIn(0f, screenSize.width.dp.toPx() - 56.dp.toPx())
+            val maxOffsetX = (screenSize.width.dp.toPx() - buttonSize.toPx()).coerceAtLeast(0f)
+            offsetX = offsetX.coerceIn(0f, maxOffsetX)
             offsetY = offsetY.coerceIn(0f, screenSize.height.dp.toPx() - 250.dp.toPx())
         }
     }
@@ -81,42 +85,54 @@ fun DraggableRefreshButton(
     )
     val hapticFeedback = LocalHapticFeedback.current
 
-    FloatingActionButton(
-        onClick = onClick,
-        shape = CircleShape,
-        modifier = modifier
-            .offset { IntOffset(animatedOffsetX.roundToInt(), animatedOffsetY.roundToInt()) }
-            .pointerInput(Unit) {
-                detectDragGestures(
-                    onDragStart = {
-                        pressing = true
-                        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                    },
-                    onDragEnd = {
-                        pressing = false
+    val draggableModifier = modifier
+        .offset { IntOffset(animatedOffsetX.roundToInt(), animatedOffsetY.roundToInt()) }
+        .pointerInput(buttonSize) {
+            detectDragGestures(
+                onDragStart = {
+                    pressing = true
+                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                },
+                onDragEnd = {
+                    pressing = false
+                    adjustFabPosition()
+                    with(density) {
+                        val screenWidth = screenSize.width.dp.toPx()
+                        val maxOffsetX = (screenWidth - buttonSize.toPx()).coerceAtLeast(0f)
+                        offsetX =
+                            if (offsetX < screenWidth / 2) {
+                                0f
+                            } else {
+                                maxOffsetX
+                            }
+                    }
+                    settings.putFloat("$preferenceName-x", offsetX)
+                    settings.putFloat("$preferenceName-y", offsetY)
+                },
+                onDrag = { change, dragAmount ->
+                    change.consume()
+                    if (pressing) {
+                        offsetX += dragAmount.x
+                        offsetY += dragAmount.y
                         adjustFabPosition()
-                        with(density) {
-                            val screenWidth = screenSize.width.dp.toPx()
-                            offsetX =
-                                if (offsetX < screenWidth / 2) {
-                                    0f
-                                } else {
-                                    screenWidth - 56.dp.toPx()
-                                }
-                        }
-                        settings.putFloat("$preferenceName-x", offsetX)
-                        settings.putFloat("$preferenceName-y", offsetY)
-                    },
-                    onDrag = { change, dragAmount ->
-                        change.consume()
-                        if (pressing) {
-                            offsetX += dragAmount.x
-                            offsetY += dragAmount.y
-                            adjustFabPosition()
-                        }
-                    },
-                )
-            },
-        content = content,
-    )
+                    }
+                },
+            )
+        }
+
+    if (buttonSize < 56.dp) {
+        SmallFloatingActionButton(
+            onClick = onClick,
+            shape = CircleShape,
+            modifier = draggableModifier,
+            content = content,
+        )
+    } else {
+        FloatingActionButton(
+            onClick = onClick,
+            shape = CircleShape,
+            modifier = draggableModifier,
+            content = content,
+        )
+    }
 }


### PR DESCRIPTION
## 背景

#370 已由维护者确认：长按拖拽已经支持，滚动时消失可通过设置关闭；真实剩余诉求主要是「下一个回答」按钮过大，以及希望减少遮挡、半透明显示。

本 PR 不写 `Resolves #370`，因为 issue 当前已关闭；改动覆盖 #370 剩余的按钮缩小/半透明诉求。

## 修改内容

- 将回答页「下一个回答」悬浮按钮改为 40dp 小按钮，图标和加载圈同步缩小到 22dp。
- 按钮可见时使用 0.82 alpha 半透明，减少对正文/问题区的遮挡。
- 保留原有 `buttonSkipAnswer` 位置存储，拖动位置仍按同一 preference 生效。
- 自动隐藏时使用 200ms 淡入淡出，退出动画结束后从命中区域移除，避免透明按钮拦截底层正文或回答切换手势。
- 通用 `DraggableRefreshButton` 新增默认值不变的 `buttonSize` 参数，其他页面仍保持原 56dp 行为。

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `./gradlew ktlintCheck`
- `./gradlew compileLiteDebugAndroidTestKotlin`
- `git diff --check`
- `$ui-voyager` 非设备复检：发现隐藏态透明按钮仍可能拦截触控，已修复并写回 memory 为 fixed。
- `$picky-user` 非设备复检：pass，未发现新的有效意见。

## 说明

- 按用户要求，本次未使用 AVD、未启动模拟器、未执行设备 UI 测试。
- 设备侧边界（设置关闭按钮、自动隐藏开关、拖动位置、问题区/回答区覆盖关系）本轮通过代码结构、编译和非设备复检覆盖；若需要真实触控/截图验证，需要后续允许 AVD。
