### PR TITLE
feat: 支持一定时间内重复推荐内容屏蔽

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,7 +60,8 @@ jobs:
       - name: Build App
         # Build .apk
         run: |
-          bash ./gradlew assembleFullDebug assembleLiteDebug
+          bash ./gradlew assembleFullDebug
+          bash ./gradlew assembleLiteDebug
         env:
           CI_BUILD_MINIFY: false
       - name: Move files

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ContentFilterSettingsScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ContentFilterSettingsScreenInstrumentedTest.kt
@@ -36,6 +36,9 @@ import com.github.zly2006.zhihu.test.resetAppPreferences
 import com.github.zly2006.zhihu.test.setScreenContent
 import com.github.zly2006.zhihu.ui.PREFERENCE_NAME
 import com.github.zly2006.zhihu.ui.subscreens.ContentFilterSettingsScreen
+import com.github.zly2006.zhihu.viewmodel.filter.DEFAULT_RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS
+import com.github.zly2006.zhihu.viewmodel.filter.ENABLE_RECENTLY_OPENED_CONTENT_FILTER_KEY
+import com.github.zly2006.zhihu.viewmodel.filter.RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS_KEY
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -81,6 +84,13 @@ class ContentFilterSettingsScreenInstrumentedTest {
 
         composeRule.onNodeWithTag(FILTER_FOLLOWED_USER_CONTENT_TAG).performClick()
         assertEquals(true, preferences().getBoolean("filterFollowedUserContent", false))
+        composeRule.onNodeWithTag(ENABLE_RECENTLY_OPENED_CONTENT_FILTER_TAG).performClick()
+        assertEquals(true, preferences().getBoolean(ENABLE_RECENTLY_OPENED_CONTENT_FILTER_KEY, false))
+        composeRule.onNodeWithTag(RECENTLY_OPENED_CONTENT_FILTER_PERIOD_FIELD_TAG, useUnmergedTree = true)
+            .assertTextContains("7 天")
+            .performClick()
+        composeRule.onNodeWithText("30 天").performClick()
+        assertEquals(30, preferences().getInt(RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS_KEY, 0))
 
         composeRule.setScreenContent {
             ContentFilterSettingsScreen()
@@ -92,6 +102,14 @@ class ContentFilterSettingsScreenInstrumentedTest {
         assertEquals(false, preferences().getBoolean("loginForRecommendation", true))
         assertEquals(true, preferences().getBoolean("enableContentFilter", false))
         assertEquals(true, preferences().getBoolean("filterFollowedUserContent", false))
+        assertEquals(true, preferences().getBoolean(ENABLE_RECENTLY_OPENED_CONTENT_FILTER_KEY, false))
+        assertEquals(
+            30,
+            preferences().getInt(
+                RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS_KEY,
+                DEFAULT_RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS,
+            ),
+        )
     }
 
     @Test
@@ -141,6 +159,9 @@ class ContentFilterSettingsScreenInstrumentedTest {
         const val LOGIN_FOR_RECOMMENDATION_TAG = "contentFilterSettings:loginForRecommendation"
         const val ENABLE_CONTENT_FILTER_TAG = "contentFilterSettings:enableContentFilter"
         const val FILTER_FOLLOWED_USER_CONTENT_TAG = "contentFilterSettings:filterFollowedUserContent"
+        const val ENABLE_RECENTLY_OPENED_CONTENT_FILTER_TAG = "contentFilterSettings:enableRecentlyOpenedContentFilter"
+        const val RECENTLY_OPENED_CONTENT_FILTER_PERIOD_FIELD_TAG =
+            "contentFilterSettings:recentlyOpenedContentFilterPeriodField"
         const val BLOCKLIST_TAG = "contentFilterSettings:blocklist"
         const val BLOCKED_FEED_HISTORY_TAG = "contentFilterSettings:blockedFeedHistory"
     }

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ContentFilterSettingsScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ContentFilterSettingsScreenInstrumentedTest.kt
@@ -86,7 +86,8 @@ class ContentFilterSettingsScreenInstrumentedTest {
         assertEquals(true, preferences().getBoolean("filterFollowedUserContent", false))
         composeRule.onNodeWithTag(ENABLE_RECENTLY_OPENED_CONTENT_FILTER_TAG).performClick()
         assertEquals(true, preferences().getBoolean(ENABLE_RECENTLY_OPENED_CONTENT_FILTER_KEY, false))
-        composeRule.onNodeWithTag(RECENTLY_OPENED_CONTENT_FILTER_PERIOD_FIELD_TAG, useUnmergedTree = true)
+        composeRule
+            .onNodeWithTag(RECENTLY_OPENED_CONTENT_FILTER_PERIOD_FIELD_TAG, useUnmergedTree = true)
             .assertTextContains("7 天")
             .performClick()
         composeRule.onNodeWithText("30 天").performClick()

--- a/app/src/main/java/com/github/zly2006/zhihu/MainActivity.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/MainActivity.kt
@@ -69,6 +69,7 @@ import com.github.zly2006.zhihu.nlp.SentenceEmbeddingManager
 import com.github.zly2006.zhihu.shared.filter.ContentOpenEventSupport
 import com.github.zly2006.zhihu.shared.filter.ContentOpenFrom
 import com.github.zly2006.zhihu.shared.filter.TrackedContentIdentity
+import com.github.zly2006.zhihu.shared.filter.cleanupContentOpenEvents
 import com.github.zly2006.zhihu.shared.nlp.KeywordWeightExtractor
 import com.github.zly2006.zhihu.shared.platform.androidSettingsStore
 import com.github.zly2006.zhihu.shared.platform.androidUserMessageSink
@@ -233,9 +234,11 @@ class MainActivity :
         // 应用启动时执行内容过滤数据库清理
         lifecycleScope.launch {
             try {
+                val database = getContentFilterDatabase(this@MainActivity)
                 if (contentFilterSettings().enableContentFilter) {
-                    ContentFilterManager(getContentFilterDatabase(this@MainActivity).contentFilterDao()).cleanupOldData()
+                    ContentFilterManager(database.contentFilterDao()).cleanupOldData()
                 }
+                cleanupContentOpenEvents(database.contentOpenEventDao())
                 Log.i(TAG, "Content filter maintenance cleanup completed")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to perform content filter cleanup", e)

--- a/docs/ai-ui-design-guide.md
+++ b/docs/ai-ui-design-guide.md
@@ -99,6 +99,8 @@ URL 解析集中在 `resolveContent()`。支持知乎问题、回答、文章、
 | `enableQualityFilter` | 质量过滤规则 | 按赞同数、关注数等指标过滤 | 查 content filter settings/runtime |
 | `enableContentFilter` | 智能内容过滤 | 过滤重复出现但未点击内容 | 关闭时相关子统计/开关应弱化 |
 | `filterFollowedUserContent` | 过滤已关注用户内容 | 是否过滤关注用户内容 | 仅智能过滤开启时可操作 |
+| `enableRecentlyOpenedContentFilter` | 过滤已打开内容 | 按打开记录隐藏已看过的问题和回答 | 默认关闭；只影响首页推荐前台过滤 |
+| `recentlyOpenedContentFilterPeriodDays` | 已打开内容过滤周期 | 近期天数，`0` 表示永久 | 仅在已打开内容过滤开启时可操作 |
 | `enableKeywordBlocking` | 关键词屏蔽 | 命中关键词时过滤 | 管理入口在 Blocklist |
 | `enableUserBlocking` | 用户屏蔽 | 命中用户时过滤 | Feed 卡片更多菜单可新增屏蔽 |
 | `enableTopicBlocking` | 主题屏蔽 | 命中主题时过滤 | 阈值项只在开启时显示 |

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/shared/filter/ContentFilterMaintenance.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/shared/filter/ContentFilterMaintenance.android.kt
@@ -25,5 +25,12 @@ import com.github.zly2006.zhihu.viewmodel.filter.getContentFilterDatabase
 @Composable
 actual fun rememberContentFilterMaintenance(): ContentFilterMaintenance {
     val context = LocalContext.current.applicationContext
-    return remember(context) { createContentFilterMaintenance(getContentFilterDatabase(context).contentFilterDao()) }
+    return remember(context) {
+        val database = getContentFilterDatabase(context)
+        createContentFilterMaintenance(
+            dao = database.contentFilterDao(),
+            extraCleanup = { cleanupContentOpenEvents(database.contentOpenEventDao()) },
+            extraClear = { database.contentOpenEventDao().clearAllRecords() },
+        )
+    }
 }

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
@@ -306,6 +306,7 @@ open class SharedAndroidPaginationEnvironment(
             settings = filterSettings,
             contentFilterManager = ContentFilterManager(filterDatabase.contentFilterDao()),
             blockedFeedRecordDao = filterDatabase.blockedFeedRecordDao(),
+            contentOpenEventDao = filterDatabase.contentOpenEventDao(),
         ).filter(items)
         val filteredItems = FeedDisplayFilterPipeline(
             settings = filterSettings,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/shared/filter/ContentFilterSupport.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/shared/filter/ContentFilterSupport.kt
@@ -16,8 +16,10 @@
  */
 
 package com.github.zly2006.zhihu.shared.filter
+
 import androidx.compose.runtime.Composable
 import com.github.zly2006.zhihu.viewmodel.filter.ContentFilterDao
+import com.github.zly2006.zhihu.viewmodel.filter.ContentOpenEventDao
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 
@@ -41,6 +43,8 @@ private const val MAX_CONTENT_FILTER_RECORDS = 10000
 
 fun createContentFilterMaintenance(
     dao: ContentFilterDao,
+    extraCleanup: suspend () -> Unit = {},
+    extraClear: suspend () -> Unit = {},
 ): ContentFilterMaintenance {
     suspend fun loadStats(): ContentFilterStats {
         val totalRecords = dao.getRecordCount()
@@ -63,11 +67,17 @@ fun createContentFilterMaintenance(
             if (dao.getRecordCount() > MAX_CONTENT_FILTER_RECORDS) {
                 dao.clearAllRecords()
             }
+            extraCleanup()
             loadStats()
         },
         clearAllData = {
             dao.clearAllRecords()
+            extraClear()
             loadStats()
         },
     )
+}
+
+suspend fun cleanupContentOpenEvents(dao: ContentOpenEventDao) {
+    dao.maintainLimit()
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/ContentFilterSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/ContentFilterSettingsScreen.kt
@@ -72,6 +72,10 @@ import com.github.zly2006.zhihu.shared.util.Log
 import com.github.zly2006.zhihu.ui.components.SettingItem
 import com.github.zly2006.zhihu.ui.components.SettingItemGroup
 import com.github.zly2006.zhihu.ui.components.SettingItemWithSwitch
+import com.github.zly2006.zhihu.viewmodel.filter.DEFAULT_RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS
+import com.github.zly2006.zhihu.viewmodel.filter.ENABLE_RECENTLY_OPENED_CONTENT_FILTER_KEY
+import com.github.zly2006.zhihu.viewmodel.filter.RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS_KEY
+import com.github.zly2006.zhihu.viewmodel.filter.RECENTLY_OPENED_CONTENT_FILTER_PERMANENT_DAYS
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.milliseconds
@@ -253,6 +257,86 @@ fun ContentFilterSettingsScreen(
                     settingKey = "filterFollowedUserContent",
                     highlightedKey = highlightedSetting,
                 )
+
+                val enableRecentlyOpenedContentFilter = remember {
+                    mutableStateOf(settings.getBoolean(ENABLE_RECENTLY_OPENED_CONTENT_FILTER_KEY, false))
+                }
+                SettingItemWithSwitch(
+                    modifier = Modifier.testTag("contentFilterSettings:enableRecentlyOpenedContentFilter"),
+                    title = { Text("过滤已打开内容") },
+                    description = { Text("隐藏指定时间内已打开过的问题和回答，减少首页重复推荐") },
+                    checked = enableRecentlyOpenedContentFilter.value,
+                    onCheckedChange = {
+                        enableRecentlyOpenedContentFilter.value = it
+                        settings.putBoolean(ENABLE_RECENTLY_OPENED_CONTENT_FILTER_KEY, it)
+                    },
+                    enabled = enableContentFilter.value,
+                    settingKey = ENABLE_RECENTLY_OPENED_CONTENT_FILTER_KEY,
+                    highlightedKey = highlightedSetting,
+                )
+
+                AnimatedVisibility(visible = enableContentFilter.value && enableRecentlyOpenedContentFilter.value) {
+                    val periodDays = remember {
+                        mutableStateOf(
+                            settings.getInt(
+                                RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS_KEY,
+                                DEFAULT_RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS,
+                            ),
+                        )
+                    }
+                    val periodEnabled = enableContentFilter.value && enableRecentlyOpenedContentFilter.value
+                    var expanded by remember { mutableStateOf(false) }
+                    val currentPeriod = recentlyOpenedContentFilterPeriodOptions
+                        .firstOrNull { it.days == periodDays.value }
+                        ?: recentlyOpenedContentFilterPeriodOptions.first { it.days == DEFAULT_RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS }
+
+                    SettingItem(
+                        modifier = Modifier.testTag("contentFilterSettings:recentlyOpenedContentFilterPeriod"),
+                        title = { Text("已打开内容过滤周期") },
+                        description = { Text("超过周期后允许再次出现在首页推荐") },
+                        enabled = periodEnabled,
+                        settingKey = RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS_KEY,
+                        highlightedKey = highlightedSetting,
+                        endAction = {
+                            ExposedDropdownMenuBox(
+                                expanded = expanded,
+                                onExpandedChange = {
+                                    if (periodEnabled) expanded = !expanded
+                                },
+                                modifier = Modifier.width(160.dp),
+                            ) {
+                                OutlinedTextField(
+                                    value = currentPeriod.label,
+                                    onValueChange = { },
+                                    readOnly = true,
+                                    enabled = periodEnabled,
+                                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                                    modifier = Modifier
+                                        .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable, true)
+                                        .testTag("contentFilterSettings:recentlyOpenedContentFilterPeriodField"),
+                                )
+                                ExposedDropdownMenu(
+                                    expanded = expanded,
+                                    onDismissRequest = { expanded = false },
+                                ) {
+                                    recentlyOpenedContentFilterPeriodOptions.forEach { option ->
+                                        DropdownMenuItem(
+                                            text = { Text(option.label) },
+                                            onClick = {
+                                                periodDays.value = option.days
+                                                settings.putInt(
+                                                    RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS_KEY,
+                                                    option.days,
+                                                )
+                                                expanded = false
+                                            },
+                                        )
+                                    }
+                                }
+                            }
+                        },
+                    )
+                }
             }
 
             SettingItemGroup {
@@ -541,3 +625,16 @@ fun ContentFilterSettingsScreen(
         }
     }
 }
+
+private data class RecentlyOpenedContentFilterPeriodOption(
+    val days: Int,
+    val label: String,
+)
+
+private val recentlyOpenedContentFilterPeriodOptions = listOf(
+    RecentlyOpenedContentFilterPeriodOption(1, "1 天"),
+    RecentlyOpenedContentFilterPeriodOption(DEFAULT_RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS, "7 天"),
+    RecentlyOpenedContentFilterPeriodOption(30, "30 天"),
+    RecentlyOpenedContentFilterPeriodOption(90, "90 天"),
+    RecentlyOpenedContentFilterPeriodOption(RECENTLY_OPENED_CONTENT_FILTER_PERMANENT_DAYS, "永久"),
+)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterDatabase.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterDatabase.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.Dispatchers
 
 @Database(
     entities = [ContentViewRecord::class, BlockedKeyword::class, BlockedUser::class, BlockedContentRecord::class, BlockedTopic::class, BlockedFeedRecord::class, ContentOpenEvent::class],
-    version = 6,
+    version = 7,
     exportSchema = false,
 )
 @ConstructedBy(ContentFilterDatabaseConstructor::class)
@@ -54,6 +54,17 @@ abstract class ContentFilterDatabase : RoomDatabase() {
 expect object ContentFilterDatabaseConstructor : RoomDatabaseConstructor<ContentFilterDatabase>
 
 expect fun getContentFilterDatabase(): ContentFilterDatabase
+
+private val migration6To7 = object : Migration(6, 7) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            """
+            CREATE INDEX IF NOT EXISTS `index_${ContentOpenEvent.TABLE_NAME}_questionId_openedAt`
+            ON `${ContentOpenEvent.TABLE_NAME}` (`questionId`, `openedAt`)
+            """.trimIndent(),
+        )
+    }
+}
 
 private val migration2To3 = object : Migration(2, 3) {
     override fun migrate(connection: SQLiteConnection) {
@@ -152,7 +163,7 @@ private val migration5To6 = object : Migration(5, 6) {
 fun buildContentFilterDatabase(
     builder: Builder<ContentFilterDatabase>,
 ): ContentFilterDatabase = builder
-    .addMigrations(migration2To3, migration3To4, migration4To5, migration5To6)
+    .addMigrations(migration2To3, migration3To4, migration4To5, migration5To6, migration6To7)
     .fallbackToDestructiveMigration(true)
     .applyPlatformDriver()
     .setQueryCoroutineContext(Dispatchers.Default)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
@@ -29,11 +29,19 @@ import com.github.zly2006.zhihu.shared.data.target
 import com.github.zly2006.zhihu.shared.filter.ContentOpenEventSupport
 import com.github.zly2006.zhihu.shared.platform.SettingsStore
 import kotlinx.serialization.json.Json
+import kotlin.time.Clock
+
+const val ENABLE_RECENTLY_OPENED_CONTENT_FILTER_KEY = "enableRecentlyOpenedContentFilter"
+const val RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS_KEY = "recentlyOpenedContentFilterPeriodDays"
+const val RECENTLY_OPENED_CONTENT_FILTER_PERMANENT_DAYS = 0
+const val DEFAULT_RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS = 7
 
 class ForegroundReadFilterPipeline(
     private val settings: FeedFilterSettings,
     private val contentFilterManager: ContentFilterManager,
     private val blockedFeedRecordDao: BlockedFeedRecordDao,
+    private val contentOpenEventDao: ContentOpenEventDao? = null,
+    private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
     suspend fun filter(items: List<FeedDisplayItem>): List<FeedDisplayItem> {
         if (settings.reverseBlock || !settings.enableContentFilter) {
@@ -44,6 +52,7 @@ class ForegroundReadFilterPipeline(
         val viewedContentIds = contentFilterManager.getAlreadyViewedContentIds(
             itemIdentityPairs.map { (_, identity) -> identity.type to identity.id },
         )
+        val openedContentFilter = resolveOpenedContentFilter(items)
 
         val keptItems = mutableListOf<FeedDisplayItem>()
         val blockedItems = mutableListOf<Pair<FilterableContent, String>>()
@@ -55,13 +64,15 @@ class ForegroundReadFilterPipeline(
                 ?.author
                 ?.isFollowing ?: false
             val isLowQualityAndroidFeed = isLowQualityForegroundFeed(item)
+            val openedReason = openedContentFilter?.blockedReason(item)
 
-            if (isFollowing || (!isViewed && !isLowQualityAndroidFeed)) {
+            if (isFollowing || (!isViewed && !isLowQualityAndroidFeed && openedReason == null)) {
                 keptItems.add(item)
                 contentFilterManager.recordContentView(identity.type, identity.id)
             } else {
+                val reason = openedReason ?: "已读过且未关注作者"
                 blockedItems.add(
-                    item.toFilterableContent(identity, DataHolder.DummyContent) to "已读过且未关注作者",
+                    item.toFilterableContent(identity, DataHolder.DummyContent) to reason,
                 )
             }
         }
@@ -72,12 +83,101 @@ class ForegroundReadFilterPipeline(
 
         return keptItems
     }
+
+    private suspend fun resolveOpenedContentFilter(items: List<FeedDisplayItem>): OpenedContentFilter? {
+        val dao = contentOpenEventDao ?: return null
+        if (!settings.enableRecentlyOpenedContentFilter) return null
+
+        val itemCandidates = items.associateWith { it.resolveOpenedContentFilterCandidates() }
+        val contentKeys = itemCandidates
+            .values
+            .flatMap { candidates -> candidates.identities.map { "${it.type}:${it.id}" } }
+            .distinct()
+        val questionIds = itemCandidates
+            .values
+            .flatMap { it.questionIds }
+            .distinct()
+        if (contentKeys.isEmpty() && questionIds.isEmpty()) return null
+
+        val openedAfter = settings.openedAfterMillis(nowMillis())
+        val openedContentKeys = if (contentKeys.isEmpty()) {
+            emptySet()
+        } else {
+            dao.getOpenedContentKeysByKeysSince(contentKeys, openedAfter).toSet()
+        }
+        val openedQuestionIds = if (questionIds.isEmpty()) {
+            emptySet()
+        } else {
+            dao.getOpenedQuestionIdsSince(questionIds, openedAfter).toSet()
+        }
+
+        return OpenedContentFilter(
+            candidatesByItem = itemCandidates,
+            openedContentKeys = openedContentKeys,
+            openedQuestionIds = openedQuestionIds,
+            reason = settings.openedContentBlockReason(),
+        )
+    }
 }
 
 private fun isLowQualityForegroundFeed(item: FeedDisplayItem): Boolean =
     item.details.contains("小时前") ||
         item.details.contains("分钟前") ||
         item.details.contains("浏览")
+
+private data class OpenedContentFilterCandidates(
+    val identities: List<FeedContentIdentity>,
+    val questionIds: List<Long>,
+)
+
+private data class OpenedContentFilter(
+    val candidatesByItem: Map<FeedDisplayItem, OpenedContentFilterCandidates>,
+    val openedContentKeys: Set<String>,
+    val openedQuestionIds: Set<Long>,
+    val reason: String,
+) {
+    fun blockedReason(item: FeedDisplayItem): String? {
+        val candidates = candidatesByItem[item] ?: return null
+        val hasOpenedContent = candidates.identities.any { "${it.type}:${it.id}" in openedContentKeys }
+        val hasOpenedQuestion = candidates.questionIds.any { it in openedQuestionIds }
+        return if (hasOpenedContent || hasOpenedQuestion) reason else null
+    }
+}
+
+private fun FeedDisplayItem.resolveOpenedContentFilterCandidates(): OpenedContentFilterCandidates {
+    val identities = linkedSetOf<FeedContentIdentity>()
+    val questionIds = linkedSetOf<Long>()
+    val primaryIdentity = resolveContentIdentity()
+    if (primaryIdentity.type == ContentType.ANSWER || primaryIdentity.type == ContentType.QUESTION) {
+        identities.add(primaryIdentity)
+    }
+    val target = feed?.target
+    if (target is com.github.zly2006.zhihu.shared.data.Feed.AnswerTarget) {
+        identities.add(FeedContentIdentity(ContentType.ANSWER, target.id.toString()))
+        questionIds.add(target.question.id)
+    }
+    if (target is com.github.zly2006.zhihu.shared.data.Feed.QuestionTarget) {
+        identities.add(FeedContentIdentity(ContentType.QUESTION, target.id.toString()))
+        questionIds.add(target.id)
+    }
+    return OpenedContentFilterCandidates(
+        identities = identities.toList(),
+        questionIds = questionIds.toList(),
+    )
+}
+
+private fun FeedFilterSettings.openedAfterMillis(nowMillis: Long): Long {
+    val periodDays = recentlyOpenedContentFilterPeriodDays
+    if (periodDays <= RECENTLY_OPENED_CONTENT_FILTER_PERMANENT_DAYS) return 0L
+    return nowMillis - periodDays.toLong() * 24L * 60L * 60L * 1000L
+}
+
+private fun FeedFilterSettings.openedContentBlockReason(): String =
+    if (recentlyOpenedContentFilterPeriodDays <= RECENTLY_OPENED_CONTENT_FILTER_PERMANENT_DAYS) {
+        "已打开过的内容（永久）"
+    } else {
+        "已打开过的内容（${recentlyOpenedContentFilterPeriodDays}天内）"
+    }
 
 data class FeedContentFilterResult(
     val kept: List<FilterableContent>,
@@ -461,6 +561,8 @@ data class FeedFilterSettings(
     val enableContentFilter: Boolean = true,
     val reverseBlock: Boolean = false,
     val filterFollowedUserContent: Boolean = false,
+    val enableRecentlyOpenedContentFilter: Boolean = false,
+    val recentlyOpenedContentFilterPeriodDays: Int = DEFAULT_RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS,
     val enableKeywordBlocking: Boolean = true,
     val enableNlpBlocking: Boolean = true,
     val nlpSimilarityThreshold: Double = 0.8,
@@ -474,6 +576,11 @@ fun SettingsStore.toFeedFilterSettings(): FeedFilterSettings = FeedFilterSetting
     enableContentFilter = getBoolean("enableContentFilter", true),
     reverseBlock = getBoolean("reverseBlock", false),
     filterFollowedUserContent = getBoolean("filterFollowedUserContent", false),
+    enableRecentlyOpenedContentFilter = getBoolean(ENABLE_RECENTLY_OPENED_CONTENT_FILTER_KEY, false),
+    recentlyOpenedContentFilterPeriodDays = getInt(
+        RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS_KEY,
+        DEFAULT_RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS,
+    ),
     enableKeywordBlocking = getBoolean("enableKeywordBlocking", true),
     enableNlpBlocking = getBoolean("enableNLPBlocking", true),
     nlpSimilarityThreshold = getFloat("nlpSimilarityThreshold", 0.8f).toDouble(),

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
@@ -48,11 +48,14 @@ class ForegroundReadFilterPipeline(
             return items
         }
 
-        val itemIdentityPairs = items.map { item -> item to item.resolveContentIdentity() }
+        val itemIdentityPairs = items.map { item ->
+            val identity = item.resolveContentIdentity()
+            item to identity
+        }
         val viewedContentIds = contentFilterManager.getAlreadyViewedContentIds(
             itemIdentityPairs.map { (_, identity) -> identity.type to identity.id },
         )
-        val openedContentFilter = resolveOpenedContentFilter(items)
+        val openedContentFilter = resolveOpenedContentFilter(itemIdentityPairs)
 
         val keptItems = mutableListOf<FeedDisplayItem>()
         val blockedItems = mutableListOf<Pair<FilterableContent, String>>()
@@ -84,11 +87,15 @@ class ForegroundReadFilterPipeline(
         return keptItems
     }
 
-    private suspend fun resolveOpenedContentFilter(items: List<FeedDisplayItem>): OpenedContentFilter? {
+    private suspend fun resolveOpenedContentFilter(
+        itemIdentityPairs: List<Pair<FeedDisplayItem, FeedContentIdentity>>,
+    ): OpenedContentFilter? {
         val dao = contentOpenEventDao ?: return null
         if (!settings.enableRecentlyOpenedContentFilter) return null
 
-        val itemCandidates = items.associateWith { it.resolveOpenedContentFilterCandidates() }
+        val itemCandidates = itemIdentityPairs.associate { (item, identity) ->
+            item to item.resolveOpenedContentFilterCandidates(identity)
+        }
         val contentKeys = itemCandidates
             .values
             .flatMap { candidates -> candidates.identities.map { "${it.type}:${it.id}" } }
@@ -144,10 +151,11 @@ private data class OpenedContentFilter(
     }
 }
 
-private fun FeedDisplayItem.resolveOpenedContentFilterCandidates(): OpenedContentFilterCandidates {
+private fun FeedDisplayItem.resolveOpenedContentFilterCandidates(
+    primaryIdentity: FeedContentIdentity,
+): OpenedContentFilterCandidates {
     val identities = linkedSetOf<FeedContentIdentity>()
     val questionIds = linkedSetOf<Long>()
-    val primaryIdentity = resolveContentIdentity()
     if (primaryIdentity.type == ContentType.ANSWER || primaryIdentity.type == ContentType.QUESTION) {
         identities.add(primaryIdentity)
     }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentOpenEvent.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentOpenEvent.kt
@@ -31,6 +31,7 @@ import kotlin.time.Clock
     indices = [
         Index(value = ["contentType", "contentId"]),
         Index(value = ["openedAt"]),
+        Index(value = ["questionId", "openedAt"]),
     ],
 )
 data class ContentOpenEvent(
@@ -44,6 +45,7 @@ data class ContentOpenEvent(
 ) {
     companion object {
         const val TABLE_NAME = "content_open_events"
+        const val MAX_RECORDS = 10_000
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentOpenEventDao.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentOpenEventDao.kt
@@ -35,4 +35,30 @@ interface ContentOpenEventDao {
         """,
     )
     suspend fun getOpenedContentKeysByKeys(keys: List<String>): List<String>
+
+    @Query(
+        """
+        SELECT contentType || ':' || contentId
+        FROM ${ContentOpenEvent.TABLE_NAME}
+        WHERE (contentType || ':' || contentId) IN (:keys)
+        AND openedAt >= :openedAfter
+        """,
+    )
+    suspend fun getOpenedContentKeysByKeysSince(
+        keys: List<String>,
+        openedAfter: Long,
+    ): List<String>
+
+    @Query(
+        """
+        SELECT DISTINCT questionId
+        FROM ${ContentOpenEvent.TABLE_NAME}
+        WHERE questionId IN (:questionIds)
+        AND openedAt >= :openedAfter
+        """,
+    )
+    suspend fun getOpenedQuestionIdsSince(
+        questionIds: List<Long>,
+        openedAfter: Long,
+    ): List<Long>
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentOpenEventDao.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentOpenEventDao.kt
@@ -61,4 +61,19 @@ interface ContentOpenEventDao {
         questionIds: List<Long>,
         openedAfter: Long,
     ): List<Long>
+
+    @Query("DELETE FROM ${ContentOpenEvent.TABLE_NAME}")
+    suspend fun clearAllRecords()
+
+    @Query(
+        """
+        DELETE FROM ${ContentOpenEvent.TABLE_NAME}
+        WHERE id NOT IN (
+            SELECT id FROM ${ContentOpenEvent.TABLE_NAME}
+            ORDER BY openedAt DESC
+            LIMIT :maxRecords
+        )
+    """,
+    )
+    suspend fun maintainLimit(maxRecords: Int = ContentOpenEvent.MAX_RECORDS)
 }

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/shared/filter/ContentFilterMaintenance.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/shared/filter/ContentFilterMaintenance.jvm.kt
@@ -24,4 +24,11 @@ import com.github.zly2006.zhihu.viewmodel.filter.getContentFilterDatabase
 
 @Composable
 actual fun rememberContentFilterMaintenance(): ContentFilterMaintenance =
-    remember { createContentFilterMaintenance(getContentFilterDatabase(desktopContentFilterDatabaseFile()).contentFilterDao()) }
+    remember {
+        val database = getContentFilterDatabase(desktopContentFilterDatabaseFile())
+        createContentFilterMaintenance(
+            dao = database.contentFilterDao(),
+            extraCleanup = { cleanupContentOpenEvents(database.contentOpenEventDao()) },
+            extraClear = { database.contentOpenEventDao().clearAllRecords() },
+        )
+    }

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
@@ -225,6 +225,7 @@ class DesktopPaginationEnvironment(
             settings = settings,
             contentFilterManager = ContentFilterManager(contentFilterDb.contentFilterDao()),
             blockedFeedRecordDao = contentFilterDb.blockedFeedRecordDao(),
+            contentOpenEventDao = contentFilterDb.contentOpenEventDao(),
         ).filter(items)
         val filteredItems = FeedDisplayFilterPipeline(
             settings = settings,

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedFilterSettingsTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedFilterSettingsTest.kt
@@ -28,6 +28,8 @@ class FeedFilterSettingsTest {
             "enableContentFilter" to false,
             "reverseBlock" to true,
             "filterFollowedUserContent" to true,
+            ENABLE_RECENTLY_OPENED_CONTENT_FILTER_KEY to true,
+            RECENTLY_OPENED_CONTENT_FILTER_PERIOD_DAYS_KEY to 30,
             "enableKeywordBlocking" to false,
             "enableNLPBlocking" to false,
             "nlpSimilarityThreshold" to 0.65f,
@@ -43,6 +45,8 @@ class FeedFilterSettingsTest {
         assertEquals(false, settings.enableContentFilter)
         assertEquals(true, settings.reverseBlock)
         assertEquals(true, settings.filterFollowedUserContent)
+        assertEquals(true, settings.enableRecentlyOpenedContentFilter)
+        assertEquals(30, settings.recentlyOpenedContentFilterPeriodDays)
         assertEquals(false, settings.enableKeywordBlocking)
         assertEquals(false, settings.enableNlpBlocking)
         assertEquals(0.65, settings.nlpSimilarityThreshold, 0.0001)

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ForegroundReadFilterPipelineTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ForegroundReadFilterPipelineTest.kt
@@ -19,11 +19,13 @@ package com.github.zly2006.zhihu.viewmodel.filter
 
 import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.ArticleType
+import com.github.zly2006.zhihu.navigation.Question
 import com.github.zly2006.zhihu.shared.data.CommonFeed
 import com.github.zly2006.zhihu.shared.data.Feed
 import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
 import com.github.zly2006.zhihu.shared.data.Person
 import com.github.zly2006.zhihu.shared.data.toFeedDisplayItemNavDestinationJson
+import com.github.zly2006.zhihu.shared.filter.ContentOpenFrom
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.io.path.createTempDirectory
@@ -33,11 +35,24 @@ import kotlin.test.assertEquals
 class ForegroundReadFilterPipelineTest {
     @Test
     fun disabledOrReverseBlockReturnsItemsWithoutRecording() = runTest {
-        val fixture = fixture(settings = FeedFilterSettings(enableContentFilter = false))
-        val item = item("item", 1)
+        val fixture = fixture(
+            settings = FeedFilterSettings(
+                enableContentFilter = false,
+                enableRecentlyOpenedContentFilter = true,
+            ),
+        )
+        val item = answerItem("item", 1)
+        fixture.database.contentOpenEventDao().insert(opened(ContentType.ANSWER, "1", openedAt = NOW - DAY))
 
         assertEquals(listOf(item), fixture.pipeline().filter(listOf(item)))
         assertEquals(0, fixture.database.contentFilterDao().getRecordCount())
+        assertEquals(
+            emptyList(),
+            fixture.database
+                .blockedFeedRecordDao()
+                .observeAll()
+                .first(),
+        )
         fixture.database.close()
     }
 
@@ -100,6 +115,88 @@ class ForegroundReadFilterPipelineTest {
     }
 
     @Test
+    fun blocksRecentlyOpenedAnswerAndQuestionButKeepsExpiredRecords() = runTest {
+        val fixture = fixture(
+            settings = FeedFilterSettings(
+                enableRecentlyOpenedContentFilter = true,
+                recentlyOpenedContentFilterPeriodDays = 7,
+            ),
+            nowMillis = NOW,
+        )
+        fixture.database.contentOpenEventDao().insert(opened(ContentType.ANSWER, "1", openedAt = NOW - DAY))
+        fixture.database.contentOpenEventDao().insert(opened(ContentType.QUESTION, "2", openedAt = NOW - DAY))
+        fixture.database.contentOpenEventDao().insert(opened(ContentType.ANSWER, "3", openedAt = NOW - 8 * DAY))
+
+        val result = fixture.pipeline().filter(
+            listOf(
+                answerItem("recent answer", 1),
+                questionItem("recent question", 2),
+                answerItem("expired answer", 3),
+            ),
+        )
+
+        assertEquals(listOf("expired answer"), result.map { it.title })
+        assertEquals(
+            listOf("已打开过的内容（7天内）", "已打开过的内容（7天内）"),
+            fixture.database
+                .blockedFeedRecordDao()
+                .observeAll()
+                .first()
+                .map { it.blockedReason },
+        )
+        fixture.database.close()
+    }
+
+    @Test
+    fun blocksAnswerWhenItsQuestionWasOpenedThroughAnotherAnswer() = runTest {
+        val fixture = fixture(
+            settings = FeedFilterSettings(enableRecentlyOpenedContentFilter = true),
+            nowMillis = NOW,
+        )
+        fixture.database.contentOpenEventDao().insert(
+            opened(ContentType.ANSWER, "10", questionId = 99, openedAt = NOW - DAY),
+        )
+
+        val result = fixture.pipeline().filter(listOf(answerFeedItem("same question answer", answerId = 11, questionId = 99)))
+
+        assertEquals(emptyList(), result)
+        assertEquals(
+            listOf("已打开过的内容（7天内）"),
+            fixture.database
+                .blockedFeedRecordDao()
+                .observeAll()
+                .first()
+                .map { it.blockedReason },
+        )
+        fixture.database.close()
+    }
+
+    @Test
+    fun permanentOpenedContentFilterIgnoresOpenedAt() = runTest {
+        val fixture = fixture(
+            settings = FeedFilterSettings(
+                enableRecentlyOpenedContentFilter = true,
+                recentlyOpenedContentFilterPeriodDays = RECENTLY_OPENED_CONTENT_FILTER_PERMANENT_DAYS,
+            ),
+            nowMillis = NOW,
+        )
+        fixture.database.contentOpenEventDao().insert(opened(ContentType.ANSWER, "1", openedAt = 1L))
+
+        val result = fixture.pipeline().filter(listOf(answerItem("old answer", 1)))
+
+        assertEquals(emptyList(), result)
+        assertEquals(
+            listOf("已打开过的内容（永久）"),
+            fixture.database
+                .blockedFeedRecordDao()
+                .observeAll()
+                .first()
+                .map { it.blockedReason },
+        )
+        fixture.database.close()
+    }
+
+    @Test
     fun contentExposureRecorderMarksInteractionAndCleanup() = runTest {
         val fixture = fixture()
 
@@ -122,16 +219,20 @@ class ForegroundReadFilterPipelineTest {
         fixture.database.close()
     }
 
-    private fun fixture(settings: FeedFilterSettings = FeedFilterSettings()): Fixture {
+    private fun fixture(
+        settings: FeedFilterSettings = FeedFilterSettings(),
+        nowMillis: Long = NOW,
+    ): Fixture {
         val database = getContentFilterDatabase(
             createTempDirectory("foreground-read-filter-pipeline").resolve("content-filter.db").toFile(),
         )
-        return Fixture(database, settings)
+        return Fixture(database, settings, nowMillis)
     }
 
     private class Fixture(
         val database: ContentFilterDatabase,
         val settings: FeedFilterSettings,
+        val nowMillis: Long,
     ) {
         val manager = ContentFilterManager(database.contentFilterDao())
 
@@ -139,6 +240,8 @@ class ForegroundReadFilterPipelineTest {
             settings = settings,
             contentFilterManager = manager,
             blockedFeedRecordDao = database.blockedFeedRecordDao(),
+            contentOpenEventDao = database.contentOpenEventDao(),
+            nowMillis = { nowMillis },
         )
     }
 
@@ -162,6 +265,69 @@ class ForegroundReadFilterPipelineTest {
         navDestinationJson = Article(type = ArticleType.Article, id = id).toFeedDisplayItemNavDestinationJson(),
     )
 
+    private fun answerItem(
+        title: String,
+        id: Long,
+    ): FeedDisplayItem = FeedDisplayItem(
+        title = title,
+        summary = null,
+        details = "",
+        feed = null,
+        navDestinationJson = Article(type = ArticleType.Answer, id = id).toFeedDisplayItemNavDestinationJson(),
+    )
+
+    private fun questionItem(
+        title: String,
+        id: Long,
+    ): FeedDisplayItem = FeedDisplayItem(
+        title = title,
+        summary = null,
+        details = "",
+        feed = null,
+        navDestinationJson = Question(questionId = id, title = title).toFeedDisplayItemNavDestinationJson(),
+    )
+
+    private fun answerFeedItem(
+        title: String,
+        answerId: Long,
+        questionId: Long,
+    ): FeedDisplayItem = FeedDisplayItem(
+        title = title,
+        summary = null,
+        details = "",
+        feed = CommonFeed(
+            target = Feed.AnswerTarget(
+                id = answerId,
+                url = "",
+                author = person(false),
+                question = questionTarget(title, questionId),
+            ),
+        ),
+    )
+
+    private fun questionTarget(
+        title: String,
+        id: Long,
+    ): Feed.QuestionTarget = Feed.QuestionTarget(
+        id = id,
+        _title = title,
+        url = "",
+        type = "question",
+    )
+
+    private fun opened(
+        contentType: String,
+        contentId: String,
+        questionId: Long? = null,
+        openedAt: Long,
+    ): ContentOpenEvent = ContentOpenEvent(
+        contentType = contentType,
+        contentId = contentId,
+        questionId = questionId,
+        openFrom = ContentOpenFrom.HOME_FEED,
+        openedAt = openedAt,
+    )
+
     private fun person(isFollowing: Boolean): Person = Person(
         id = "author-id",
         url = "",
@@ -171,4 +337,9 @@ class ForegroundReadFilterPipelineTest {
         avatarUrl = "",
         isFollowing = isFollowing,
     )
+
+    private companion object {
+        const val DAY = 24L * 60L * 60L * 1000L
+        const val NOW = 20L * DAY
+    }
 }

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ForegroundReadFilterPipelineTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ForegroundReadFilterPipelineTest.kt
@@ -57,6 +57,28 @@ class ForegroundReadFilterPipelineTest {
     }
 
     @Test
+    fun disabledRecentlyOpenedContentFilterLetsOpenedContentPass() = runTest {
+        val fixture = fixture(
+            settings = FeedFilterSettings(
+                enableContentFilter = true,
+                enableRecentlyOpenedContentFilter = false,
+            ),
+        )
+        val item = answerItem("opened answer", 1)
+        fixture.database.contentOpenEventDao().insert(opened(ContentType.ANSWER, "1", openedAt = NOW - DAY))
+
+        assertEquals(listOf(item), fixture.pipeline().filter(listOf(item)))
+        assertEquals(
+            emptyList(),
+            fixture.database
+                .blockedFeedRecordDao()
+                .observeAll()
+                .first(),
+        )
+        fixture.database.close()
+    }
+
+    @Test
     fun keepsUnviewedNormalItemAndRecordsView() = runTest {
         val fixture = fixture()
         val item = item("item", 1, details = "文章 · 100 赞")
@@ -172,6 +194,30 @@ class ForegroundReadFilterPipelineTest {
     }
 
     @Test
+    fun blocksAnswerWhenItsQuestionWasOpenedDirectly() = runTest {
+        val fixture = fixture(
+            settings = FeedFilterSettings(enableRecentlyOpenedContentFilter = true),
+            nowMillis = NOW,
+        )
+        fixture.database.contentOpenEventDao().insert(
+            opened(ContentType.QUESTION, "99", openedAt = NOW - DAY),
+        )
+
+        val result = fixture.pipeline().filter(listOf(answerFeedItem("same opened question", answerId = 11, questionId = 99)))
+
+        assertEquals(emptyList(), result)
+        assertEquals(
+            listOf("已打开过的内容（7天内）"),
+            fixture.database
+                .blockedFeedRecordDao()
+                .observeAll()
+                .first()
+                .map { it.blockedReason },
+        )
+        fixture.database.close()
+    }
+
+    @Test
     fun permanentOpenedContentFilterIgnoresOpenedAt() = runTest {
         val fixture = fixture(
             settings = FeedFilterSettings(
@@ -216,6 +262,23 @@ class ForegroundReadFilterPipelineTest {
         )
         fixture.manager.cleanupOldData()
         assertEquals(null, fixture.database.contentFilterDao().getViewRecord("article:old"))
+        fixture.database.close()
+    }
+
+    @Test
+    fun contentOpenEventMaintainLimitKeepsNewestRows() = runTest {
+        val fixture = fixture()
+        fixture.database.contentOpenEventDao().insert(opened(ContentType.ANSWER, "older", openedAt = 1L))
+        fixture.database.contentOpenEventDao().insert(opened(ContentType.ANSWER, "newer", openedAt = 2L))
+
+        fixture.database.contentOpenEventDao().maintainLimit(maxRecords = 1)
+
+        assertEquals(
+            listOf("answer:newer"),
+            fixture.database
+                .contentOpenEventDao()
+                .getOpenedContentKeysByKeys(listOf("answer:older", "answer:newer")),
+        )
         fixture.database.close()
     }
 

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ForegroundReadFilterPipelineTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ForegroundReadFilterPipelineTest.kt
@@ -200,7 +200,7 @@ class ForegroundReadFilterPipelineTest {
             nowMillis = NOW,
         )
         fixture.database.contentOpenEventDao().insert(
-            opened(ContentType.QUESTION, "99", openedAt = NOW - DAY),
+            opened(ContentType.QUESTION, "99", questionId = 99, openedAt = NOW - DAY),
         )
 
         val result = fixture.pipeline().filter(listOf(answerFeedItem("same opened question", answerId = 11, questionId = 99)))

--- a/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/NativeFilterSupport.kt
+++ b/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/NativeFilterSupport.kt
@@ -81,6 +81,10 @@ private val emptyContentOpenEventDao = object : ContentOpenEventDao {
         questionIds: List<Long>,
         openedAfter: Long,
     ): List<Long> = emptyList()
+
+    override suspend fun clearAllRecords() = Unit
+
+    override suspend fun maintainLimit(maxRecords: Int) = Unit
 }
 
 private val emptyBlockedKeywordDao = object : BlockedKeywordDao {

--- a/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/NativeFilterSupport.kt
+++ b/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/NativeFilterSupport.kt
@@ -71,6 +71,16 @@ private val emptyContentOpenEventDao = object : ContentOpenEventDao {
     override suspend fun insert(event: ContentOpenEvent): Long = 0L
 
     override suspend fun getOpenedContentKeysByKeys(keys: List<String>): List<String> = emptyList()
+
+    override suspend fun getOpenedContentKeysByKeysSince(
+        keys: List<String>,
+        openedAfter: Long,
+    ): List<String> = emptyList()
+
+    override suspend fun getOpenedQuestionIdsSince(
+        questionIds: List<Long>,
+        openedAfter: Long,
+    ): List<Long> = emptyList()
 }
 
 private val emptyBlockedKeywordDao = object : BlockedKeywordDao {


### PR DESCRIPTION
## 概要
- 为内容过滤设置新增“过滤已打开内容”和过滤周期选项，支持 1 天 / 7 天 / 30 天 / 90 天 / 永久
- 基于 `ContentOpenEventDao` 的已打开记录，在首页前台过滤阶段屏蔽指定周期内已打开过的问题和回答
- 补充 JVM / Android 测试与设计文档映射

## 详细改动
- `ForegroundReadFilterPipeline` 新增已打开内容过滤逻辑，复用 `ContentOpenEventSupport` 与 Room 打开记录
- `ContentOpenEventDao` 增加按时间窗口查询内容键和问题 ID 的接口
- Android / JVM 分页环境把 `contentOpenEventDao` 注入前台过滤流程，native 空实现同步补齐接口
- 设置页新增开关与周期下拉框，默认仍为关闭，不改动其他过滤默认值

## Cleanup 结果
已按 `$zhihu-pp-ai-slop-cleaner` 做 focused cleanup pass：
- 执行低调用扫描：`python3 .agents/skills/zhihu-pp-ai-slop-cleaner/scripts/scan_low_call_functions.py --root . --max-calls 2 --output /tmp/zhihu_low_functions.tsv`
- 执行相似函数扫描：`python3 .agents/skills/zhihu-pp-ai-slop-cleaner/scripts/find_similar_kotlin_functions.py --root . --threshold 0.82 --output /tmp/zhihu_similar_functions.tsv`
- 本次改动文件未命中新引入的薄 helper / 纯转发包装 / 重复 helper
- 保留的新增结构仅包括有实际语义的候选集与周期选项类型，没有额外抽象层

## 本地审查
已完成：
- `git diff --check`
- `git diff --stat`
- `rg -n "TODO|unused|deprecated wrapper|pure forwarding" app shared desktopApp -g '*.kt'`
- 逐文件静态审查新增的 DAO 查询、过滤候选集、设置项状态与测试覆盖

## 验证策略
- 按最新执行策略，未继续本地 Gradle 验证
- 原因：Gradle 9 即使传 `--no-daemon` 仍会 fork single-use `GradleDaemon`，与当前并行工作流冲突
- 已执行 `./gradlew --stop || true` 清理 issue-387 相关 daemon；当前没有该 worktree 的残留 daemon
- 后续以 GitHub CI 作为 Gradle 构建 / 测试验证来源

## UI / 截图
- 本 PR 涉及设置页 UI，但当前未提供最终截图
- 原因：按最新策略停止本地 Gradle / APK 验证；且此前 `off` AVD `boot-check` early exit，未能产出可用远端截图

## Issue
Resolves #387
