### PR TITLE
fix: 修复文章 HTML 导出未保存文件

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleExportEnvironmentInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleExportEnvironmentInstrumentedTest.kt
@@ -20,15 +20,19 @@ package com.github.zly2006.zhihu
 import android.content.ContentResolver
 import android.content.Context
 import android.graphics.Bitmap
+import android.os.Build
+import android.os.Environment
 import android.provider.MediaStore
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.zly2006.zhihu.shared.data.DataHolder
 import com.github.zly2006.zhihu.viewmodel.SharedAndroidPaginationEnvironment
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
 
 @RunWith(AndroidJUnit4::class)
 class ArticleExportEnvironmentInstrumentedTest {
@@ -55,6 +59,29 @@ class ArticleExportEnvironmentInstrumentedTest {
             bitmap.recycle()
             context.deleteSavedImage(displayName)
         }
+
+        val htmlDisplayName = "zhihu-html-export-regression-${System.currentTimeMillis()}.html"
+        try {
+            val savedLocation = environment.saveHtmlToDownloads(htmlDisplayName, "<html><body>正文</body></html>")
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                assertEquals("Zhihu++/$htmlDisplayName", savedLocation)
+                assertTrue(context.savedDownloadExists(htmlDisplayName))
+            } else {
+                assertEquals(
+                    File(
+                        File(
+                            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+                            "Zhihu++",
+                        ),
+                        htmlDisplayName,
+                    ).absolutePath,
+                    savedLocation,
+                )
+                assertTrue(File(savedLocation).exists())
+            }
+        } finally {
+            context.deleteSavedDownload(htmlDisplayName)
+        }
     }
 
     private fun Context.savedImageExists(displayName: String): Boolean =
@@ -68,6 +95,37 @@ class ArticleExportEnvironmentInstrumentedTest {
         )
     }
 
+    private fun Context.savedDownloadExists(displayName: String): Boolean =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            contentResolver.querySavedDownload(displayName) { count > 0 } == true
+        } else {
+            File(
+                File(
+                    Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+                    "Zhihu++",
+                ),
+                displayName,
+            ).exists()
+        }
+
+    private fun Context.deleteSavedDownload(displayName: String) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            contentResolver.delete(
+                MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+                "${MediaStore.MediaColumns.DISPLAY_NAME}=?",
+                arrayOf(displayName),
+            )
+        } else {
+            File(
+                File(
+                    Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+                    "Zhihu++",
+                ),
+                displayName,
+            ).delete()
+        }
+    }
+
     private fun <T> ContentResolver.querySavedImage(
         displayName: String,
         block: android.database.Cursor.() -> T,
@@ -78,6 +136,21 @@ class ArticleExportEnvironmentInstrumentedTest {
         arrayOf(displayName),
         null,
     )?.use(block)
+
+    private fun <T> ContentResolver.querySavedDownload(
+        displayName: String,
+        block: android.database.Cursor.() -> T,
+    ): T? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        query(
+            MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+            arrayOf(MediaStore.MediaColumns._ID),
+            "${MediaStore.MediaColumns.DISPLAY_NAME}=?",
+            arrayOf(displayName),
+            null,
+        )?.use(block)
+    } else {
+        null
+    }
 
     private fun sampleArticleContent(): DataHolder.Article = DataHolder.Article(
         id = 1001L,

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
@@ -21,11 +21,15 @@ import android.Manifest
 import android.app.Activity
 import android.app.AlertDialog
 import android.content.ClipData
+import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
 import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
@@ -98,6 +102,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import java.io.File
 import com.github.zly2006.zhihu.navigation.Article as ArticleDestination
 import com.github.zly2006.zhihu.util.buildArticleExportHtml as buildAndroidArticleExportHtml
 import io.ktor.http.ContentType as KtorContentType
@@ -537,6 +542,63 @@ open class SharedAndroidPaginationEnvironment(
         displayName: String,
         bitmap: Any,
     ) = saveBitmapToGallery(context, displayName, bitmap as android.graphics.Bitmap)
+
+    override fun saveHtmlToDownloads(
+        displayName: String,
+        htmlContent: String,
+    ): String = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        saveHtmlToDownloadsWithMediaStore(displayName, htmlContent)
+    } else {
+        saveHtmlToLegacyDownloads(displayName, htmlContent)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun saveHtmlToDownloadsWithMediaStore(
+        displayName: String,
+        htmlContent: String,
+    ): String {
+        val resolver = context.contentResolver
+        val contentValues = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
+            put(MediaStore.MediaColumns.MIME_TYPE, "text/html")
+            put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS + "/Zhihu++")
+            put(MediaStore.MediaColumns.IS_PENDING, 1)
+        }
+        val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues)
+            ?: throw IllegalStateException("无法创建下载文件")
+
+        return try {
+            resolver.openOutputStream(uri)?.bufferedWriter(Charsets.UTF_8)?.use { writer ->
+                writer.write(htmlContent)
+            } ?: throw IllegalStateException("无法打开下载文件")
+
+            contentValues.clear()
+            contentValues.put(MediaStore.MediaColumns.IS_PENDING, 0)
+            resolver.update(uri, contentValues, null, null)
+            "Zhihu++/$displayName"
+        } catch (e: Exception) {
+            resolver.delete(uri, null, null)
+            throw e
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun saveHtmlToLegacyDownloads(
+        displayName: String,
+        htmlContent: String,
+    ): String {
+        val downloadsDir = File(
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+            "Zhihu++",
+        )
+        if (!downloadsDir.exists() && !downloadsDir.mkdirs()) {
+            throw IllegalStateException("无法创建下载目录")
+        }
+
+        val file = File(downloadsDir, displayName)
+        file.writeText(htmlContent)
+        return file.absolutePath
+    }
 
     override fun articleImageExportRenderer(loadAssetText: (String) -> String): ArticleImageExportRenderer =
         AndroidArticleExportRenderer(context, loadAssetText)


### PR DESCRIPTION
## 变更内容

- 恢复 Android 端 `saveHtmlToDownloads` 平台实现，文章 HTML 导出会重新写入下载目录。
- Android 10 及以上写入系统 `Download/Zhihu++`，旧系统写入公共下载目录 `Download/Zhihu++`，保持 KMP 重写前的返回路径行为。
- 扩展文章导出环境 instrumented test，覆盖 HTML 导出文件真实写入 Downloads 的回归。

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `./gradlew :app:compileLiteDebugAndroidTestKotlin`

Resolves #411