### PR TITLE
fix: 修复评论弹层预测返回层级

### DIFF
--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/shared/platform/AndroidPlatformCapabilities.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/shared/platform/AndroidPlatformCapabilities.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.Intent
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.PredictiveBackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalConfiguration
@@ -32,6 +33,7 @@ import com.github.zly2006.zhihu.ui.PREFERENCE_NAME
 import com.github.zly2006.zhihu.ui.components.OpenImageDialog
 import com.github.zly2006.zhihu.util.clipboardManager
 import com.github.zly2006.zhihu.util.luoTianYiUrlLauncher
+import kotlinx.coroutines.CancellationException
 
 private const val WEBVIEW_ACTIVITY_CLASS = "com.github.zly2006.zhihu.WebviewActivity"
 
@@ -153,3 +155,21 @@ actual fun PlatformBackHandler(
     enabled: Boolean,
     onBack: () -> Unit,
 ) = BackHandler(enabled = enabled, onBack = onBack)
+
+@Composable
+actual fun PlatformPredictiveBackHandler(
+    enabled: Boolean,
+    onProgress: (Float) -> Unit,
+    onCancel: () -> Unit,
+    onBack: () -> Unit,
+) = PredictiveBackHandler(enabled = enabled) { progress ->
+    try {
+        progress.collect { backEvent ->
+            onProgress(backEvent.progress)
+        }
+        onBack()
+    } catch (e: CancellationException) {
+        onCancel()
+        throw e
+    }
+}

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/shared/platform/PlatformCapabilities.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/shared/platform/PlatformCapabilities.kt
@@ -95,4 +95,12 @@ expect fun PlatformBackHandler(
 )
 
 @Composable
+expect fun PlatformPredictiveBackHandler(
+    enabled: Boolean,
+    onProgress: (Float) -> Unit,
+    onCancel: () -> Unit,
+    onBack: () -> Unit,
+)
+
+@Composable
 expect fun rememberIsLiteVariant(): Boolean

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CommentScreenComponent.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CommentScreenComponent.kt
@@ -102,6 +102,7 @@ fun CommentScreenComponent(
                 shouldDismissOnClickOutside = true,
             ),
             dragHandle = { DragHandleTitle("评论") },
+            usePlatformWindow = false,
         ) {
             CommentScreen(
                 content = { content },
@@ -121,6 +122,7 @@ fun CommentScreenComponent(
                 shouldDismissOnClickOutside = true,
             ),
             dragHandle = { DragHandleTitle("回复") },
+            usePlatformWindow = false,
         ) {
             CommentScreen(
                 content = { childTarget },

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/MyModalBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/MyModalBottomSheet.kt
@@ -85,6 +85,7 @@ import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
+import com.github.zly2006.zhihu.shared.platform.PlatformPredictiveBackHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlin.math.max
@@ -106,6 +107,7 @@ fun MyModalBottomSheet(
     dragHandle: @Composable (() -> Unit)? = { BottomSheetDefaults.DragHandle() },
     contentWindowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
     properties: ModalBottomSheetProperties = ModalBottomSheetProperties(),
+    usePlatformWindow: Boolean = true,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val scope = rememberCoroutineScope()
@@ -128,15 +130,8 @@ fun MyModalBottomSheet(
     }
     val predictiveBackProgress = remember { Animatable(initialValue = 0f) }
 
-    ModalBottomSheetDialog(
-        properties = properties,
-        contentColor = contentColor,
-        onDismissRequest = {
-            // 修复返回键需要按两次才关闭的问题。
-            scope.launch { sheetState.hide() }.invokeOnCompletion { onDismissRequest() }
-        },
-        predictiveBackProgress = predictiveBackProgress,
-    ) {
+    @Composable
+    fun SheetContent() {
         Box(modifier = Modifier.fillMaxSize().imePadding().semantics { isTraversalGroup = true }) {
             MyBottomSheetScrim(
                 color = scrimColor,
@@ -162,6 +157,32 @@ fun MyModalBottomSheet(
                 content = content,
             )
         }
+    }
+
+    if (usePlatformWindow) {
+        ModalBottomSheetDialog(
+            properties = properties,
+            contentColor = contentColor,
+            onDismissRequest = {
+                // 修复返回键需要按两次才关闭的问题。
+                scope.launch { sheetState.hide() }.invokeOnCompletion { onDismissRequest() }
+            },
+            predictiveBackProgress = predictiveBackProgress,
+        ) {
+            SheetContent()
+        }
+    } else {
+        PlatformPredictiveBackHandler(
+            enabled = properties.shouldDismissOnBackPress && sheetState.targetValue != Hidden,
+            onProgress = { progress ->
+                scope.launch { predictiveBackProgress.snapTo(progress) }
+            },
+            onCancel = {
+                scope.launch { predictiveBackProgress.animateTo(0f) }
+            },
+            onBack = animateToDismiss,
+        )
+        SheetContent()
     }
     if (sheetState.hasExpandedState) {
         LaunchedEffect(sheetState) { sheetState.show() }

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/shared/platform/JvmPlatformCapabilities.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/shared/platform/JvmPlatformCapabilities.kt
@@ -160,4 +160,12 @@ actual fun PlatformBackHandler(
 ) = Unit // TODO: desktop back handler
 
 @Composable
+actual fun PlatformPredictiveBackHandler(
+    enabled: Boolean,
+    onProgress: (Float) -> Unit,
+    onCancel: () -> Unit,
+    onBack: () -> Unit,
+) = PlatformBackHandler(enabled = enabled, onBack = onBack)
+
+@Composable
 actual fun rememberIsLiteVariant(): Boolean = false

--- a/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/shared/platform/NativePlatformCapabilities.kt
+++ b/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/shared/platform/NativePlatformCapabilities.kt
@@ -54,6 +54,14 @@ actual fun rememberPlainTextClipboard(): (label: String, text: String) -> Unit =
 actual fun PlatformBackHandler(enabled: Boolean, onBack: () -> Unit) = Unit // TODO: iOS 返回手势处理
 
 @Composable
+actual fun PlatformPredictiveBackHandler(
+    enabled: Boolean,
+    onProgress: (Float) -> Unit,
+    onCancel: () -> Unit,
+    onBack: () -> Unit,
+) = PlatformBackHandler(enabled = enabled, onBack = onBack)
+
+@Composable
 actual fun rememberScreenSizeDp(): ScreenSizeDp = ScreenSizeDp(width = 0f, height = 0f) // TODO: iOS 屏幕尺寸获取
 
 @Composable


### PR DESCRIPTION
## 变更说明

- 将评论根弹层和子评论弹层改为在当前 Activity Compose 树内渲染，避免评论弹层使用独立 Dialog window 干扰个人页的预测性返回。
- 为同窗口弹层补充预测性返回进度处理，复用现有 bottom sheet 缩放效果。
- 保留 `MyModalBottomSheet` 默认平台窗口行为，只有评论弹层显式关闭平台 window。

## 最终效果截图

本地 AVD 截图已留存：`/tmp/person_over_inline_comments_final.png`

## 验证

按用户要求跳过测试。
