### PR TITLE
feat: 支持按话题屏蔽想法

### DIFF
--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/data/AndroidDataSupport.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/data/AndroidDataSupport.kt
@@ -71,7 +71,7 @@ suspend fun DataHolder.getContentDetail(
     context: Context,
     pin: Pin,
 ): DataHolder.Pin? {
-    val apiUrl = "https://www.zhihu.com/api/v4/pins/${pin.id}"
+    val apiUrl = "https://www.zhihu.com/api/v4/pins/${pin.id}?include=topics"
 
     return runCatching {
         val jo = AccountData.fetchGet(context, apiUrl) { signFetchRequest() }!!

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PinScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PinScreen.kt
@@ -136,7 +136,7 @@ private suspend fun loadPinDetail(
     pin: Pin,
 ): PinScreenUiState {
     environment.addReadHistory(pin.id.toString(), "pin")
-    val jsonObject = environment.fetchJson("https://www.zhihu.com/api/v4/pins/${pin.id}", "")
+    val jsonObject = environment.fetchJson("https://www.zhihu.com/api/v4/pins/${pin.id}?include=topics", "")
         ?: error("想法详情为空")
     val content = decodePinContentDetail(jsonObject)
     environment.postHistoryDestination(pin)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
@@ -429,6 +429,7 @@ private fun FeedCardMenuBox(
                     is com.github.zly2006.zhihu.shared.data.DataHolder.Answer -> raw.question.topics
                     is com.github.zly2006.zhihu.shared.data.DataHolder.Question -> raw.topics
                     is com.github.zly2006.zhihu.shared.data.DataHolder.Article -> raw.topics ?: emptyList()
+                    is com.github.zly2006.zhihu.shared.data.DataHolder.Pin -> raw.topics ?: emptyList()
                     else -> emptyList()
                 }
                 topics.forEach { topic ->

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
@@ -488,6 +488,7 @@ fun extractTopicIds(raw: DataHolder.Content): List<String>? = when (raw) {
     is DataHolder.Answer -> raw.question.topics.map { it.id }
     is DataHolder.Question -> raw.topics.map { it.id }
     is DataHolder.Article -> raw.topics?.map { it.id }
+    is DataHolder.Pin -> raw.topics?.map { it.id }
     else -> null
 }
 

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/viewmodel/feed/PinTopicBlockingTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/viewmodel/feed/PinTopicBlockingTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for Android.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.viewmodel.feed
+
+import com.github.zly2006.zhihu.shared.data.DataHolder
+import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
+import com.github.zly2006.zhihu.viewmodel.filter.extractTopicIds
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PinTopicBlockingTest {
+    @Test
+    fun extractsTopicIdsFromPin() {
+        assertEquals(listOf("topic-1", "topic-2"), extractTopicIds(pin("pin-1").raw!!))
+    }
+
+    @Test
+    fun removesPinItemsByBlockedTopic() {
+        val viewModel = TestFeedViewModel()
+        viewModel.displayItems.addAll(
+            listOf(
+                pin("blocked-pin", "topic-blocked"),
+                pin("kept-pin", "topic-kept"),
+            ),
+        )
+
+        removeFeedItemsByBlockedTopic(viewModel, "topic-blocked")
+
+        assertEquals(listOf("kept-pin"), viewModel.displayItems.map { it.title })
+    }
+
+    private fun pin(
+        title: String,
+        vararg topicIds: String = arrayOf("topic-1", "topic-2"),
+    ): FeedDisplayItem = FeedDisplayItem(
+        title = title,
+        summary = null,
+        details = "想法",
+        feed = null,
+        raw = DataHolder.Pin(
+            id = title,
+            author = author(),
+            topics = topicIds.map { topic(it) },
+        ),
+    )
+
+    private fun topic(id: String): DataHolder.Topic = DataHolder.Topic(
+        id = id,
+        type = "topic",
+        url = "https://www.zhihu.com/topic/$id",
+        name = id,
+    )
+
+    private fun author(): DataHolder.Author = DataHolder.Author(
+        avatarUrl = "",
+        gender = 0,
+        headline = "",
+        id = "author-id",
+        isAdvertiser = false,
+        isOrg = false,
+        name = "作者",
+        type = "people",
+        url = "",
+        urlToken = "author",
+        userType = "people",
+    )
+
+    private class TestFeedViewModel : BaseFeedViewModel() {
+        override val initialUrl: String = "https://api.zhihu.com/topstory/recommend"
+    }
+}

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
@@ -374,7 +374,7 @@ class DesktopPaginationEnvironment(
     }.getOrNull()
 
     private suspend fun fetchDesktopPinContentDetail(pin: Pin): DataHolder.Pin? = runCatching {
-        val json = store.signedFetchJson("https://www.zhihu.com/api/v4/pins/${pin.id}") {
+        val json = store.signedFetchJson("https://www.zhihu.com/api/v4/pins/${pin.id}?include=topics") {
             method = HttpMethod.Get
         } ?: return@runCatching null
         decodePinContentDetail(json)


### PR DESCRIPTION
## 变更内容
- 想法详情请求补充 `include=topics`，让 Pin 详情能带回主题数据。
- Feed 卡片更多菜单支持对想法的主题执行屏蔽。
- 内容过滤提取逻辑支持从想法读取 topic id，并新增定向测试覆盖按主题移除想法。

## 验证
- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `./gradlew :shared:jvmTest --tests 'com.github.zly2006.zhihu.viewmodel.feed.PinTopicBlockingTest'`
- `git diff --check`
- 真实账号签名请求：`/api/v3/moments?limit=100&desktop=true` 找到 Pin `2047357750334771738`，`/api/v4/pins/2047357750334771738?include=topics` 返回 7 个 `topics`。

## UI 验证
截图来自实际运行的 Lite Debug APK + AVD `Medium_Phone_2`。已尝试恢复本地 Android 登录备份，但当前账号状态显示“登录已过期”，因此无法进入真实 feed 的想法菜单完成最终交互截图。

![登录态阻塞截图](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-437/login-expired.png)

