### PR TITLE
feat: 增加稍后再看功能

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
@@ -159,6 +159,9 @@ data object Notification : NavDestination {
 }
 
 @Serializable
+data object ReadLater : NavDestination
+
+@Serializable
 data object SentenceSimilarityTest : NavDestination
 
 @Serializable

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
@@ -82,6 +82,7 @@ import com.github.zly2006.zhihu.navigation.LocalNavigator
 import com.github.zly2006.zhihu.navigation.Notification
 import com.github.zly2006.zhihu.navigation.OnlineHistory
 import com.github.zly2006.zhihu.navigation.Person
+import com.github.zly2006.zhihu.navigation.ReadLater
 import com.github.zly2006.zhihu.shared.platform.rememberPlainTextClipboard
 import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.platform.rememberSystemUrlOpener
@@ -109,6 +110,7 @@ const val ACCOUNT_SETTINGS_SHORTCUT_COLLECTIONS_TAG = "accountSettings.shortcutC
 const val ACCOUNT_SETTINGS_SHORTCUT_SUBSCRIPTIONS_TAG = "accountSettings.shortcutSubscriptions"
 const val ACCOUNT_SETTINGS_SHORTCUT_NOTIFICATION_TAG = "accountSettings.shortcutNotification"
 const val ACCOUNT_SETTINGS_SHORTCUT_HISTORY_TAG = "accountSettings.shortcutHistory"
+const val ACCOUNT_SETTINGS_READ_LATER_TAG = "accountSettings.readLater"
 const val ACCOUNT_SETTINGS_APPEARANCE_TAG = "accountSettings.appearance"
 const val ACCOUNT_SETTINGS_RECOMMEND_TAG = "accountSettings.recommend"
 const val ACCOUNT_SETTINGS_SYSTEM_TAG = "accountSettings.system"
@@ -418,6 +420,14 @@ fun AccountSettingScreen(
             }
 
             SettingItemGroup {
+                SettingItem(
+                    title = { Text("稍后再看") },
+                    description = { Text("本地保存的回答和文章") },
+                    icon = { Icon(Icons.Default.BookmarkBorder, null) },
+                    modifier = Modifier.testTag(ACCOUNT_SETTINGS_READ_LATER_TAG),
+                    onClick = { navigator.onNavigate(ReadLater) },
+                )
+
                 SettingItem(
                     title = { Text("外观与阅读体验") },
                     description = { Text("主题颜色、字体大小等") },

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
@@ -472,14 +472,6 @@ fun ArticleActionsMenu(
     val readLaterStore = rememberReadLaterStore()
     val userMessages = rememberUserMessageSink()
     val coroutineScope = rememberCoroutineScope()
-    val readLaterArticle = readLaterArticleSnapshot(
-        article = article,
-        title = viewModel.title,
-        authorName = viewModel.authorName,
-        authorBio = viewModel.authorBio,
-        avatarSrc = viewModel.authorAvatarSrc.takeIf { it.isNotBlank() },
-        content = viewModel.content,
-    )
     val isReadLaterSaved = readLaterStore.contains(article)
 
     @Composable
@@ -617,7 +609,16 @@ fun ArticleActionsMenu(
                     readLaterStore.remove(article)
                     userMessages.showShortMessage("已从稍后再看移除")
                 } else {
-                    readLaterStore.add(readLaterArticle)
+                    readLaterStore.add(
+                        article.copy(
+                            title = viewModel.title.ifBlank { article.title },
+                            authorName = viewModel.authorName.ifBlank { article.authorName },
+                            authorBio = viewModel.authorBio.ifBlank { article.authorBio },
+                            avatarSrc = viewModel.authorAvatarSrc.takeIf { it.isNotBlank() } ?: article.avatarSrc,
+                            excerpt = article.excerpt?.takeIf { it.isNotBlank() }
+                                ?: Ksoup.parse(viewModel.content).text().take(160),
+                        ),
+                    )
                     userMessages.showShortMessage("已加入稍后再看")
                 }
             },

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
@@ -469,7 +469,18 @@ fun ArticleActionsMenu(
     onSetImmersiveDoubleTap: () -> Unit = {},
 ) {
     val articleActionsRuntime = rememberArticleActionsRuntime()
+    val readLaterStore = rememberReadLaterStore()
+    val userMessages = rememberUserMessageSink()
     val coroutineScope = rememberCoroutineScope()
+    val readLaterArticle = readLaterArticleSnapshot(
+        article = article,
+        title = viewModel.title,
+        authorName = viewModel.authorName,
+        authorBio = viewModel.authorBio,
+        avatarSrc = viewModel.authorAvatarSrc.takeIf { it.isNotBlank() },
+        content = viewModel.content,
+    )
+    val isReadLaterSaved = readLaterStore.contains(article)
 
     @Composable
     fun MenuActionButton(
@@ -592,6 +603,23 @@ fun ArticleActionsMenu(
                     article,
                     articleActionText(article, viewModel.questionId, viewModel.title, viewModel.authorName),
                 )
+            },
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        MenuActionButton(
+            icon = if (isReadLaterSaved) Icons.Filled.Bookmark else Icons.Filled.BookmarkBorder,
+            text = if (isReadLaterSaved) "从稍后再看移除" else "加入稍后再看",
+            onClick = {
+                onDismissRequest()
+                if (isReadLaterSaved) {
+                    readLaterStore.remove(article)
+                    userMessages.showShortMessage("已从稍后再看移除")
+                } else {
+                    readLaterStore.add(readLaterArticle)
+                    userMessages.showShortMessage("已加入稍后再看")
+                }
             },
         )
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ReadLaterScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ReadLaterScreen.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.fleeksoft.ksoup.Ksoup
 import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.LocalNavigator
 import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
@@ -137,7 +136,7 @@ class ReadLaterStore(
 fun rememberReadLaterStore(): ReadLaterStore {
     val settings = rememberSettingsStore()
     val store = remember(settings) { ReadLaterStore(settings) }
-    DisposableEffect(settings, store) {
+    DisposableEffect(settings) {
         val unregister = settings.observeKeyChanges { key ->
             if (key == READ_LATER_ITEMS_KEY) {
                 store.reload()
@@ -147,22 +146,6 @@ fun rememberReadLaterStore(): ReadLaterStore {
     }
     return store
 }
-
-fun readLaterArticleSnapshot(
-    article: Article,
-    title: String,
-    authorName: String,
-    authorBio: String,
-    avatarSrc: String?,
-    content: String,
-): Article =
-    article.copy(
-        title = title.ifBlank { article.title },
-        authorName = authorName.ifBlank { article.authorName },
-        authorBio = authorBio.ifBlank { article.authorBio },
-        avatarSrc = avatarSrc ?: article.avatarSrc,
-        excerpt = article.excerpt?.takeIf { it.isNotBlank() } ?: Ksoup.parse(content).text().take(160),
-    )
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ReadLaterScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ReadLaterScreen.kt
@@ -106,7 +106,10 @@ class ReadLaterStore(
     }
 
     fun reload() {
-        items = loadItems()
+        val loadedItems = loadItems()
+        if (loadedItems != items) {
+            items = loadedItems
+        }
     }
 
     private fun save(nextItems: List<ReadLaterItem>) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ReadLaterScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ReadLaterScreen.kt
@@ -1,0 +1,291 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for Android.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.DeleteSweep
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.fleeksoft.ksoup.Ksoup
+import com.github.zly2006.zhihu.navigation.Article
+import com.github.zly2006.zhihu.navigation.LocalNavigator
+import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
+import com.github.zly2006.zhihu.shared.data.toFeedDisplayItemNavDestinationJson
+import com.github.zly2006.zhihu.shared.platform.PlatformBackHandler
+import com.github.zly2006.zhihu.shared.platform.SettingsStore
+import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
+import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
+import com.github.zly2006.zhihu.ui.components.FeedCard
+import com.github.zly2006.zhihu.viewmodel.formatArticleDateTime
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlin.time.Clock
+
+const val READ_LATER_LIST_TAG = "readLater.list"
+const val READ_LATER_EMPTY_TAG = "readLater.empty"
+const val READ_LATER_OVERFLOW_TAG = "readLater.overflow"
+const val READ_LATER_ITEM_TAG_PREFIX = "readLater.item"
+
+private const val READ_LATER_ITEMS_KEY = "readLaterItems"
+private const val MAX_READ_LATER_ITEMS = 500
+
+private val readLaterJson = Json {
+    ignoreUnknownKeys = true
+}
+
+@Serializable
+data class ReadLaterItem(
+    val article: Article,
+    val savedAtEpochMillis: Long,
+)
+
+class ReadLaterStore(
+    private val settings: SettingsStore,
+) {
+    var items by mutableStateOf(loadItems())
+        private set
+
+    fun contains(article: Article): Boolean = items.any { it.article == article }
+
+    fun add(article: Article) {
+        save(
+            listOf(ReadLaterItem(article, Clock.System.now().toEpochMilliseconds())) +
+                items.filterNot { it.article == article },
+        )
+    }
+
+    fun remove(article: Article) {
+        save(items.filterNot { it.article == article })
+    }
+
+    fun clear() {
+        save(emptyList())
+    }
+
+    fun reload() {
+        items = loadItems()
+    }
+
+    private fun save(nextItems: List<ReadLaterItem>) {
+        items = nextItems.take(MAX_READ_LATER_ITEMS)
+        if (items.isEmpty()) {
+            settings.remove(READ_LATER_ITEMS_KEY)
+        } else {
+            settings.putString(
+                READ_LATER_ITEMS_KEY,
+                readLaterJson.encodeToString(ListSerializer(ReadLaterItem.serializer()), items),
+            )
+        }
+    }
+
+    private fun loadItems(): List<ReadLaterItem> =
+        settings
+            .getStringOrNull(READ_LATER_ITEMS_KEY)
+            ?.let { raw ->
+                runCatching {
+                    readLaterJson.decodeFromString(ListSerializer(ReadLaterItem.serializer()), raw)
+                }.getOrNull()
+            }.orEmpty()
+            .take(MAX_READ_LATER_ITEMS)
+}
+
+@Composable
+fun rememberReadLaterStore(): ReadLaterStore {
+    val settings = rememberSettingsStore()
+    val store = remember(settings) { ReadLaterStore(settings) }
+    DisposableEffect(settings, store) {
+        val unregister = settings.observeKeyChanges { key ->
+            if (key == READ_LATER_ITEMS_KEY) {
+                store.reload()
+            }
+        }
+        onDispose(unregister)
+    }
+    return store
+}
+
+fun readLaterArticleSnapshot(
+    article: Article,
+    title: String,
+    authorName: String,
+    authorBio: String,
+    avatarSrc: String?,
+    content: String,
+): Article =
+    article.copy(
+        title = title.ifBlank { article.title },
+        authorName = authorName.ifBlank { article.authorName },
+        authorBio = authorBio.ifBlank { article.authorBio },
+        avatarSrc = avatarSrc ?: article.avatarSrc,
+        excerpt = article.excerpt?.takeIf { it.isNotBlank() } ?: Ksoup.parse(content).text().take(160),
+    )
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReadLaterScreen() {
+    val navigator = LocalNavigator.current
+    val store = rememberReadLaterStore()
+    val userMessages = rememberUserMessageSink()
+    var showActionsMenu by remember { mutableStateOf(false) }
+    var showClearDialog by remember { mutableStateOf(false) }
+
+    PlatformBackHandler(enabled = showActionsMenu) {
+        showActionsMenu = false
+    }
+    PlatformBackHandler(enabled = showClearDialog) {
+        showClearDialog = false
+    }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("稍后再看") },
+                navigationIcon = {
+                    IconButton(onClick = navigator.onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                actions = {
+                    Box {
+                        IconButton(
+                            onClick = { showActionsMenu = true },
+                            modifier = Modifier.testTag(READ_LATER_OVERFLOW_TAG),
+                        ) {
+                            Icon(Icons.Filled.MoreVert, contentDescription = "更多选项")
+                        }
+                        DropdownMenu(
+                            expanded = showActionsMenu,
+                            onDismissRequest = { showActionsMenu = false },
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("清空稍后再看") },
+                                leadingIcon = { Icon(Icons.Filled.DeleteSweep, contentDescription = null) },
+                                enabled = store.items.isNotEmpty(),
+                                onClick = {
+                                    showActionsMenu = false
+                                    showClearDialog = true
+                                },
+                            )
+                        }
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        if (showClearDialog) {
+            AlertDialog(
+                onDismissRequest = { showClearDialog = false },
+                title = { Text("清空稍后再看") },
+                text = { Text("所有本地保存的稍后再看条目都会被移除。") },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            showClearDialog = false
+                            store.clear()
+                            userMessages.showShortMessage("已清空稍后再看")
+                        },
+                    ) {
+                        Text("清空")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showClearDialog = false }) {
+                        Text("取消")
+                    }
+                },
+            )
+        }
+        if (store.items.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .testTag(READ_LATER_EMPTY_TAG),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "还没有保存稍后再看的内容",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .testTag(READ_LATER_LIST_TAG),
+            ) {
+                items(
+                    items = store.items,
+                    key = { "${it.article.type}:${it.article.id}" },
+                ) { item ->
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp)
+                            .testTag("${READ_LATER_ITEM_TAG_PREFIX}.${item.article.type}.${item.article.id}"),
+                    ) {
+                        FeedCard(
+                            item = FeedDisplayItem(
+                                title = item.article.title,
+                                summary = item.article.excerpt.orEmpty(),
+                                details = "保存于 ${formatArticleDateTime(item.savedAtEpochMillis / 1000)}",
+                                feed = null,
+                                navDestinationJson = item.article.toFeedDisplayItemNavDestinationJson(),
+                                avatarSrc = item.article.avatarSrc,
+                                authorName = item.article.authorName,
+                            ),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -106,6 +106,7 @@ import com.github.zly2006.zhihu.navigation.OnlineHistory
 import com.github.zly2006.zhihu.navigation.Person
 import com.github.zly2006.zhihu.navigation.Pin
 import com.github.zly2006.zhihu.navigation.Question
+import com.github.zly2006.zhihu.navigation.ReadLater
 import com.github.zly2006.zhihu.navigation.Search
 import com.github.zly2006.zhihu.navigation.SentenceSimilarityTest
 import com.github.zly2006.zhihu.navigation.TopLevelDestination
@@ -510,6 +511,9 @@ fun ZhihuMain(
                 }
                 composable<Notification.NotificationSettings> {
                     NotificationSettingsScreen()
+                }
+                composable<ReadLater> {
+                    ReadLaterScreen()
                 }
                 composable<SentenceSimilarityTest> {
                     platformAdapter.sentenceSimilarityTest()

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/ui/ReadLaterStoreTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/ui/ReadLaterStoreTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for Android.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.ui
+
+import com.github.zly2006.zhihu.navigation.Article
+import com.github.zly2006.zhihu.navigation.ArticleType
+import com.github.zly2006.zhihu.shared.platform.SettingsStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ReadLaterStoreTest {
+    @Test
+    fun addPersistsAndMovesDuplicateToTop() {
+        val settings = mapBackedSettingsStore()
+        val store = ReadLaterStore(settings)
+        val first = Article(title = "第一篇", type = ArticleType.Article, id = 1)
+        val second = Article(title = "第二篇", type = ArticleType.Answer, id = 2)
+
+        store.add(first)
+        store.add(second)
+        store.add(first.copy(title = "第一篇更新"))
+
+        assertEquals(listOf(1L, 2L), store.items.map { it.article.id })
+        assertEquals(
+            "第一篇更新",
+            store.items
+                .first()
+                .article.title,
+        )
+        assertTrue(ReadLaterStore(settings).contains(first))
+    }
+
+    @Test
+    fun removeOnlyDeletesMatchingArticle() {
+        val settings = mapBackedSettingsStore()
+        val store = ReadLaterStore(settings)
+        val answer = Article(type = ArticleType.Answer, id = 1)
+        val article = Article(type = ArticleType.Article, id = 1)
+
+        store.add(answer)
+        store.add(article)
+        store.remove(answer)
+
+        assertFalse(store.contains(answer))
+        assertTrue(store.contains(article))
+    }
+
+    @Test
+    fun clearRemovesPersistedItems() {
+        val settings = mapBackedSettingsStore()
+        val store = ReadLaterStore(settings)
+
+        store.add(Article(type = ArticleType.Answer, id = 1))
+        store.clear()
+
+        assertTrue(store.items.isEmpty())
+        assertTrue(ReadLaterStore(settings).items.isEmpty())
+    }
+
+    private fun mapBackedSettingsStore(): SettingsStore {
+        val map = mutableMapOf<String, Any>()
+        return SettingsStore(
+            getBoolean = { key, defaultValue -> map[key] as? Boolean ?: defaultValue },
+            putBoolean = { key, value -> map[key] = value },
+            getString = { key, defaultValue -> map[key] as? String ?: defaultValue },
+            putString = { key, value -> map[key] = value },
+            getStringOrNull = { key -> map[key] as? String },
+            putStringSet = { key, value -> map[key] = value },
+            getStringSet = { key, defaultValue ->
+                (map[key] as? Set<*>)
+                    ?.filterIsInstance<String>()
+                    ?.toSet()
+                    ?: defaultValue
+            },
+            getInt = { key, defaultValue -> map[key] as? Int ?: defaultValue },
+            putInt = { key, value -> map[key] = value },
+            getLong = { key, defaultValue -> map[key] as? Long ?: defaultValue },
+            putLong = { key, value -> map[key] = value },
+            getFloat = { key, defaultValue -> map[key] as? Float ?: defaultValue },
+            putFloat = { key, value -> map[key] = value },
+            remove = { key -> map.remove(key) },
+        )
+    }
+}


### PR DESCRIPTION
Resolves #372

## 改动概览
- 在回答/文章页右上角菜单增加“加入稍后再看 / 从稍后再看移除”操作
- 新增 `ReadLater` 导航目标和 `ReadLaterScreen`，展示本地保存的回答、文章列表，并支持清空全部
- 在账号页增加“稍后再看”入口
- 为 `ReadLaterStore` 增加持久化回归测试，覆盖重复置顶、按类型删除、清空持久化

## MVP 边界
- 这次只做本地稍后再看，不做云同步
- 列表页支持进入内容和清空全部；单条移除当前主要通过内容页菜单完成
- 保存的是本地内容快照元数据，用于回头定位和重新打开，不扩展成离线全文缓存

## Focused Cleanup
- 运行了 `python3 .agents/skills/zhihu-pp-ai-slop-cleaner/scripts/scan_low_call_functions.py --root . --max-calls 2 --output /tmp/zhihu_low_functions.tsv`
- 运行了 `python3 .agents/skills/zhihu-pp-ai-slop-cleaner/scripts/find_similar_kotlin_functions.py --root . --threshold 0.82 --output /tmp/zhihu_similar_functions.tsv`
- 针对本次改动文件做了 focused review，并把 `ReadLaterScreen` 里单次调用、只负责字段搬运的 `toFeedDisplayItem` helper 内联删除
- 保留了 `ReadLaterStore`、`rememberReadLaterStore`、`readLaterArticleSnapshot`：它们分别承担持久化契约、跨页面状态订阅和保存快照策略，不是纯转发包装层

## 本地验证
- `git diff --check`
- focused 静态审查：检查薄 helper / 重复 helper / 无意义抽象 / 明显 TODO 噪音

## Gradle / CI 说明
- 本机未继续执行 Gradle 验证。原因是本机 Gradle 9 即使传 `--no-daemon` 仍会 fork single-use GradleDaemon，会和当前并行验证策略冲突。
- 按本次执行策略，`assembleLiteDebug`、`ktlintFormat` 及后续 Gradle 验证交由 GitHub CI 执行。

## 截图 / 阻塞
- 阻塞：按最新执行策略停止了本机 Gradle 和 AVD 路径，本次未生成新 APK，因此暂时没有真实运行截图。
