### PR TITLE
fix: 修复底部标签重选滚动触发

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/DailyScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/DailyScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -80,6 +81,8 @@ import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.navigation.resolveContent
 import com.github.zly2006.zhihu.shared.data.DailySection
 import com.github.zly2006.zhihu.shared.data.DailyStory
+import com.github.zly2006.zhihu.shared.ui.TopLevelReselectAction
+import com.github.zly2006.zhihu.shared.ui.topLevelReselectAction
 import com.github.zly2006.zhihu.shared.util.formatDailyDate
 import com.github.zly2006.zhihu.shared.util.twoDigitString
 import com.github.zly2006.zhihu.shared.viewmodel.DailyViewModel
@@ -105,6 +108,8 @@ import kotlin.time.ExperimentalTime
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalTime::class)
 @Composable
 fun DailyScreen(
+    scrollToTopTrigger: Int = 0,
+    isActive: Boolean = true,
     testState: DailyScreenUiState? = null,
     onTestDateSelected: ((String) -> Unit)? = null,
     onTestLoadMore: (() -> Unit)? = null,
@@ -119,6 +124,7 @@ fun DailyScreen(
     var showDatePicker by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     val listState = rememberLazyListState()
+    var cachedScrollToTopTrigger by remember { mutableIntStateOf(scrollToTopTrigger) }
     val uiState = testState ?: DailyScreenUiState(
         sections = viewModel.sections,
         isLoading = viewModel.isLoading,
@@ -171,6 +177,21 @@ fun DailyScreen(
             }
             isRefreshing = false
         }
+    }
+
+    LaunchedEffect(scrollToTopTrigger, isActive) {
+        val action = topLevelReselectAction(
+            triggerDelta = scrollToTopTrigger - cachedScrollToTopTrigger,
+            isAtTop = listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0,
+        )
+        if (isActive) {
+            when (action) {
+                TopLevelReselectAction.Refresh -> doRefresh()
+                TopLevelReselectAction.ScrollToTop -> listState.animateScrollToItem(0)
+                null -> {}
+            }
+        }
+        cachedScrollToTopTrigger = scrollToTopTrigger
     }
 
     if (showDatePicker) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HotListScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HotListScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.CircularProgressIndicator
@@ -29,6 +30,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -40,6 +42,8 @@ import com.github.zly2006.zhihu.shared.data.HotListFeed
 import com.github.zly2006.zhihu.shared.platform.UserMessageDuration
 import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
+import com.github.zly2006.zhihu.shared.ui.TopLevelReselectAction
+import com.github.zly2006.zhihu.shared.ui.topLevelReselectAction
 import com.github.zly2006.zhihu.ui.components.BlockUserConfirmDialog
 import com.github.zly2006.zhihu.ui.components.DraggableRefreshButton
 import com.github.zly2006.zhihu.ui.components.FeedCard
@@ -62,6 +66,8 @@ const val HOT_LIST_REFRESH_BUTTON_TAG = "hot_list_refresh_button"
 @Composable
 fun HotListScreen(
     innerPadding: PaddingValues = PaddingValues(0.dp),
+    scrollToTopTrigger: Int = 0,
+    isActive: Boolean = true,
     onTestRefreshClick: (() -> Unit)? = null,
     onTestLoadMore: (() -> Unit)? = null,
 ) {
@@ -69,11 +75,28 @@ fun HotListScreen(
     val environment = rememberPaginationEnvironment(viewModel.allowGuestAccess)
     val userMessages = rememberUserMessageSink()
     val settings = rememberSettingsStore()
+    val listState = rememberLazyListState()
+    var cachedScrollToTopTrigger by remember { mutableIntStateOf(scrollToTopTrigger) }
 
     LaunchedEffect(Unit) {
         if (viewModel.displayItems.isEmpty()) {
             viewModel.refresh(environment)
         }
+    }
+
+    LaunchedEffect(scrollToTopTrigger, isActive) {
+        val action = topLevelReselectAction(
+            triggerDelta = scrollToTopTrigger - cachedScrollToTopTrigger,
+            isAtTop = listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0,
+        )
+        if (isActive) {
+            when (action) {
+                TopLevelReselectAction.Refresh -> onTestRefreshClick?.invoke() ?: viewModel.refresh(environment)
+                TopLevelReselectAction.ScrollToTop -> listState.animateScrollToItem(0)
+                null -> {}
+            }
+        }
+        cachedScrollToTopTrigger = scrollToTopTrigger
     }
 
     LaunchedEffect(viewModel.errorMessage) {
@@ -90,6 +113,7 @@ fun HotListScreen(
         FeedPullToRefresh(viewModel, environment) {
             PaginatedList(
                 items = viewModel.displayItems,
+                listState = listState,
                 onLoadMore = { onTestLoadMore?.invoke() ?: viewModel.loadMore(environment) },
                 modifier = Modifier
                     .padding(innerPadding)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/OnlineHistoryScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/OnlineHistoryScreen.kt
@@ -19,6 +19,7 @@ package com.github.zly2006.zhihu.ui
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.AlertDialog
@@ -34,6 +35,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -45,6 +47,8 @@ import com.github.zly2006.zhihu.navigation.History
 import com.github.zly2006.zhihu.navigation.LocalNavigator
 import com.github.zly2006.zhihu.shared.platform.PlatformBackHandler
 import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
+import com.github.zly2006.zhihu.shared.ui.TopLevelReselectAction
+import com.github.zly2006.zhihu.shared.ui.topLevelReselectAction
 import com.github.zly2006.zhihu.ui.components.FeedCard
 import com.github.zly2006.zhihu.ui.components.FeedPullToRefresh
 import com.github.zly2006.zhihu.ui.components.PaginatedList
@@ -62,18 +66,38 @@ const val ONLINE_HISTORY_OVERFLOW_TAG = "online_history_overflow"
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun OnlineHistoryScreen() {
+fun OnlineHistoryScreen(
+    scrollToTopTrigger: Int = 0,
+    isActive: Boolean = true,
+) {
     val navigator = LocalNavigator.current
     val viewModel: OnlineHistoryViewModel = viewModel { OnlineHistoryViewModel() }
     val paginationEnvironment = rememberPaginationEnvironment(allowGuestAccess = false)
     val userMessages = rememberUserMessageSink()
     val coroutineScope = rememberCoroutineScope()
+    val listState = rememberLazyListState()
+    var cachedScrollToTopTrigger by remember { mutableIntStateOf(scrollToTopTrigger) }
     var showClearHistoryDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         if (viewModel.displayItems.isEmpty()) {
             viewModel.refresh(paginationEnvironment)
         }
+    }
+
+    LaunchedEffect(scrollToTopTrigger, isActive) {
+        val action = topLevelReselectAction(
+            triggerDelta = scrollToTopTrigger - cachedScrollToTopTrigger,
+            isAtTop = listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0,
+        )
+        if (isActive) {
+            when (action) {
+                TopLevelReselectAction.Refresh -> viewModel.refresh(paginationEnvironment)
+                TopLevelReselectAction.ScrollToTop -> listState.animateScrollToItem(0)
+                null -> {}
+            }
+        }
+        cachedScrollToTopTrigger = scrollToTopTrigger
     }
 
     PlatformBackHandler(enabled = showClearHistoryDialog) {
@@ -154,6 +178,7 @@ fun OnlineHistoryScreen() {
                     .padding(innerPadding)
                     .testTag("online_history_list"),
                 items = viewModel.displayItems,
+                listState = listState,
                 onLoadMore = { viewModel.loadMore(paginationEnvironment) },
                 isEnd = { viewModel.isEnd },
             ) { item ->

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -581,9 +581,19 @@ private fun MainTabsPager(
                 innerPadding = innerPadding,
                 isActive = pagerState.currentPage == pageIndex,
             )
-            MainTabPage.HotListPage -> HotListScreen(innerPadding)
-            MainTabPage.DailyPage -> DailyScreen()
-            MainTabPage.OnlineHistoryPage -> OnlineHistoryScreen()
+            MainTabPage.HotListPage -> HotListScreen(
+                innerPadding = innerPadding,
+                scrollToTopTrigger = scrollToTopTrigger,
+                isActive = pagerState.currentPage == pageIndex,
+            )
+            MainTabPage.DailyPage -> DailyScreen(
+                scrollToTopTrigger = scrollToTopTrigger,
+                isActive = pagerState.currentPage == pageIndex,
+            )
+            MainTabPage.OnlineHistoryPage -> OnlineHistoryScreen(
+                scrollToTopTrigger = scrollToTopTrigger,
+                isActive = pagerState.currentPage == pageIndex,
+            )
             MainTabPage.MyCollectionsPage -> MyCollectionsTopLevelPage()
             MainTabPage.AccountPage -> AccountSettingScreen(innerPadding)
         }


### PR DESCRIPTION
## 变更说明

- 将主壳底栏重选产生的 `scrollToTopTrigger` 传给热榜、日报、历史三个主 tab 页。
- 热榜和历史复用 `PaginatedList` 已有的 `listState` 注入能力，日报复用页面内已有 `LazyListState`。
- 三个页面统一复用现有 `topLevelReselectAction` 语义：单次重选且列表不在顶部时滚动到顶部；已经在顶部或连续触发时刷新。

Resolves #445

## 验证

- `./gradlew assembleLiteDebug`：通过。
- `./gradlew ktlintFormat`：通过。
- `git diff --check`：通过。
- 远端 `off` AVD：`status` 空闲，`boot-check` 成功，`boot_completed after 33s`。
- 实际安装/启动 Lite Debug APK：`adb install -r` 成功，`monkey` 启动成功，但当前远端 AVD 无可用登录态，应用停在 `LoginActivity`，因此无法进入热榜/日报/历史列表做可见交互截图或 `ui-test dump` 验证目标页面。

## 截图 / AVD 证据

截图来自实际运行的 Lite Debug APK + 远端 `off-ci-api35-1` AVD。由于登录态阻塞，截图只能证明 APK 已在真实 AVD 启动到登录页，不能证明目标列表滚动效果。

![远端 AVD 登录态阻塞截图](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-447/issue445-login-blocker.png)

## 风险

- 未在已登录 AVD 上完成热榜、日报、历史的端到端滚动/刷新手势验证；当前结论基于代码路径复用 Home/Follow 的同一状态机和本地构建通过。
- 没有新增 instrumented test，避免本地跑完整 Android instrument suite；现有调用点保留默认参数，兼容旧测试构造。
