### PR TITLE
fix: 修复知乎划线评论打不开

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CommentScreenComponent.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CommentScreenComponent.kt
@@ -102,7 +102,7 @@ fun CommentScreenComponent(
                 shouldDismissOnClickOutside = true,
             ),
             dragHandle = { DragHandleTitle("评论") },
-            usePlatformWindow = false,
+            usePlatformWindow = content !is Article,
         ) {
             CommentScreen(
                 content = { content },
@@ -122,7 +122,7 @@ fun CommentScreenComponent(
                 shouldDismissOnClickOutside = true,
             ),
             dragHandle = { DragHandleTitle("回复") },
-            usePlatformWindow = false,
+            usePlatformWindow = childTarget.article !is Article,
         ) {
             CommentScreen(
                 content = { childTarget },


### PR DESCRIPTION
Resolves #434