### PR TITLE
fix: 修复账号面板浏览历史入口

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,13 +54,13 @@ jobs:
         uses: android-actions/setup-android@v3
       # Run Tests Build
       - name: Run KtLint
-        run: ./gradlew ktlintCheck
+        run: ./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process ktlintCheck
       - name: Run gradle tests
-        run: ./gradlew test
+        run: ./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process test
       - name: Build App
         # Build .apk
         run: |
-          bash ./gradlew assembleFullDebug assembleLiteDebug
+          ./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process assembleFullDebug assembleLiteDebug
         env:
           CI_BUILD_MINIFY: false
       - name: Move files

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
@@ -20,6 +20,7 @@ package com.github.zly2006.zhihu
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -36,6 +37,7 @@ import com.github.zly2006.zhihu.navigation.Follow
 import com.github.zly2006.zhihu.navigation.Home
 import com.github.zly2006.zhihu.navigation.Notification
 import com.github.zly2006.zhihu.navigation.OnlineHistory
+import com.github.zly2006.zhihu.navigation.TopLevelDestination
 import com.github.zly2006.zhihu.test.InstrumentedTestEnvironment
 import com.github.zly2006.zhihu.test.MainActivityComposeRule
 import com.github.zly2006.zhihu.test.RecordingNavigator
@@ -56,6 +58,7 @@ import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_SHORTCUT_NOTIFICATION_TAG
 import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_SYSTEM_TAG
 import com.github.zly2006.zhihu.ui.AccountSettingScreen
 import com.github.zly2006.zhihu.ui.AccountSettingsAccountState
+import com.github.zly2006.zhihu.ui.LocalMainTabSelectionRequester
 import com.github.zly2006.zhihu.ui.PREFERENCE_NAME
 import com.github.zly2006.zhihu.ui.subscreens.BOTTOM_BAR_ITEMS_PREFERENCE_KEY
 import io.ktor.http.HttpMethod
@@ -67,6 +70,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import com.github.zly2006.zhihu.shared.data.Person as AccountPerson
 
 @RunWith(AndroidJUnit4::class)
@@ -160,8 +164,10 @@ class AccountSettingScreenInstrumentedTest {
         // 2. The favorites shortcut should navigate to the seeded Collections destination and must
         //    not close the surrounding account surface.
         // 3. The notification and history shortcuts represent overlay-style exits from the account
-        //    surface, so each one must call onDismissRequest exactly once. History opens the
-        //    OnlineHistory route directly because the bottom-bar history tab can be hidden.
+        //    surface, so each one must call onDismissRequest exactly once.
+        // 4. The history shortcut must request MainTabs to select the hidden top-level history
+        //    page instead of pushing an isolated route. The shell behavior itself is covered by
+        //    ZhihuMainNavigationInstrumentedTest.
         preferences
             .edit()
             .putBoolean("duo3_home_account", true)
@@ -188,11 +194,13 @@ class AccountSettingScreenInstrumentedTest {
                 }
                 """.trimIndent(),
         )
+        val requestedMainTab = AtomicReference<TopLevelDestination?>(null)
         val dismissCount = AtomicInteger(0)
         val navigator = showScreen(
             unreadCount = 7,
             onDismissRequest = { dismissCount.incrementAndGet() },
             refreshAccountProfileOnEnter = true,
+            onSelectMainTab = { destination -> requestedMainTab.set(destination) },
         )
 
         composeRule.waitUntil(timeoutMillis = 5_000) {
@@ -220,18 +228,20 @@ class AccountSettingScreenInstrumentedTest {
 
         composeRule.onNodeWithTag(ACCOUNT_SETTINGS_SHORTCUT_HISTORY_TAG).performClick()
         composeRule.waitUntil(timeoutMillis = 5_000) {
-            navigator.destinations.size == 3 && dismissCount.get() == 2
+            navigator.destinations.size == 2 &&
+                dismissCount.get() == 2 &&
+                requestedMainTab.get() == OnlineHistory
         }
 
         assertEquals(
             listOf(
                 Collections(SEEDED_ACCOUNT_URL_TOKEN),
                 Notification,
-                OnlineHistory,
             ),
             navigator.destinations,
         )
         assertEquals(2, dismissCount.get())
+        assertEquals(OnlineHistory, requestedMainTab.get())
     }
 
     @Test
@@ -261,14 +271,17 @@ class AccountSettingScreenInstrumentedTest {
         onDismissRequest: () -> Unit = {},
         refreshAccountProfileOnEnter: Boolean = false,
         testAccountData: AccountSettingsAccountState? = null,
+        onSelectMainTab: (TopLevelDestination) -> Unit = {},
     ): RecordingNavigator = composeRule.setScreenContent {
-        AccountSettingScreen(
-            innerPadding = PaddingValues(),
-            unreadCount = unreadCount,
-            onDismissRequest = onDismissRequest,
-            refreshAccountProfileOnEnter = refreshAccountProfileOnEnter,
-            testAccountData = testAccountData,
-        )
+        CompositionLocalProvider(LocalMainTabSelectionRequester provides onSelectMainTab) {
+            AccountSettingScreen(
+                innerPadding = PaddingValues(),
+                unreadCount = unreadCount,
+                onDismissRequest = onDismissRequest,
+                refreshAccountProfileOnEnter = refreshAccountProfileOnEnter,
+                testAccountData = testAccountData,
+            )
+        }
     }
 
     private fun seededLoggedInAccountData(): AccountData.Data = AccountData.Data(

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
@@ -160,8 +160,8 @@ class AccountSettingScreenInstrumentedTest {
         // 2. The favorites shortcut should navigate to the seeded Collections destination and must
         //    not close the surrounding account surface.
         // 3. The notification and history shortcuts represent overlay-style exits from the account
-        //    surface, so each one must call onDismissRequest exactly once. History selects the
-        //    OnlineHistory main tab directly instead of going through the local Navigator.
+        //    surface, so each one must call onDismissRequest exactly once. History opens the
+        //    OnlineHistory route directly because the bottom-bar history tab can be hidden.
         preferences
             .edit()
             .putBoolean("duo3_home_account", true)
@@ -220,13 +220,14 @@ class AccountSettingScreenInstrumentedTest {
 
         composeRule.onNodeWithTag(ACCOUNT_SETTINGS_SHORTCUT_HISTORY_TAG).performClick()
         composeRule.waitUntil(timeoutMillis = 5_000) {
-            dismissCount.get() == 2 && composeRule.activity.mainTabNavigationTarget == OnlineHistory
+            navigator.destinations.size == 3 && dismissCount.get() == 2
         }
 
         assertEquals(
             listOf(
                 Collections(SEEDED_ACCOUNT_URL_TOKEN),
                 Notification,
+                OnlineHistory,
             ),
             navigator.destinations,
         )

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
@@ -219,8 +219,9 @@ class ZhihuMainNavigationInstrumentedTest {
             composeRule.activity.navigate(MainTabs, popup = true)
         }
 
-        composeRule.waitUntilTabSelected("nav_tab_daily")
-        composeRule.onNodeWithTag("nav_tab_daily").assertIsSelected()
+        composeRule.waitUntilTextSelected("推荐")
+        composeRule.onNodeWithTag("nav_tab_follow").assertIsSelected()
+        composeRule.onNodeWithText("推荐").assertIsSelected()
         composeRule.onNodeWithTag("nav_tab_home").assertDoesNotExist()
 
         composeRule.activity.runOnUiThread {

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
@@ -46,6 +46,7 @@ import com.github.zly2006.zhihu.shared.filter.ContentOpenFrom
 import com.github.zly2006.zhihu.test.MainActivityComposeRule
 import com.github.zly2006.zhihu.test.resetAppPreferences
 import com.github.zly2006.zhihu.test.setZhihuMainContent
+import com.github.zly2006.zhihu.ui.ONLINE_HISTORY_OVERFLOW_TAG
 import com.github.zly2006.zhihu.ui.PREFERENCE_NAME
 import com.github.zly2006.zhihu.ui.subscreens.BOTTOM_BAR_ITEMS_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.subscreens.START_DESTINATION_PREFERENCE_KEY
@@ -228,6 +229,38 @@ class ZhihuMainNavigationInstrumentedTest {
 
         composeRule.waitUntilTabSelected("nav_tab_follow")
         composeRule.onNodeWithTag("nav_tab_follow").assertIsSelected()
+    }
+
+    @Test
+    fun hiddenHistorySelection_staysInsideMainTabsWithoutRevivingHiddenBottomTab() {
+        // Hidden history still belongs to the main shell. Selecting it should surface the history
+        // page inside MainTabs while keeping the hidden bottom-bar item hidden.
+        composeRule.launchZhihuMain(
+            startDestination = Home.name,
+            bottomBarItems = linkedSetOf(Home.name, Follow.name, Daily.name, Account.name),
+        )
+
+        composeRule.waitUntilTabSelected("nav_tab_home")
+        composeRule.onNodeWithTag("nav_tab_onlinehistory").assertDoesNotExist()
+
+        composeRule.activity.runOnUiThread {
+            composeRule.activity.navigateMainTab(OnlineHistory)
+        }
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.activity.mainTabNavigationTarget == null &&
+                composeRule
+                    .onAllNodes(hasTestTag(ONLINE_HISTORY_OVERFLOW_TAG))
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+        }
+
+        composeRule.onNodeWithTag(ONLINE_HISTORY_OVERFLOW_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag("nav_tab_onlinehistory").assertDoesNotExist()
+        composeRule.onNodeWithTag("nav_tab_home").assertIsNotSelected()
+        composeRule.onNodeWithTag("nav_tab_follow").assertIsNotSelected()
+        composeRule.onNodeWithTag("nav_tab_daily").assertIsNotSelected()
+        composeRule.onNodeWithTag("nav_tab_account").assertIsNotSelected()
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/test/ComposeScreenTestHost.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/test/ComposeScreenTestHost.kt
@@ -20,6 +20,7 @@ package com.github.zly2006.zhihu.test
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.performTouchInput
@@ -88,8 +89,12 @@ fun MainActivityComposeRule.setZhihuMainContent() {
     activity.setContent { }
     waitForIdle()
     activity.setContent {
+        val navController = rememberNavController()
         ZhihuTheme {
-            AndroidZhihuMain(navController = rememberNavController())
+            SideEffect {
+                activity.navController = navController
+            }
+            AndroidZhihuMain(navController = navController)
         }
     }
     waitForIdle()

--- a/app/src/main/java/com/github/zly2006/zhihu/MainActivity.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/MainActivity.kt
@@ -570,6 +570,12 @@ class MainActivity :
         }
     }
 
+    /**
+     * 请求主壳在 [MainTabs] 内切换顶层目标。
+     *
+     * 这里更新的是壳层 tab 选择状态，不是把目标补成新的独立 route；目标若当前被底部栏隐藏，
+     * 也应继续由 [com.github.zly2006.zhihu.ui.ZhihuMain] 决定如何在主 pager 中承载。
+     */
     fun navigateMainTab(destination: TopLevelDestination) {
         mainTabNavigationTarget = destination
         navigateToMainTabs()

--- a/app/src/main/java/com/github/zly2006/zhihu/MainActivity.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/MainActivity.kt
@@ -54,7 +54,6 @@ import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.ArticleType
 import com.github.zly2006.zhihu.navigation.CollectionContent
 import com.github.zly2006.zhihu.navigation.History
-import com.github.zly2006.zhihu.navigation.Home
 import com.github.zly2006.zhihu.navigation.MainTabs
 import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.navigation.Notification
@@ -516,7 +515,6 @@ class MainActivity :
             return
         }
         if (route == MainTabs) {
-            mainTabNavigationTarget = Home
             navigateToMainTabs()
             return
         }

--- a/app/src/main/java/com/github/zly2006/zhihu/ui/ZhihuMainAndroidContent.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/ZhihuMainAndroidContent.kt
@@ -28,6 +28,7 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
@@ -48,13 +49,15 @@ import com.github.zly2006.zhihu.viewmodel.ArticleViewModel
 @Composable
 fun AndroidZhihuMain(navController: NavHostController) {
     val activity = LocalActivity.current as MainActivity
-    ZhihuMain(
-        navController = navController,
-        navigationState = rememberAndroidZhihuMainNavigationState(),
-        preferenceState = rememberAndroidZhihuMainPreferenceState(),
-        isDarkTheme = com.github.zly2006.zhihu.theme.ThemeManager.isDarkTheme,
-        platformAdapter = androidZhihuMainPlatformAdapter(activity),
-    )
+    CompositionLocalProvider(LocalMainTabSelectionRequester provides activity::navigateMainTab) {
+        ZhihuMain(
+            navController = navController,
+            navigationState = rememberAndroidZhihuMainNavigationState(),
+            preferenceState = rememberAndroidZhihuMainPreferenceState(),
+            isDarkTheme = com.github.zly2006.zhihu.theme.ThemeManager.isDarkTheme,
+            platformAdapter = androidZhihuMainPlatformAdapter(activity),
+        )
+    }
 }
 
 private fun androidZhihuMainPlatformAdapter(activity: MainActivity) = ZhihuMainPlatformAdapter(

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/AndroidUiRuntimes.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/AndroidUiRuntimes.kt
@@ -44,7 +44,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.zly2006.zhihu.data.AccountData
 import com.github.zly2006.zhihu.data.asApiEnvironment
 import com.github.zly2006.zhihu.navigation.Article
-import com.github.zly2006.zhihu.navigation.TopLevelDestination
 import com.github.zly2006.zhihu.shared.data.RecommendationMode
 import com.github.zly2006.zhihu.shared.data.ZHIHU_ME_URL
 import com.github.zly2006.zhihu.shared.data.ZhihuJson
@@ -126,7 +125,6 @@ actual fun rememberAccountSettingsPlatformRuntime(): AccountSettingsRuntime {
         },
         logout = { AccountData.delete(context) },
         appVersionInfo = { context.zhihuVersionInfo() },
-        selectMainTab = { destination -> context.navigateMainTab(destination) },
     )
 }
 
@@ -150,24 +148,6 @@ private fun Context.zhihuVersionInfo(): String {
         ?: if ((applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0) "debug" else "release"
     val gitHash = metaData?.getString("com.github.zly2006.zhihu.GIT_HASH") ?: "unknown"
     return "$versionName $buildType, $gitHash"
-}
-
-private fun Context.navigateMainTab(destination: TopLevelDestination) {
-    val activity = findActivity() ?: return
-    activity
-        .javaClass
-        .methods
-        .firstOrNull { method ->
-            method.name == "navigateMainTab" &&
-                method.parameterTypes.size == 1 &&
-                method.parameterTypes.first().isAssignableFrom(destination::class.java)
-        }?.invoke(activity, destination)
-}
-
-private fun Context.findActivity(): android.app.Activity? = when (this) {
-    is android.app.Activity -> this
-    is ContextWrapper -> baseContext.findActivity()
-    else -> null
 }
 
 @Composable

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/AndroidUiRuntimes.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/AndroidUiRuntimes.kt
@@ -88,6 +88,7 @@ private const val QR_SCAN_RESULT_EXTRA = "scan_result"
 @Composable
 actual fun rememberAccountSettingsPlatformRuntime(): AccountSettingsRuntime {
     val context = LocalContext.current
+    val requestMainTabSelection = LocalMainTabSelectionRequester.current
     val accountDataState = AccountData.asState()
     val scanActivityLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult(),
@@ -125,6 +126,7 @@ actual fun rememberAccountSettingsPlatformRuntime(): AccountSettingsRuntime {
         },
         logout = { AccountData.delete(context) },
         appVersionInfo = { context.zhihuVersionInfo() },
+        selectMainTab = { destination -> requestMainTabSelection?.invoke(destination) },
     )
 }
 

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/AndroidUiRuntimes.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/AndroidUiRuntimes.kt
@@ -126,7 +126,7 @@ actual fun rememberAccountSettingsPlatformRuntime(): AccountSettingsRuntime {
         },
         logout = { AccountData.delete(context) },
         appVersionInfo = { context.zhihuVersionInfo() },
-        selectMainTab = { destination -> requestMainTabSelection?.invoke(destination) },
+        selectMainTab = requestMainTabSelection,
     )
 }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
@@ -28,8 +28,8 @@ sealed interface NavDestination
 /**
  * 底部栏和主 pager 使用的 tab 目标。
  *
- * 为了兼容旧调用，tab 目标仍可能同时是历史遗留的 [NavDestination] 值。需要进入主壳时应使用 [MainTabs]，
- * 再由主壳选择对应 tab。
+ * 顶层目标只表达“主壳应该切到哪个 tab”，不表达“主 NavHost 里要 push 哪个独立页面”。
+ * 即使某个 tab 当前被底部栏隐藏，也应由 [MainTabs] 决定是否临时纳入主 pager，而不是单独注册一个同名 route。
  */
 interface TopLevelDestination {
     val name: String
@@ -90,9 +90,12 @@ data object History : NavDestination, TopLevelDestination {
 
 /**
  * 主 pager 的历史顶层 tab 目标。
+ *
+ * 账号页等入口需要跳到浏览历史时，应让 [MainTabs] 选中这个顶层目标。即使底部栏暂时隐藏“历史”，
+ * 也不能把它补成主 NavHost 的独立页面 route。
  */
 @Serializable
-data object OnlineHistory : NavDestination, TopLevelDestination {
+data object OnlineHistory : TopLevelDestination {
     override val name: String
         get() = "OnlineHistory"
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
@@ -92,7 +92,7 @@ data object History : NavDestination, TopLevelDestination {
  * 主 pager 的历史顶层 tab 目标。
  */
 @Serializable
-data object OnlineHistory : TopLevelDestination {
+data object OnlineHistory : NavDestination, TopLevelDestination {
     override val name: String
         get() = "OnlineHistory"
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
@@ -366,7 +366,7 @@ fun AccountSettingScreen(
                                     .background(MaterialTheme.colorScheme.primaryContainer)
                                     .clickable {
                                         onDismissRequest()
-                                        navigator.onNavigate(OnlineHistory)
+                                        runtime.selectMainTab(OnlineHistory)
                                     }.padding(8.dp, 16.dp),
                                 verticalArrangement = Arrangement.Center,
                                 horizontalAlignment = Alignment.CenterHorizontally,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
@@ -366,7 +366,7 @@ fun AccountSettingScreen(
                                     .background(MaterialTheme.colorScheme.primaryContainer)
                                     .clickable {
                                         onDismissRequest()
-                                        runtime.selectMainTab(OnlineHistory)
+                                        navigator.onNavigate(OnlineHistory)
                                     }.padding(8.dp, 16.dp),
                                 verticalArrangement = Arrangement.Center,
                                 horizontalAlignment = Alignment.CenterHorizontally,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/OnlineHistoryScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/OnlineHistoryScreen.kt
@@ -61,8 +61,9 @@ const val ONLINE_HISTORY_OVERFLOW_TAG = "online_history_overflow"
 /**
  * 在线浏览历史页面。
  *
- * 页面展示知乎账号侧的浏览历史，提供刷新、分页加载和清空历史入口。它既可能作为底部栏 tab 出现，也可能从账号页快捷入口独立 push。
- * 当前实现本身不绘制返回箭头，底栏显隐由外层 route 决定；如果包装层需要独立返回入口，应由包装层显式传入对应状态。
+ * 页面展示知乎账号侧的浏览历史，提供刷新、分页加载和清空历史入口。它始终属于 [com.github.zly2006.zhihu.navigation.MainTabs]
+ * 这套顶层导航语义：底部栏显示“历史”时，它作为可见 tab 出现；底部栏隐藏“历史”时，主壳仍可临时把它放进主 pager 供快捷入口选中。
+ * 当前实现本身不绘制返回箭头，底栏显隐由外层主壳决定。
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
@@ -568,10 +569,18 @@ fun rememberZhihuMainPreferenceState(
 ): ZhihuMainPreferenceState = remember { ZhihuMainPreferenceState(readSnapshot) }
 
 /**
+ * 主壳向子页面暴露的顶层 tab 选择入口。
+ *
+ * 子页面只能请求主壳切换顶层目标，不能把旧顶层 tab 重新包装成独立 route 压入返回栈。
+ */
+val LocalMainTabSelectionRequester = staticCompositionLocalOf<((TopLevelDestination) -> Unit)?> { null }
+
+/**
  * 当前平台注入 [ZhihuMain] 的导航回调。
  *
  * common UI 的所有点击都通过这个对象发起导航。平台代码负责把旧的顶层目的地映射到
  * [com.github.zly2006.zhihu.navigation.MainTabs]、记录内容打开来源，并处理视频这类平台专用目标。
+ * 顶层目标即使当前被底部栏隐藏，也只能在主壳里消费，不能额外注册成同名独立页面。
  */
 data class ZhihuMainNavigationState(
     val mainTabNavigationTarget: TopLevelDestination?,
@@ -592,7 +601,8 @@ data class AccountSettingsAccountState(
  * 账号设置页消费的平台与账号服务。
  *
  * composable 自己负责视觉层级：资料头部、快捷入口、设置入口和关于/许可证区域。登录、扫码、退出、版本信息和主 tab 选择仍由平台注入，
- * 这样同一套账号 UI 可以运行在 Android、Desktop、预览和测试中。
+ * 这样同一套账号 UI 可以运行在 Android、Desktop、预览和测试中。这里的 [selectMainTab] 只请求 [MainTabs]
+ * 在主壳里切换顶层目标，不意味着去 push 一个独立 route。
  */
 data class AccountSettingsRuntime(
     val accountState: State<AccountSettingsAccountState>,
@@ -601,6 +611,7 @@ data class AccountSettingsRuntime(
     val requestQrLoginScan: () -> Unit,
     val logout: () -> Unit,
     val appVersionInfo: () -> String,
+    val selectMainTab: (TopLevelDestination) -> Unit,
 )
 
 @Composable

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
@@ -572,8 +572,9 @@ fun rememberZhihuMainPreferenceState(
  * 主壳向子页面暴露的顶层 tab 选择入口。
  *
  * 子页面只能请求主壳切换顶层目标，不能把旧顶层 tab 重新包装成独立 route 压入返回栈。
+ * 默认实现是 no-op，这样预览或独立测试即使没有主壳 provider 也不会崩溃。
  */
-val LocalMainTabSelectionRequester = staticCompositionLocalOf<((TopLevelDestination) -> Unit)?> { null }
+val LocalMainTabSelectionRequester = staticCompositionLocalOf<(TopLevelDestination) -> Unit> { {} }
 
 /**
  * 当前平台注入 [ZhihuMain] 的导航回调。

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
@@ -601,7 +601,6 @@ data class AccountSettingsRuntime(
     val requestQrLoginScan: () -> Unit,
     val logout: () -> Unit,
     val appVersionInfo: () -> String,
-    val selectMainTab: (TopLevelDestination) -> Unit,
 )
 
 @Composable

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -65,6 +65,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -117,6 +118,7 @@ import com.github.zly2006.zhihu.ui.subscreens.ContentFilterSettingsScreen
 import com.github.zly2006.zhihu.ui.subscreens.DeveloperSettingsScreen
 import com.github.zly2006.zhihu.ui.subscreens.OpenSourceLicensesScreen
 import com.github.zly2006.zhihu.ui.subscreens.SystemAndUpdateSettingsScreen
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 import kotlin.reflect.typeOf
@@ -334,9 +336,21 @@ fun ZhihuMain(
         mainTabNavigationTarget?.let { destination ->
             // 平台适配层会把旧的顶层 route 请求映射到 MainTabs。这里消费该请求，
             // 让 deeplink 等调用方仍能选中 Home/Follow 等 tab，而不是把旧 route 压入返回栈。
-            pageIndexForBottomDestination(destination)?.let { targetPage ->
-                mainPagerState.scrollToPage(targetPage)
+            val targetPage = pageIndexForBottomDestination(destination) ?: return@let
+            mainPagerState.scrollToPage(targetPage)
+            snapshotFlow {
+                Triple(
+                    mainPagerState.currentPage,
+                    currentMainTabPage()?.bottomDestination?.let { it::class },
+                    mainPagerState.isScrollInProgress,
+                )
+            }.first { (currentPage, settledDestinationClass, isScrollInProgress) ->
+                currentPage == targetPage &&
+                    settledDestinationClass == destination::class &&
+                    !isScrollInProgress
             }
+            currentMainTabDestination = destination
+            navigationState.setCurrentMainTabOpenFrom(destination.openFrom)
             navigationState.consumeMainTabNavigationTarget(destination)
         }
     }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -144,6 +144,27 @@ private sealed class MainTabPage(
     data object AccountPage : MainTabPage(Account, "account")
 }
 
+private val topLevelDestinationsInOrder: List<TopLevelDestination> = listOf(
+    Home,
+    Follow,
+    HotList,
+    Daily,
+    OnlineHistory,
+    MyCollections,
+    Account,
+)
+
+private fun mainTabPagesForDestination(destination: TopLevelDestination): List<MainTabPage> = when (destination) {
+    Home -> listOf(MainTabPage.HomePage)
+    Follow -> listOf(MainTabPage.FollowRecommendPage, MainTabPage.FollowDynamicPage)
+    HotList -> listOf(MainTabPage.HotListPage)
+    Daily -> listOf(MainTabPage.DailyPage)
+    OnlineHistory -> listOf(MainTabPage.OnlineHistoryPage)
+    MyCollections -> listOf(MainTabPage.MyCollectionsPage)
+    Account -> listOf(MainTabPage.AccountPage)
+    else -> emptyList()
+}
+
 /**
  * 共享主壳使用的平台适配层。
  *
@@ -167,6 +188,8 @@ data class ZhihuMainPlatformAdapter(
  * 这个 composable 是顶层体验的唯一所有者：渲染可配置底部导航栏，承载横向主 tab pager，向子页面提供 [LocalNavigator]，
  * 并注册跨平台共享的 typed [NavDestination] route。设计上把顶层 tab 收在 [MainTabs] 内部，而不是把每个 tab
  * 都作为独立 NavHost 页面 push，这样 tab 重选、回到顶部、顶/底栏自动隐藏和持久化 tab 选择都能使用同一套状态模型。
+ * 当某个顶层目标当前被底部栏隐藏时，主壳也应该自己决定是否临时把对应页放回 pager，而不是退化成跳去别的 tab
+ * 或额外补一个同名 route。
  *
  * 用户可见的主壳设置通过 [preferenceState] 流入。设置页退出时只 reload 这份状态，不重建 NavHost，从而在应用底栏和主题相关变更时
  * 保留已加载页面、返回栈和滚动位置。
@@ -231,40 +254,57 @@ fun ZhihuMain(
         allBottomBarItems.firstOrNull { it.first.name == key }
     }
 
-    val mainTabPages = remember(bottomBarItems) {
-        bottomBarItems.flatMap { item ->
-            when (item.first) {
-                Home -> listOf(MainTabPage.HomePage)
-                Follow -> listOf(MainTabPage.FollowRecommendPage, MainTabPage.FollowDynamicPage)
-                HotList -> listOf(MainTabPage.HotListPage)
-                Daily -> listOf(MainTabPage.DailyPage)
-                OnlineHistory -> listOf(MainTabPage.OnlineHistoryPage)
-                MyCollections -> listOf(MainTabPage.MyCollectionsPage)
-                Account -> listOf(MainTabPage.AccountPage)
-                else -> emptyList()
+    val mainTabNavigationTarget = navigationState.mainTabNavigationTarget
+    var currentMainTabDestination by remember { mutableStateOf(startDestination) }
+    val supplementalMainTabDestinations: List<TopLevelDestination> = remember(
+        bottomBarItems,
+        currentMainTabDestination,
+        mainTabNavigationTarget,
+    ) {
+        buildList<TopLevelDestination> {
+            if (bottomBarItems.none { it.first::class == currentMainTabDestination::class }) {
+                add(currentMainTabDestination)
             }
+            mainTabNavigationTarget
+                ?.takeIf { destination ->
+                    bottomBarItems.none { it.first::class == destination::class } &&
+                        none { supplementalDestination -> supplementalDestination::class == destination::class }
+                }?.let { destination ->
+                    add(destination)
+                }
         }
     }
+    val mainTabPages: List<MainTabPage> = remember(bottomBarItems, supplementalMainTabDestinations) {
+        topLevelDestinationsInOrder
+            .filter { destination ->
+                bottomBarItems.any { it.first::class == destination::class } ||
+                    supplementalMainTabDestinations.any { supplementalDestination ->
+                        supplementalDestination::class == destination::class
+                    }
+            }.flatMap { destination ->
+                mainTabPagesForDestination(destination)
+            }
+    }
 
-    fun pageIndexForDestination(destination: TopLevelDestination): Int = mainTabPages
+    fun pageIndexForDestination(destination: TopLevelDestination): Int? = mainTabPages
         .indexOfFirst {
             it.bottomDestination::class == destination::class
-        }.takeIf { it >= 0 } ?: mainTabPages
-        .indexOfFirst {
-            it.bottomDestination::class == startDestination::class
-        }.takeIf { it >= 0 } ?: 0
+        }.takeIf { it >= 0 }
+
+    fun fallbackPageIndex(destination: TopLevelDestination): Int = pageIndexForDestination(destination)
+        ?: pageIndexForDestination(startDestination)
+        ?: 0
 
     var lastFollowPageKey by rememberSaveable { mutableStateOf(MainTabPage.FollowRecommendPage.key) }
     val mainPagerState = rememberPagerState(
-        initialPage = pageIndexForDestination(startDestination),
+        initialPage = fallbackPageIndex(startDestination),
         pageCount = { mainTabPages.size },
     )
     val coroutineScope = rememberCoroutineScope()
 
     fun currentMainTabPage(): MainTabPage? = mainTabPages.getOrNull(mainPagerState.currentPage)
-    var currentMainTabDestination by remember { mutableStateOf(startDestination) }
 
-    fun pageIndexForBottomDestination(destination: TopLevelDestination): Int {
+    fun pageIndexForBottomDestination(destination: TopLevelDestination): Int? {
         if (destination == Follow) {
             val rememberedFollowPage = mainTabPages.indexOfFirst { it.key == lastFollowPageKey }
             if (rememberedFollowPage >= 0) return rememberedFollowPage
@@ -273,7 +313,7 @@ fun ZhihuMain(
     }
 
     fun navigateTopLevel(destination: TopLevelDestination) {
-        val targetPage = pageIndexForBottomDestination(destination)
+        val targetPage = pageIndexForBottomDestination(destination) ?: return
         coroutineScope.launch {
             mainPagerState.animateScrollToPage(targetPage)
         }
@@ -290,12 +330,13 @@ fun ZhihuMain(
         }
     }
 
-    val mainTabNavigationTarget = navigationState.mainTabNavigationTarget
     LaunchedEffect(mainTabNavigationTarget, mainTabPages) {
         mainTabNavigationTarget?.let { destination ->
             // 平台适配层会把旧的顶层 route 请求映射到 MainTabs。这里消费该请求，
             // 让 deeplink 等调用方仍能选中 Home/Follow 等 tab，而不是把旧 route 压入返回栈。
-            mainPagerState.scrollToPage(pageIndexForBottomDestination(destination))
+            pageIndexForBottomDestination(destination)?.let { targetPage ->
+                mainPagerState.scrollToPage(targetPage)
+            }
             navigationState.consumeMainTabNavigationTarget(destination)
         }
     }
@@ -310,7 +351,7 @@ fun ZhihuMain(
             } else {
                 startDestination
             }
-            val targetPage = pageIndexForDestination(targetDestination)
+            val targetPage = fallbackPageIndex(targetDestination)
             if (mainPagerState.currentPage != targetPage || mainPagerState.currentPage !in mainTabPages.indices) {
                 mainPagerState.scrollToPage(targetPage)
             }
@@ -472,9 +513,6 @@ fun ZhihuMain(
                 }
                 composable<History> {
                     LegacyLocalHistoryScreen(innerPadding)
-                }
-                composable<OnlineHistory> {
-                    OnlineHistoryScreen()
                 }
                 composable<Account> {
                     AccountSettingScreen(innerPadding)

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/DesktopZhihuMain.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/DesktopZhihuMain.kt
@@ -165,7 +165,6 @@ fun DesktopZhihuMain() {
                 }
             }
             MainTabs -> {
-                mainTabNavigationTarget = Home
                 navigateToMainTabs()
             }
             else -> {

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/DesktopZhihuMain.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/DesktopZhihuMain.kt
@@ -119,6 +119,9 @@ fun DesktopZhihuMain() {
 
     fun navigate(route: NavDestination) {
         when (route) {
+            OnlineHistory -> {
+                navController.navigate(route)
+            }
             is TopLevelDestination -> {
                 mainTabNavigationTarget = route
                 navigateToMainTabs()

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/DesktopZhihuMain.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/DesktopZhihuMain.kt
@@ -26,6 +26,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -119,9 +120,6 @@ fun DesktopZhihuMain() {
 
     fun navigate(route: NavDestination) {
         when (route) {
-            OnlineHistory -> {
-                navController.navigate(route)
-            }
             is TopLevelDestination -> {
                 mainTabNavigationTarget = route
                 navigateToMainTabs()
@@ -187,55 +185,62 @@ fun DesktopZhihuMain() {
         }
     }
 
-    ZhihuMain(
-        navController = navController,
-        navigationState = ZhihuMainNavigationState(
-            mainTabNavigationTarget = mainTabNavigationTarget,
-            navigate = ::navigate,
-            setCurrentMainTabOpenFrom = { currentMainTabOpenFrom = it },
-            consumeMainTabNavigationTarget = { destination ->
-                if (mainTabNavigationTarget == destination) {
-                    mainTabNavigationTarget = null
-                }
-            },
-        ),
-        preferenceState = rememberDesktopZhihuMainPreferenceState(),
-        isDarkTheme = ThemeManager.isDarkTheme(),
-        platformAdapter = ZhihuMainPlatformAdapter(
-            articleEnterTransition = {
-                when (desktopArticleAnswerSwitchState.answerTransitionDirection) {
-                    ArticleAnswerTransitionDirection.VERTICAL_NEXT ->
-                        slideInVertically(tween(300)) { it } + fadeIn(tween(300))
-                    ArticleAnswerTransitionDirection.VERTICAL_PREVIOUS ->
-                        slideInVertically(tween(300)) { -it } + fadeIn(tween(300))
-                    ArticleAnswerTransitionDirection.HORIZONTAL_NEXT ->
-                        slideInHorizontally(tween(300)) { it } + fadeIn(tween(300))
-                    ArticleAnswerTransitionDirection.HORIZONTAL_PREVIOUS ->
-                        slideInHorizontally(tween(300)) { -it } + fadeIn(tween(300))
-                    else -> slideInHorizontally(tween(300)) { it }
-                }
-            },
-            articleExitTransition = {
-                when (desktopArticleAnswerSwitchState.answerTransitionDirection) {
-                    ArticleAnswerTransitionDirection.VERTICAL_NEXT ->
-                        slideOutVertically(tween(300)) { -it } + fadeOut(tween(300))
-                    ArticleAnswerTransitionDirection.VERTICAL_PREVIOUS ->
-                        slideOutVertically(tween(300)) { it } + fadeOut(tween(300))
-                    ArticleAnswerTransitionDirection.HORIZONTAL_NEXT ->
-                        slideOutHorizontally(tween(300)) { -it } + fadeOut(tween(300))
-                    ArticleAnswerTransitionDirection.HORIZONTAL_PREVIOUS ->
-                        slideOutHorizontally(tween(300)) { it } + fadeOut(tween(300))
-                    else -> ExitTransition.None
-                }
-            },
-            article = { article: Article, navEntry ->
-                val articleViewModel: ArticleViewModel = viewModel(navEntry) {
-                    ArticleViewModel(article, httpClient, userMessages)
-                }
-                ArticleScreen(article, articleViewModel)
-            },
-        ),
-    )
+    CompositionLocalProvider(
+        LocalMainTabSelectionRequester provides { destination ->
+            mainTabNavigationTarget = destination
+            navigateToMainTabs()
+        },
+    ) {
+        ZhihuMain(
+            navController = navController,
+            navigationState = ZhihuMainNavigationState(
+                mainTabNavigationTarget = mainTabNavigationTarget,
+                navigate = ::navigate,
+                setCurrentMainTabOpenFrom = { currentMainTabOpenFrom = it },
+                consumeMainTabNavigationTarget = { destination ->
+                    if (mainTabNavigationTarget == destination) {
+                        mainTabNavigationTarget = null
+                    }
+                },
+            ),
+            preferenceState = rememberDesktopZhihuMainPreferenceState(),
+            isDarkTheme = ThemeManager.isDarkTheme(),
+            platformAdapter = ZhihuMainPlatformAdapter(
+                articleEnterTransition = {
+                    when (desktopArticleAnswerSwitchState.answerTransitionDirection) {
+                        ArticleAnswerTransitionDirection.VERTICAL_NEXT ->
+                            slideInVertically(tween(300)) { it } + fadeIn(tween(300))
+                        ArticleAnswerTransitionDirection.VERTICAL_PREVIOUS ->
+                            slideInVertically(tween(300)) { -it } + fadeIn(tween(300))
+                        ArticleAnswerTransitionDirection.HORIZONTAL_NEXT ->
+                            slideInHorizontally(tween(300)) { it } + fadeIn(tween(300))
+                        ArticleAnswerTransitionDirection.HORIZONTAL_PREVIOUS ->
+                            slideInHorizontally(tween(300)) { -it } + fadeIn(tween(300))
+                        else -> slideInHorizontally(tween(300)) { it }
+                    }
+                },
+                articleExitTransition = {
+                    when (desktopArticleAnswerSwitchState.answerTransitionDirection) {
+                        ArticleAnswerTransitionDirection.VERTICAL_NEXT ->
+                            slideOutVertically(tween(300)) { -it } + fadeOut(tween(300))
+                        ArticleAnswerTransitionDirection.VERTICAL_PREVIOUS ->
+                            slideOutVertically(tween(300)) { it } + fadeOut(tween(300))
+                        ArticleAnswerTransitionDirection.HORIZONTAL_NEXT ->
+                            slideOutHorizontally(tween(300)) { -it } + fadeOut(tween(300))
+                        ArticleAnswerTransitionDirection.HORIZONTAL_PREVIOUS ->
+                            slideOutHorizontally(tween(300)) { it } + fadeOut(tween(300))
+                        else -> ExitTransition.None
+                    }
+                },
+                article = { article: Article, navEntry ->
+                    val articleViewModel: ArticleViewModel = viewModel(navEntry) {
+                        ArticleViewModel(article, httpClient, userMessages)
+                    }
+                    ArticleScreen(article, articleViewModel)
+                },
+            ),
+        )
+    }
 }
 
 /**

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/JvmUiRuntimes.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/JvmUiRuntimes.kt
@@ -381,7 +381,7 @@ actual fun rememberAccountSettingsPlatformRuntime(): AccountSettingsRuntime {
             accountState.value = AccountSettingsAccountState()
         },
         appVersionInfo = { "desktop" },
-        selectMainTab = { destination -> requestMainTabSelection?.invoke(destination) },
+        selectMainTab = requestMainTabSelection,
     )
 }
 

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/JvmUiRuntimes.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/JvmUiRuntimes.kt
@@ -36,7 +36,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.zly2006.zhihu.markdown.RenderMarkdown
 import com.github.zly2006.zhihu.navigation.Article
-import com.github.zly2006.zhihu.navigation.TopLevelDestination
 import com.github.zly2006.zhihu.shared.data.RecommendationMode
 import com.github.zly2006.zhihu.shared.desktop.DesktopAccountStore
 import com.github.zly2006.zhihu.shared.desktop.DesktopLoginRequests
@@ -381,7 +380,6 @@ actual fun rememberAccountSettingsPlatformRuntime(): AccountSettingsRuntime {
             accountState.value = AccountSettingsAccountState()
         },
         appVersionInfo = { "desktop" },
-        selectMainTab = { _: TopLevelDestination -> },
     )
 }
 

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/JvmUiRuntimes.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/JvmUiRuntimes.kt
@@ -356,6 +356,7 @@ private fun chooseBlocklistImportFile(): File? {
 actual fun rememberAccountSettingsPlatformRuntime(): AccountSettingsRuntime {
     val store = remember { DesktopAccountStore() }
     val accountState = remember { mutableStateOf(store.load().toAccountSettingsAccountState()) }
+    val requestMainTabSelection = LocalMainTabSelectionRequester.current
     return AccountSettingsRuntime(
         accountState = accountState,
         refreshProfile = {
@@ -380,6 +381,7 @@ actual fun rememberAccountSettingsPlatformRuntime(): AccountSettingsRuntime {
             accountState.value = AccountSettingsAccountState()
         },
         appVersionInfo = { "desktop" },
+        selectMainTab = { destination -> requestMainTabSelection?.invoke(destination) },
     )
 }
 

--- a/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/ui/NativeUiRuntimes.kt
+++ b/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/ui/NativeUiRuntimes.kt
@@ -151,7 +151,6 @@ actual fun rememberAccountSettingsPlatformRuntime(): AccountSettingsRuntime {
             requestQrLoginScan = { userMessages.showMessage("iOS 扫码登录暂未实现") }, // TODO: iOS 扫码登录
             logout = { }, // TODO: iOS 登出
             appVersionInfo = { "iOS" },
-            selectMainTab = { }, // TODO: iOS 主 Tab 切换
         )
     }
 }

--- a/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/ui/NativeUiRuntimes.kt
+++ b/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/ui/NativeUiRuntimes.kt
@@ -143,7 +143,8 @@ actual fun rememberHomeScreenRuntime(recommendationMode: RecommendationMode): Ho
 @Composable
 actual fun rememberAccountSettingsPlatformRuntime(): AccountSettingsRuntime {
     val userMessages = rememberUserMessageSink()
-    return remember(userMessages) {
+    val requestMainTabSelection = LocalMainTabSelectionRequester.current
+    return remember(userMessages, requestMainTabSelection) {
         AccountSettingsRuntime(
             accountState = mutableStateOf(AccountSettingsAccountState()),
             refreshProfile = { }, // TODO: iOS 刷新用户信息
@@ -151,6 +152,7 @@ actual fun rememberAccountSettingsPlatformRuntime(): AccountSettingsRuntime {
             requestQrLoginScan = { userMessages.showMessage("iOS 扫码登录暂未实现") }, // TODO: iOS 扫码登录
             logout = { }, // TODO: iOS 登出
             appVersionInfo = { "iOS" },
+            selectMainTab = { destination -> requestMainTabSelection?.invoke(destination) },
         )
     }
 }

--- a/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/ui/NativeUiRuntimes.kt
+++ b/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/ui/NativeUiRuntimes.kt
@@ -152,7 +152,7 @@ actual fun rememberAccountSettingsPlatformRuntime(): AccountSettingsRuntime {
             requestQrLoginScan = { userMessages.showMessage("iOS 扫码登录暂未实现") }, // TODO: iOS 扫码登录
             logout = { }, // TODO: iOS 登出
             appVersionInfo = { "iOS" },
-            selectMainTab = { destination -> requestMainTabSelection?.invoke(destination) },
+            selectMainTab = requestMainTabSelection,
         )
     }
 }


### PR DESCRIPTION
## 变更

- 修正 `ZhihuMainNavigationInstrumentedTest` 的测试宿主：`setZhihuMainContent()` 重新创建测试用 `NavHostController` 后，会同步回 `activity.navController`，让 `composeRule.activity.navigate(...)` 命中当前屏幕正在使用的主壳 NavHost，而不是 Activity 启动时那套旧 controller。
- 保持 `MainTabs` 的正确语义断言：导航到 `MainTabs` 只表示回到/显示主壳，并保留当前主壳 pager 与 tab 状态；不会静默重置到 `Home`，也不会静默重置到配置的 `startDestination`。
- 因此该 instrumented test 不再断言“回到 `MainTabs` 后重新选中 `Daily`”，而是继续断言当前的 `Follow/推荐` 仍保持选中，同时隐藏 tab 依旧不复活。
- 保留前一提交 `58933972` 的隐藏历史页消费时序修复：隐藏的 `OnlineHistory` 仍作为 supplemental page 保留到 pager 真正落稳后再消费目标。

## 根因说明

这次 CI 剩余失败不是产品代码又把 `MainTabs` 重置到了错误的启动页，而是测试宿主在替换 content 后没有同步 `activity` 当前使用的 `NavHostController`。

结果是：

- 测试画面上的主壳使用的是新 controller；
- `composeRule.activity.navigate(MainTabs, popup = true)` 调到的却是旧 controller；
- 用例随后等待当前 UI 切换到某个 tab，自然会超时。

另外，之前失败 worker 试图把 `MainTabs` 重新映射到 `startDestination` 的思路是错误的，本 PR 不保留那条路径。

## 本轮验证

- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process app:compileLiteDebugAndroidTestKotlin`
- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process assembleLiteDebug`
- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process ktlintFormat`
- `/Users/zhaoliyan/.agents/skills/off-android-avd-ci-debug/scripts/off-avd-ci-debug.sh status`
- `/Users/zhaoliyan/.agents/skills/off-android-avd-ci-debug/scripts/off-avd-ci-debug.sh boot-check`
- `/Users/zhaoliyan/.agents/skills/off-android-avd-ci-debug/scripts/off-avd-ci-debug.sh kill`

## 设备执行说明

- 本轮未执行定向 `ZhihuMainNavigationInstrumentedTest.startDestinationAndHiddenBottomTabsRemainCompatibleWithFlattenedPager`。
- 原因不是编译失败，而是当前公开的 off AVD skill 只提供 `status` / `boot-check` / `kill` 这类短生命周期健康检查入口，没有现成的可复用交互会话来承接一次规范的远端定向 connected instrumentation 运行。
- 因此该用例仍以 PR 上的 instrumented CI 为最终验收。

## 风险

- 这次改动聚焦在 instrumented test 宿主与断言语义，没有改生产导航实现。
- 如果 CI 仍然失败，更可能是 runner 时序或测试同步点仍有遗漏，而不是又回到了“把 `MainTabs` 重置为启动页”的错误设计。

Resolves #444

## CI 加固

- 为避免 `ktlintCheck` / `test` / `assemble*Debug` 共用同一个 Gradle daemon 在 CI runner 上累积 heap 压力，本次把 PR workflow 里的 Gradle 调用统一改成 `--no-daemon -Dkotlin.compiler.execution.strategy=in-process`。
- 本地已用相同参数验证 `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process assembleFullDebug assembleLiteDebug` 通过。


## 清理复审补充

- 按 `$zhihu-pp-ai-slop-cleaner` 复审了本 PR 相对 `origin/master` 的变更，重点检查了主壳导航、测试宿主同步、runtime 注入链路和 workflow 变更里的薄包装层。
- 保留的真实契约：`MainTabs`/顶层 tab 语义、隐藏历史页仍留在主壳 pager 内消费、`ComposeScreenTestHost` 对当前 `NavHostController` 的同步、CI workflow 的 `--no-daemon`/in-process 加固。
- 本次额外 cleanup 提交 `7c27731b` 只压缩了一类无语义包装：把 `LocalMainTabSelectionRequester` 收紧为默认 no-op 的非空 contract，Android/Desktop/iOS runtime 直接把它传给 `AccountSettingsRuntime.selectMainTab`，删除 3 处 `destination -> current?.invoke(destination)` 形式的空转发。

## 本地验证与 daemon 说明

- 原计划本地执行：`app:compileLiteDebugAndroidTestKotlin`、`assembleLiteDebug`、`ktlintFormat`。
- 实际执行中，即使 Gradle 命令已经带 `--no-daemon -Dkotlin.compiler.execution.strategy=in-process`，当前仓库/环境仍会拉起 single-use `GradleDaemon`，不符合本次 cleanup gate。
- 因此本地 Gradle 验证在用户指出后已立即停止；随后执行 `./gradlew --stop || true`，并补充清理残留 `GradleWrapperMain` / `GradleDaemon` / `KotlinCompileDaemon`，最终进程检查已无残留 daemon。
- 本地完成的无 daemon 检查：`git diff --check`。PR 的功能级最终验收继续以 GitHub checks 为准。
