### PR TITLE
feat: 增加设置项搜索功能

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
@@ -49,6 +49,7 @@ import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_LICENSES_TAG
 import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_LOGIN_ITEM_TAG
 import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_PROFILE_HEADER_TAG
 import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_RECOMMEND_TAG
+import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_SEARCH_TAG
 import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_SCROLL_TAG
 import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_SHORTCUT_COLLECTIONS_TAG
 import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_SHORTCUT_HISTORY_TAG
@@ -120,8 +121,8 @@ class AccountSettingScreenInstrumentedTest {
     fun coreSettingsRowsNavigateInOrderAndBottomScrollRemainsStableAcrossRoundTrips() {
         // Expected behavior:
         // 1. The always-available local settings rows must navigate to their corresponding account
-        //    sub-destinations in a deterministic order: appearance, recommendation, system/update,
-        //    and open-source licenses.
+        //    sub-destinations in a deterministic order: search, appearance, recommendation,
+        //    system/update, and open-source licenses.
         // 2. Reaching the about section should rely on scroll semantics from the tagged scroll
         //    container instead of raw coordinates, so the test remains stable on different devices.
         // 3. A forward-and-reverse swipe cycle plus an explicit scroll back to the top should leave
@@ -129,6 +130,7 @@ class AccountSettingScreenInstrumentedTest {
         //    repeated navigation-row interaction and scrolling.
         val navigator = showScreen()
 
+        composeRule.onNodeWithTag(ACCOUNT_SETTINGS_SEARCH_TAG).assertIsDisplayed().performClick()
         composeRule.onNodeWithTag(ACCOUNT_SETTINGS_APPEARANCE_TAG).assertIsDisplayed().performClick()
         composeRule.onNodeWithTag(ACCOUNT_SETTINGS_RECOMMEND_TAG).assertIsDisplayed().performClick()
         composeRule.onNodeWithTag(ACCOUNT_SETTINGS_SYSTEM_TAG).assertIsDisplayed().performClick()
@@ -137,13 +139,14 @@ class AccountSettingScreenInstrumentedTest {
         composeRule.onNodeWithTag(ACCOUNT_SETTINGS_LICENSES_TAG).assertIsDisplayed().performClick()
 
         composeRule.waitUntil(timeoutMillis = 5_000) {
-            navigator.destinations.size == 4
+            navigator.destinations.size == 5
         }
         assertEquals(
             listOf(
+                Account.SettingsSearch,
                 Account.AppearanceSettings(),
                 Account.RecommendSettings(),
-                Account.SystemAndUpdateSettings,
+                Account.SystemAndUpdateSettings(),
                 Account.OpenSourceLicenses,
             ),
             navigator.destinations,

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
@@ -36,7 +36,6 @@ import com.github.zly2006.zhihu.navigation.Follow
 import com.github.zly2006.zhihu.navigation.Home
 import com.github.zly2006.zhihu.navigation.Notification
 import com.github.zly2006.zhihu.navigation.OnlineHistory
-import com.github.zly2006.zhihu.shared.data.Person as AccountPerson
 import com.github.zly2006.zhihu.test.InstrumentedTestEnvironment
 import com.github.zly2006.zhihu.test.MainActivityComposeRule
 import com.github.zly2006.zhihu.test.RecordingNavigator
@@ -69,6 +68,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import com.github.zly2006.zhihu.shared.data.Person as AccountPerson
 
 @RunWith(AndroidJUnit4::class)
 class AccountSettingScreenInstrumentedTest {

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
@@ -60,7 +60,6 @@ import com.github.zly2006.zhihu.ui.AccountSettingsAccountState
 import com.github.zly2006.zhihu.ui.PREFERENCE_NAME
 import com.github.zly2006.zhihu.ui.subscreens.BOTTOM_BAR_ITEMS_PREFERENCE_KEY
 import io.ktor.http.HttpMethod
-import java.util.concurrent.atomic.AtomicInteger
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -68,6 +67,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.atomic.AtomicInteger
 import com.github.zly2006.zhihu.shared.data.Person as AccountPerson
 
 @RunWith(AndroidJUnit4::class)

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
@@ -49,8 +49,8 @@ import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_LICENSES_TAG
 import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_LOGIN_ITEM_TAG
 import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_PROFILE_HEADER_TAG
 import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_RECOMMEND_TAG
-import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_SEARCH_TAG
 import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_SCROLL_TAG
+import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_SEARCH_TAG
 import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_SHORTCUT_COLLECTIONS_TAG
 import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_SHORTCUT_HISTORY_TAG
 import com.github.zly2006.zhihu.ui.ACCOUNT_SETTINGS_SHORTCUT_NOTIFICATION_TAG

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
@@ -68,7 +68,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.concurrent.atomic.AtomicInteger
-import com.github.zly2006.zhihu.shared.data.Person as AccountPerson
+import com.github.zly2006.zhihu.data.Person as AccountPerson
 
 @RunWith(AndroidJUnit4::class)
 class AccountSettingScreenInstrumentedTest {

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/AccountSettingScreenInstrumentedTest.kt
@@ -36,6 +36,7 @@ import com.github.zly2006.zhihu.navigation.Follow
 import com.github.zly2006.zhihu.navigation.Home
 import com.github.zly2006.zhihu.navigation.Notification
 import com.github.zly2006.zhihu.navigation.OnlineHistory
+import com.github.zly2006.zhihu.shared.data.Person as AccountPerson
 import com.github.zly2006.zhihu.test.InstrumentedTestEnvironment
 import com.github.zly2006.zhihu.test.MainActivityComposeRule
 import com.github.zly2006.zhihu.test.RecordingNavigator
@@ -60,6 +61,7 @@ import com.github.zly2006.zhihu.ui.AccountSettingsAccountState
 import com.github.zly2006.zhihu.ui.PREFERENCE_NAME
 import com.github.zly2006.zhihu.ui.subscreens.BOTTOM_BAR_ITEMS_PREFERENCE_KEY
 import io.ktor.http.HttpMethod
+import java.util.concurrent.atomic.AtomicInteger
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -67,8 +69,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.concurrent.atomic.AtomicInteger
-import com.github.zly2006.zhihu.data.Person as AccountPerson
 
 @RunWith(AndroidJUnit4::class)
 class AccountSettingScreenInstrumentedTest {

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/NotificationScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/NotificationScreenInstrumentedTest.kt
@@ -101,7 +101,7 @@ class NotificationScreenInstrumentedTest {
     fun notificationScreen_settingsButton_navigatesToNotificationSettings() {
         /*
          * Expected behavior:
-         * 1. Pressing the toolbar settings button should navigate to Notification.NotificationSettings.
+         * 1. Pressing the toolbar settings button should navigate to Notification.NotificationSettings().
          * 2. This action should not trigger a back event because it is a forward navigation path.
          * 3. The recorded destination list should contain exactly the settings destination after one click.
          */
@@ -110,7 +110,7 @@ class NotificationScreenInstrumentedTest {
         composeRule.onNodeWithContentDescription("设置").performClick()
 
         assertEquals(0, recordingNavigator.backCount)
-        assertEquals(listOf(Notification.NotificationSettings), recordingNavigator.destinations)
+        assertEquals(listOf(Notification.NotificationSettings()), recordingNavigator.destinations)
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/NotificationScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/NotificationScreenInstrumentedTest.kt
@@ -104,7 +104,7 @@ class NotificationScreenInstrumentedTest {
     fun notificationScreen_settingsButton_navigatesToNotificationSettings() {
         /*
          * Expected behavior:
-         * 1. Pressing the toolbar settings button should navigate to Notification.NotificationSettings.
+         * 1. Pressing the toolbar settings button should navigate to Notification.NotificationSettings().
          * 2. This action should not trigger a back event because it is a forward navigation path.
          * 3. The recorded destination list should contain exactly the settings destination after one click.
          */
@@ -113,7 +113,7 @@ class NotificationScreenInstrumentedTest {
         composeRule.onNodeWithContentDescription("设置").performClick()
 
         assertEquals(0, recordingNavigator.backCount)
-        assertEquals(listOf(Notification.NotificationSettings), recordingNavigator.destinations)
+        assertEquals(listOf(Notification.NotificationSettings()), recordingNavigator.destinations)
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/SettingsSearchScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/SettingsSearchScreenInstrumentedTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for Android.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu
+
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.zly2006.zhihu.navigation.Account
+import com.github.zly2006.zhihu.navigation.Notification
+import com.github.zly2006.zhihu.test.MainActivityComposeRule
+import com.github.zly2006.zhihu.test.RecordingNavigator
+import com.github.zly2006.zhihu.test.resetAppPreferences
+import com.github.zly2006.zhihu.test.setScreenContent
+import com.github.zly2006.zhihu.ui.subscreens.SETTINGS_SEARCH_INPUT_TAG
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SettingsSearchScreenInstrumentedTest {
+    @get:Rule
+    val composeRule: MainActivityComposeRule = createAndroidComposeRule<MainActivity>()
+
+    @Before
+    fun setUp() {
+        composeRule.resetAppPreferences()
+    }
+
+    @Test
+    fun searchScreen_filtersAppearanceResultsAndNavigatesToTargetSetting() {
+        val navigator = setSearchScreenContent()
+
+        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG).performTextInput("热搜")
+        composeRule.onNodeWithTag("settingsSearch.result.appearance.showSearchHotSearch")
+            .assertIsDisplayed()
+            .performClick()
+
+        assertEquals(
+            listOf(Account.AppearanceSettings(setting = "showSearchHotSearch")),
+            navigator.destinations,
+        )
+    }
+
+    @Test
+    fun searchScreen_canJumpToSystemAndNotificationSettingsEntries() {
+        val navigator = setSearchScreenContent()
+
+        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG).performTextInput("GitHub Token")
+        composeRule.onNodeWithTag("settingsSearch.result.system.githubToken")
+            .assertIsDisplayed()
+            .performClick()
+        assertEquals(
+            listOf(Account.SystemAndUpdateSettings(setting = "githubToken")),
+            navigator.destinations,
+        )
+
+        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG).performTextClearance()
+        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG).performTextInput("系统通知")
+        composeRule.onNodeWithTag("settingsSearch.result.notification.displayInAppNotifications")
+            .assertDoesNotExist()
+        composeRule.onNodeWithTag("settingsSearch.result.notification.systemNotifications")
+            .assertIsDisplayed()
+            .performClick()
+
+        assertEquals(
+            listOf(
+                Account.SystemAndUpdateSettings(setting = "githubToken"),
+                Notification.NotificationSettings(setting = "systemNotifications"),
+            ),
+            navigator.destinations,
+        )
+    }
+
+    private fun setSearchScreenContent(): RecordingNavigator = composeRule.setScreenContent {
+        com.github.zly2006.zhihu.ui.subscreens.SettingsSearchScreen()
+    }
+}

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/SettingsSearchScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/SettingsSearchScreenInstrumentedTest.kt
@@ -52,8 +52,10 @@ class SettingsSearchScreenInstrumentedTest {
     fun searchScreen_filtersAppearanceResultsAndNavigatesToTargetSetting() {
         val navigator = setSearchScreenContent()
 
-        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG).performTextInput("热搜")
-        composeRule.onNodeWithTag("settingsSearch.result.appearance.showSearchHotSearch")
+        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG)
+            .performTextInput("热搜")
+        composeRule
+            .onNodeWithTag("settingsSearch.result.appearance.showSearchHotSearch")
             .assertIsDisplayed()
             .performClick()
 
@@ -67,8 +69,10 @@ class SettingsSearchScreenInstrumentedTest {
     fun searchScreen_canJumpToSystemAndNotificationSettingsEntries() {
         val navigator = setSearchScreenContent()
 
-        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG).performTextInput("GitHub Token")
-        composeRule.onNodeWithTag("settingsSearch.result.system.githubToken")
+        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG)
+            .performTextInput("GitHub Token")
+        composeRule
+            .onNodeWithTag("settingsSearch.result.system.githubToken")
             .assertIsDisplayed()
             .performClick()
         assertEquals(
@@ -76,11 +80,15 @@ class SettingsSearchScreenInstrumentedTest {
             navigator.destinations,
         )
 
-        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG).performTextClearance()
-        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG).performTextInput("系统通知")
-        composeRule.onNodeWithTag("settingsSearch.result.notification.displayInAppNotifications")
+        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG)
+            .performTextClearance()
+        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG)
+            .performTextInput("系统通知")
+        composeRule
+            .onNodeWithTag("settingsSearch.result.notification.displayInAppNotifications")
             .assertDoesNotExist()
-        composeRule.onNodeWithTag("settingsSearch.result.notification.systemNotifications")
+        composeRule
+            .onNodeWithTag("settingsSearch.result.notification.systemNotifications")
             .assertIsDisplayed()
             .performClick()
 
@@ -93,7 +101,8 @@ class SettingsSearchScreenInstrumentedTest {
         )
     }
 
-    private fun setSearchScreenContent(): RecordingNavigator = composeRule.setScreenContent {
-        com.github.zly2006.zhihu.ui.subscreens.SettingsSearchScreen()
-    }
+    private fun setSearchScreenContent(): RecordingNavigator =
+        composeRule.setScreenContent {
+            com.github.zly2006.zhihu.ui.subscreens.SettingsSearchScreen()
+        }
 }

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/SettingsSearchScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/SettingsSearchScreenInstrumentedTest.kt
@@ -17,9 +17,10 @@
 
 package com.github.zly2006.zhihu
 
-import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
@@ -32,6 +33,7 @@ import com.github.zly2006.zhihu.test.RecordingNavigator
 import com.github.zly2006.zhihu.test.resetAppPreferences
 import com.github.zly2006.zhihu.test.setScreenContent
 import com.github.zly2006.zhihu.ui.subscreens.SETTINGS_SEARCH_INPUT_TAG
+import com.github.zly2006.zhihu.ui.subscreens.SettingsSearchScreen
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -52,7 +54,8 @@ class SettingsSearchScreenInstrumentedTest {
     fun searchScreen_filtersAppearanceResultsAndNavigatesToTargetSetting() {
         val navigator = setSearchScreenContent()
 
-        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG)
+        composeRule
+            .onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG)
             .performTextInput("热搜")
         composeRule
             .onNodeWithTag("settingsSearch.result.appearance.showSearchHotSearch")
@@ -69,7 +72,8 @@ class SettingsSearchScreenInstrumentedTest {
     fun searchScreen_canJumpToSystemAndNotificationSettingsEntries() {
         val navigator = setSearchScreenContent()
 
-        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG)
+        composeRule
+            .onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG)
             .performTextInput("GitHub Token")
         composeRule
             .onNodeWithTag("settingsSearch.result.system.githubToken")
@@ -80,13 +84,15 @@ class SettingsSearchScreenInstrumentedTest {
             navigator.destinations,
         )
 
-        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG)
+        composeRule
+            .onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG)
             .performTextClearance()
-        composeRule.onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG)
+        composeRule
+            .onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG)
             .performTextInput("系统通知")
         composeRule
-            .onNodeWithTag("settingsSearch.result.notification.displayInAppNotifications")
-            .assertDoesNotExist()
+            .onAllNodesWithTag("settingsSearch.result.notification.displayInAppNotifications")
+            .assertCountEquals(0)
         composeRule
             .onNodeWithTag("settingsSearch.result.notification.systemNotifications")
             .assertIsDisplayed()
@@ -103,6 +109,6 @@ class SettingsSearchScreenInstrumentedTest {
 
     private fun setSearchScreenContent(): RecordingNavigator =
         composeRule.setScreenContent {
-            com.github.zly2006.zhihu.ui.subscreens.SettingsSearchScreen()
+            SettingsSearchScreen()
         }
 }

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/SettingsSearchScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/SettingsSearchScreenInstrumentedTest.kt
@@ -70,6 +70,24 @@ class SettingsSearchScreenInstrumentedTest {
     }
 
     @Test
+    fun searchScreen_matchesPageNamesConfiguredByGroupedSettings() {
+        val navigator = setSearchScreenContent()
+
+        composeRule
+            .onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG)
+            .performTextInput("热榜")
+        composeRule
+            .onNodeWithTag("settingsSearch.result.appearance.bottomBar")
+            .assertIsDisplayed()
+            .performClick()
+
+        assertEquals(
+            listOf(Account.AppearanceSettings(setting = "appearanceSettings.bottomBarSection")),
+            navigator.destinations,
+        )
+    }
+
+    @Test
     fun searchScreen_canJumpToSystemAndNotificationSettingsEntries() {
         val navigator = setSearchScreenContent()
 

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/SettingsSearchScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/SettingsSearchScreenInstrumentedTest.kt
@@ -32,6 +32,7 @@ import com.github.zly2006.zhihu.test.MainActivityComposeRule
 import com.github.zly2006.zhihu.test.RecordingNavigator
 import com.github.zly2006.zhihu.test.resetAppPreferences
 import com.github.zly2006.zhihu.test.setScreenContent
+import com.github.zly2006.zhihu.ui.PREFERENCE_NAME
 import com.github.zly2006.zhihu.ui.subscreens.SETTINGS_SEARCH_INPUT_TAG
 import com.github.zly2006.zhihu.ui.subscreens.SettingsSearchScreen
 import org.junit.Assert.assertEquals
@@ -105,6 +106,35 @@ class SettingsSearchScreenInstrumentedTest {
             ),
             navigator.destinations,
         )
+    }
+
+    @Test
+    fun searchScreen_onlyExposesDeveloperEntryWhenDeveloperModeIsEnabled() {
+        val hiddenNavigator = setSearchScreenContent()
+
+        composeRule
+            .onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG)
+            .performTextInput("签名请求")
+        composeRule
+            .onAllNodesWithTag("settingsSearch.result.developer.page")
+            .assertCountEquals(0)
+        assertEquals(0, hiddenNavigator.destinations.size)
+
+        composeRule.activity
+            .getSharedPreferences(PREFERENCE_NAME, 0)
+            .edit()
+            .putBoolean("developer", true)
+            .apply()
+        val enabledNavigator = setSearchScreenContent()
+
+        composeRule
+            .onNodeWithTag(SETTINGS_SEARCH_INPUT_TAG)
+            .performTextInput("签名请求")
+        composeRule
+            .onNodeWithTag("settingsSearch.result.developer.page")
+            .assertIsDisplayed()
+            .performClick()
+        assertEquals(listOf(Account.DeveloperSettings), enabledNavigator.destinations)
     }
 
     private fun setSearchScreenContent(): RecordingNavigator =

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
@@ -137,7 +137,12 @@ data object Account : TopLevelDestination {
     data object IdentityManagement : NavDestination
 
     @Serializable
-    data object SystemAndUpdateSettings : NavDestination
+    data class SystemAndUpdateSettings(
+        val setting: String = "",
+    ) : NavDestination
+
+    @Serializable
+    data object SettingsSearch : NavDestination
 
     @Serializable
     data object OpenSourceLicenses : NavDestination
@@ -161,7 +166,9 @@ data object Daily : TopLevelDestination {
 @Serializable
 data object Notification : NavDestination {
     @Serializable
-    data object NotificationSettings : NavDestination
+    data class NotificationSettings(
+        val setting: String = "",
+    ) : NavDestination
 
     @Serializable
     data class Entry(

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
@@ -431,37 +431,39 @@ fun AccountSettingScreen(
                 }
             }
 
-            Surface(
-                modifier = Modifier
-                    .height(36.dp)
-                    .testTag(ACCOUNT_SETTINGS_SEARCH_TAG),
-                shape = RoundedCornerShape(24.dp),
-                color = MaterialTheme.colorScheme.surfaceVariant,
-                onClick = {
-                    navigator.onNavigate(Account.SettingsSearch)
-                },
-            ) {
-                Row(
+            Column(Modifier.padding(horizontal = 16.dp)) {
+                Surface(
                     modifier = Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = 16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
+                        .height(36.dp)
+                        .testTag(ACCOUNT_SETTINGS_SEARCH_TAG),
+                    shape = RoundedCornerShape(24.dp),
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                    onClick = {
+                        navigator.onNavigate(Account.SettingsSearch)
+                    },
                 ) {
-                    Icon(
-                        Icons.Default.Search,
-                        contentDescription = "搜索",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Text(
-                        text = "搜索设置项",
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
+                    Row(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            Icons.Default.Search,
+                            contentDescription = "搜索",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text(
+                            text = "搜索设置项",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                    }
                 }
-            }
 
-            Spacer(Modifier.height(16.dp))
+                Spacer(Modifier.height(16.dp))
+            }
 
             SettingItemGroup {
                 if (data.login && data.identityManagementSupported) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -430,6 +431,38 @@ fun AccountSettingScreen(
                 }
             }
 
+            Surface(
+                modifier = Modifier
+                    .height(36.dp)
+                    .testTag(ACCOUNT_SETTINGS_SEARCH_TAG),
+                shape = RoundedCornerShape(24.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                onClick = {
+                    navigator.onNavigate(Account.SettingsSearch)
+                },
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        Icons.Default.Search,
+                        contentDescription = "搜索",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = "搜索设置项",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
             SettingItemGroup {
                 if (data.login && data.identityManagementSupported) {
                     SettingItem(
@@ -440,14 +473,6 @@ fun AccountSettingScreen(
                         onClick = { navigator.onNavigate(Account.IdentityManagement) },
                     )
                 }
-
-                SettingItem(
-                    title = { Text("搜索设置项") },
-                    description = { Text("按名称快速跳到对应设置") },
-                    icon = { Icon(Icons.Default.Search, null) },
-                    modifier = Modifier.testTag(ACCOUNT_SETTINGS_SEARCH_TAG),
-                    onClick = { navigator.onNavigate(Account.SettingsSearch) },
-                )
 
                 SettingItem(
                     title = { Text("外观与阅读体验") },

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.QrCodeScanner
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.SwitchAccount
 import androidx.compose.material3.AlertDialog
@@ -116,6 +117,7 @@ const val ACCOUNT_SETTINGS_SHORTCUT_HISTORY_TAG = "accountSettings.shortcutHisto
 const val ACCOUNT_SETTINGS_APPEARANCE_TAG = "accountSettings.appearance"
 const val ACCOUNT_SETTINGS_READING_TAG = "accountSettings.reading"
 const val ACCOUNT_SETTINGS_RECOMMEND_TAG = "accountSettings.recommend"
+const val ACCOUNT_SETTINGS_SEARCH_TAG = "accountSettings.search"
 const val ACCOUNT_SETTINGS_SYSTEM_TAG = "accountSettings.system"
 const val ACCOUNT_SETTINGS_DEVELOPER_TAG = "accountSettings.developer"
 const val ACCOUNT_SETTINGS_LICENSES_TAG = "accountSettings.licenses"
@@ -440,6 +442,14 @@ fun AccountSettingScreen(
                 }
 
                 SettingItem(
+                    title = { Text("搜索设置项") },
+                    description = { Text("按名称快速跳到对应设置") },
+                    icon = { Icon(Icons.Default.Search, null) },
+                    modifier = Modifier.testTag(ACCOUNT_SETTINGS_SEARCH_TAG),
+                    onClick = { navigator.onNavigate(Account.SettingsSearch) },
+                )
+
+                SettingItem(
                     title = { Text("外观与阅读体验") },
                     description = { Text("主题颜色、字体大小等") },
                     icon = { Icon(Icons.Default.Palette, null) },
@@ -470,7 +480,7 @@ fun AccountSettingScreen(
                     description = { Text("GitHub、更新设置等") },
                     icon = { Icon(Icons.Default.Settings, null) },
                     modifier = Modifier.testTag(ACCOUNT_SETTINGS_SYSTEM_TAG),
-                    onClick = { navigator.onNavigate(Account.SystemAndUpdateSettings) },
+                    onClick = { navigator.onNavigate(Account.SystemAndUpdateSettings()) },
                 )
 
                 AnimatedVisibility(isDeveloper) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
@@ -592,7 +592,7 @@ fun HomeScreen(
                                 leadingIcon = { Icon(Icons.Default.ArrowCircleUp, contentDescription = null) },
                                 accept = { Text("查看更新") },
                                 onAccept = {
-                                    navigator.onNavigate(Account.SystemAndUpdateSettings)
+                                    navigator.onNavigate(Account.SystemAndUpdateSettings())
                                 },
                                 dismiss = { Text("以后") },
                                 onDismiss = {
@@ -627,7 +627,7 @@ fun HomeScreen(
                                                     ?.let(openExternalUrl)
                                             }
                                             HOME_NOTIFICATION_ACTION_OPEN_UPDATE_SETTINGS -> {
-                                                navigator.onNavigate(Account.SystemAndUpdateSettings)
+                                                navigator.onNavigate(Account.SystemAndUpdateSettings())
                                             }
                                             HOME_NOTIFICATION_ACTION_OPEN_PIN -> {
                                                 accept.value?.jsonPrimitive?.contentOrNull?.toLongOrNull()?.let {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
@@ -607,7 +607,7 @@ fun HomeScreen(
                                 leadingIcon = { Icon(Icons.Default.ArrowCircleUp, contentDescription = null) },
                                 accept = { Text("查看更新") },
                                 onAccept = {
-                                    navigator.onNavigate(Account.SystemAndUpdateSettings)
+                                    navigator.onNavigate(Account.SystemAndUpdateSettings())
                                 },
                                 dismiss = { Text("以后") },
                                 onDismiss = {
@@ -644,7 +644,7 @@ fun HomeScreen(
                                                     ?.let(openExternalUrl)
                                             }
                                             HOME_NOTIFICATION_ACTION_OPEN_UPDATE_SETTINGS -> {
-                                                navigator.onNavigate(Account.SystemAndUpdateSettings)
+                                                navigator.onNavigate(Account.SystemAndUpdateSettings())
                                             }
                                             HOME_NOTIFICATION_ACTION_OPEN_PIN -> {
                                                 accept.value?.jsonPrimitive?.contentOrNull?.toLongOrNull()?.let {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/NotificationScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/NotificationScreen.kt
@@ -150,7 +150,7 @@ fun NotificationScreen() {
                             Icon(Icons.Default.MarkChatRead, contentDescription = "已读")
                         }
                     }
-                    IconButton(onClick = { navigator.onNavigate(Notification.NotificationSettings) }) {
+                    IconButton(onClick = { navigator.onNavigate(Notification.NotificationSettings()) }) {
                         Icon(Icons.Default.Settings, contentDescription = "设置")
                     }
                 },

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/NotificationSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/NotificationSettingsScreen.kt
@@ -61,10 +61,13 @@ object NotificationPreferences {
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun NotificationSettingsScreen() {
+fun NotificationSettingsScreen(
+    setting: String? = null,
+) {
     val navigator = LocalNavigator.current
     val settingsStore = rememberNotificationSettingsStore()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val highlightedSetting = setting.orEmpty()
 
     var systemNotificationSettings by remember {
         mutableStateOf(
@@ -125,6 +128,8 @@ fun NotificationSettingsScreen() {
                         autoMarkAsRead = checked
                         settingsStore.setAutoMarkAsReadEnabled(checked)
                     },
+                    settingKey = "autoMarkAsRead",
+                    highlightedKey = highlightedSetting,
                 )
                 SettingItemWithSwitch(
                     title = { Text("显示未读红点") },
@@ -133,10 +138,16 @@ fun NotificationSettingsScreen() {
                         unreadBadgeEnabled = checked
                         settingsStore.setUnreadBadgeEnabled(checked)
                     },
+                    settingKey = "unreadBadge",
+                    highlightedKey = highlightedSetting,
                 )
             }
 
-            SettingItemGroup(title = "系统通知") {
+            SettingItemGroup(
+                title = "系统通知",
+                settingKey = "systemNotifications",
+                highlightedKey = highlightedSetting,
+            ) {
                 NotificationType.entries.forEach { type ->
                     SettingItemWithSwitch(
                         title = { Text(type.displayName) },
@@ -154,6 +165,8 @@ fun NotificationSettingsScreen() {
             SettingItemGroup(
                 title = "应用内显示",
                 footer = { Text("选择在通知页面显示哪些通知") },
+                settingKey = "displayInAppNotifications",
+                highlightedKey = highlightedSetting,
             ) {
                 NotificationType.entries.forEach { type ->
                     SettingItemWithSwitch(

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -134,6 +134,7 @@ import com.github.zly2006.zhihu.ui.subscreens.DeveloperSettingsScreen
 import com.github.zly2006.zhihu.ui.subscreens.IdentityManagementScreen
 import com.github.zly2006.zhihu.ui.subscreens.OpenSourceLicensesScreen
 import com.github.zly2006.zhihu.ui.subscreens.ReadingSettingsScreen
+import com.github.zly2006.zhihu.ui.subscreens.SettingsSearchScreen
 import com.github.zly2006.zhihu.ui.subscreens.SystemAndUpdateSettingsScreen
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -632,8 +633,10 @@ fun ZhihuMain(
                     composable<Notification.Message> { navEntry ->
                         PrivateMessageScreen(navEntry.toRoute())
                     }
-                    composable<Notification.NotificationSettings> {
-                        NotificationSettingsScreen()
+                    composable<Notification.NotificationSettings> { navEntry ->
+                        NotificationSettingsScreen(
+                            setting = navEntry.toRoute<Notification.NotificationSettings>().setting,
+                        )
                     }
                     composable<SentenceSimilarityTest> {
                         sentenceSimilarityContent()
@@ -652,11 +655,16 @@ fun ZhihuMain(
                     composable<Account.IdentityManagement> {
                         IdentityManagementScreen()
                     }
-                    composable<Account.SystemAndUpdateSettings> {
-                        SystemAndUpdateSettingsScreen()
+                    composable<Account.SystemAndUpdateSettings> { navEntry ->
+                        SystemAndUpdateSettingsScreen(
+                            setting = navEntry.toRoute<Account.SystemAndUpdateSettings>().setting,
+                        )
                     }
                     composable<Account.ReadingSettings> {
                         ReadingSettingsScreen()
+                    }
+                    composable<Account.SettingsSearch> {
+                        SettingsSearchScreen()
                     }
                     composable<Account.OpenSourceLicenses> {
                         OpenSourceLicensesScreen()

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -134,6 +134,7 @@ import com.github.zly2006.zhihu.ui.subscreens.DeveloperSettingsScreen
 import com.github.zly2006.zhihu.ui.subscreens.IdentityManagementScreen
 import com.github.zly2006.zhihu.ui.subscreens.OpenSourceLicensesScreen
 import com.github.zly2006.zhihu.ui.subscreens.ReadingSettingsScreen
+import com.github.zly2006.zhihu.ui.subscreens.SettingsSearchScreen
 import com.github.zly2006.zhihu.ui.subscreens.SystemAndUpdateSettingsScreen
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -630,8 +631,10 @@ fun ZhihuMain(
                     composable<Notification.Message> { navEntry ->
                         PrivateMessageScreen(navEntry.toRoute())
                     }
-                    composable<Notification.NotificationSettings> {
-                        NotificationSettingsScreen()
+                    composable<Notification.NotificationSettings> { navEntry ->
+                        NotificationSettingsScreen(
+                            setting = navEntry.toRoute<Notification.NotificationSettings>().setting,
+                        )
                     }
                     composable<SentenceSimilarityTest> {
                         sentenceSimilarityContent()
@@ -650,11 +653,16 @@ fun ZhihuMain(
                     composable<Account.IdentityManagement> {
                         IdentityManagementScreen()
                     }
-                    composable<Account.SystemAndUpdateSettings> {
-                        SystemAndUpdateSettingsScreen()
+                    composable<Account.SystemAndUpdateSettings> { navEntry ->
+                        SystemAndUpdateSettingsScreen(
+                            setting = navEntry.toRoute<Account.SystemAndUpdateSettings>().setting,
+                        )
                     }
                     composable<Account.ReadingSettings> {
                         ReadingSettingsScreen()
+                    }
+                    composable<Account.SettingsSearch> {
+                        SettingsSearchScreen()
                     }
                     composable<Account.OpenSourceLicenses> {
                         OpenSourceLicensesScreen()

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
@@ -639,6 +639,9 @@ fun AppearanceSettingsScreen(
                         showFeedThumbnail.value = it
                         settings.putBoolean("showFeedThumbnail", it)
                     },
+                    settingKey = "showFeedThumbnail",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("showFeedThumbnail"),
                 )
 
                 SettingItemWithSwitch(
@@ -649,6 +652,9 @@ fun AppearanceSettingsScreen(
                         showRefreshFab.value = it
                         settings.putBoolean("showRefreshFab", it)
                     },
+                    settingKey = "showRefreshFab",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("showRefreshFab"),
                 )
 
                 var feedCardStyleExpanded by remember { mutableStateOf(false) }
@@ -662,6 +668,9 @@ fun AppearanceSettingsScreen(
                 SettingItem(
                     title = { Text("信息流样式") },
                     description = { Text("卡片样式使用圆角卡片展示，分割线样式使用细线分隔条目。") },
+                    settingKey = "feedCardStyle",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("feedCardStyle"),
                     endAction = {
                         ExposedDropdownMenuBox(
                             expanded = feedCardStyleExpanded,
@@ -774,6 +783,9 @@ fun AppearanceSettingsScreen(
                         isTitleAutoHide.value = it
                         settings.putBoolean("titleAutoHide", it)
                     },
+                    settingKey = "titleAutoHide",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("titleAutoHide"),
                 )
 
                 val autoHideArticleBottomBar = remember {
@@ -787,6 +799,9 @@ fun AppearanceSettingsScreen(
                         autoHideArticleBottomBar.value = it
                         settings.putBoolean("autoHideArticleBottomBar", it)
                     },
+                    settingKey = "autoHideArticleBottomBar",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("autoHideArticleBottomBar"),
                 )
 
                 SettingItemWithSwitch(
@@ -797,6 +812,9 @@ fun AppearanceSettingsScreen(
                         buttonSkipAnswer.value = it
                         settings.putBoolean("buttonSkipAnswer", it)
                     },
+                    settingKey = "buttonSkipAnswer",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("buttonSkipAnswer"),
                 )
 
                 val autoHideSkipAnswerButton = remember { mutableStateOf(settings.getBoolean("autoHideSkipAnswerButton", true)) }
@@ -821,6 +839,9 @@ fun AppearanceSettingsScreen(
                         pinAnswerDate.value = it
                         settings.putBoolean("pinAnswerDate", it)
                     },
+                    settingKey = "pinAnswerDate",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("pinAnswerDate"),
                 )
 
                 var answerSwitchExpanded by remember { mutableStateOf(false) }
@@ -835,6 +856,9 @@ fun AppearanceSettingsScreen(
                 SettingItem(
                     title = { Text("回答切换手势") },
                     description = { Text("在回答页面通过手势切换同一问题下的其他回答。") },
+                    settingKey = "answerSwitchMode",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("answerSwitchMode"),
                     endAction = {
                         ExposedDropdownMenuBox(
                             expanded = answerSwitchExpanded,
@@ -1325,6 +1349,9 @@ fun AppearanceSettingsScreen(
                         settings.putBoolean("use_custom_nav_host", it)
                         userMessages.showShortMessage("需要重启应用生效")
                     },
+                    settingKey = "use_custom_nav_host",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("use_custom_nav_host"),
                 )
 
                 val enablePredictiveBack = remember { mutableStateOf(settings.getBoolean("enable_predictive_back", true)) }
@@ -1336,6 +1363,9 @@ fun AppearanceSettingsScreen(
                         enablePredictiveBack.value = it
                         settings.putBoolean("enable_predictive_back", it)
                     },
+                    settingKey = "enable_predictive_back",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("enable_predictive_back"),
                 )
             }
             // ── 123duo3 UI 改进 ─────────────────────────────────────────────────

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
@@ -637,6 +637,9 @@ fun AppearanceSettingsScreen(
                         showFeedThumbnail.value = it
                         settings.putBoolean("showFeedThumbnail", it)
                     },
+                    settingKey = "showFeedThumbnail",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("showFeedThumbnail"),
                 )
 
                 SettingItemWithSwitch(
@@ -647,6 +650,9 @@ fun AppearanceSettingsScreen(
                         showRefreshFab.value = it
                         settings.putBoolean("showRefreshFab", it)
                     },
+                    settingKey = "showRefreshFab",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("showRefreshFab"),
                 )
 
                 var feedCardStyleExpanded by remember { mutableStateOf(false) }
@@ -660,6 +666,9 @@ fun AppearanceSettingsScreen(
                 SettingItem(
                     title = { Text("信息流样式") },
                     description = { Text("卡片样式使用圆角卡片展示，分割线样式使用细线分隔条目。") },
+                    settingKey = "feedCardStyle",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("feedCardStyle"),
                     endAction = {
                         ExposedDropdownMenuBox(
                             expanded = feedCardStyleExpanded,
@@ -772,6 +781,9 @@ fun AppearanceSettingsScreen(
                         isTitleAutoHide.value = it
                         settings.putBoolean("titleAutoHide", it)
                     },
+                    settingKey = "titleAutoHide",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("titleAutoHide"),
                 )
 
                 val autoHideArticleBottomBar = remember {
@@ -785,6 +797,9 @@ fun AppearanceSettingsScreen(
                         autoHideArticleBottomBar.value = it
                         settings.putBoolean("autoHideArticleBottomBar", it)
                     },
+                    settingKey = "autoHideArticleBottomBar",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("autoHideArticleBottomBar"),
                 )
 
                 SettingItemWithSwitch(
@@ -795,6 +810,9 @@ fun AppearanceSettingsScreen(
                         buttonSkipAnswer.value = it
                         settings.putBoolean("buttonSkipAnswer", it)
                     },
+                    settingKey = "buttonSkipAnswer",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("buttonSkipAnswer"),
                 )
 
                 val autoHideSkipAnswerButton = remember { mutableStateOf(settings.getBoolean("autoHideSkipAnswerButton", true)) }
@@ -819,6 +837,9 @@ fun AppearanceSettingsScreen(
                         pinAnswerDate.value = it
                         settings.putBoolean("pinAnswerDate", it)
                     },
+                    settingKey = "pinAnswerDate",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("pinAnswerDate"),
                 )
 
                 var answerSwitchExpanded by remember { mutableStateOf(false) }
@@ -833,6 +854,9 @@ fun AppearanceSettingsScreen(
                 SettingItem(
                     title = { Text("回答切换手势") },
                     description = { Text("在回答页面通过手势切换同一问题下的其他回答。") },
+                    settingKey = "answerSwitchMode",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("answerSwitchMode"),
                     endAction = {
                         ExposedDropdownMenuBox(
                             expanded = answerSwitchExpanded,
@@ -1304,6 +1328,9 @@ fun AppearanceSettingsScreen(
                         settings.putBoolean("use_custom_nav_host", it)
                         userMessages.showShortMessage("需要重启应用生效")
                     },
+                    settingKey = "use_custom_nav_host",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("use_custom_nav_host"),
                 )
 
                 val enablePredictiveBack = remember { mutableStateOf(settings.getBoolean("enable_predictive_back", true)) }
@@ -1315,6 +1342,9 @@ fun AppearanceSettingsScreen(
                         enablePredictiveBack.value = it
                         settings.putBoolean("enable_predictive_back", it)
                     },
+                    settingKey = "enable_predictive_back",
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor("enable_predictive_back"),
                 )
             }
             // ── 123duo3 UI 改进 ─────────────────────────────────────────────────

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/ContentFilterSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/ContentFilterSettingsScreen.kt
@@ -326,6 +326,8 @@ fun ContentFilterSettingsScreen(
                                 "当回答的问题包含 >= ${topicThreshold.value} 个被屏蔽主题时，屏蔽该内容",
                             )
                         },
+                        settingKey = "topicBlockingThreshold",
+                        highlightedKey = highlightedSetting,
                         endAction = {
                             Text(
                                 topicThreshold.value.toString(),

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
@@ -1,0 +1,351 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for Android.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.ui.subscreens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.github.zly2006.zhihu.navigation.Account
+import com.github.zly2006.zhihu.navigation.LocalNavigator
+import com.github.zly2006.zhihu.navigation.NavDestination
+import com.github.zly2006.zhihu.navigation.Notification
+import com.github.zly2006.zhihu.shared.aigc.AIGC_MARKING_ENABLED_PREFERENCE_KEY
+import com.github.zly2006.zhihu.shared.notification.NotificationType
+import com.github.zly2006.zhihu.shared.ui.ANSWER_DOUBLE_TAP_ACTION_PREFERENCE_KEY
+import com.github.zly2006.zhihu.ui.ARTICLE_USE_WEBVIEW_PREFERENCE_KEY
+import com.github.zly2006.zhihu.ui.components.SettingItem
+import com.github.zly2006.zhihu.ui.components.SettingItemGroup
+
+const val SETTINGS_SEARCH_INPUT_TAG = "settingsSearch.input"
+const val SETTINGS_SEARCH_RESULTS_TAG = "settingsSearch.results"
+
+private data class SettingsSearchEntry(
+    val id: String,
+    val title: String,
+    val section: String,
+    val description: String,
+    val destination: NavDestination,
+    val keywords: List<String> = emptyList(),
+) {
+    fun matches(query: String): Boolean {
+        val normalizedTerms = query
+            .trim()
+            .lowercase()
+            .split(Regex("\\s+"))
+            .filter { it.isNotEmpty() }
+        if (normalizedTerms.isEmpty()) return true
+        val searchableText = buildString {
+            append(title)
+            append('\n')
+            append(section)
+            append('\n')
+            append(description)
+            if (keywords.isNotEmpty()) {
+                append('\n')
+                append(keywords.joinToString(" "))
+            }
+        }.lowercase()
+        return normalizedTerms.all(searchableText::contains)
+    }
+}
+
+private fun appearanceEntry(
+    id: String,
+    title: String,
+    description: String,
+    settingKey: String,
+    keywords: List<String> = emptyList(),
+): SettingsSearchEntry = SettingsSearchEntry(
+    id = id,
+    title = title,
+    section = "外观与阅读体验",
+    description = description,
+    destination = Account.AppearanceSettings(setting = settingKey),
+    keywords = keywords,
+)
+
+private fun recommendEntry(
+    id: String,
+    title: String,
+    description: String,
+    settingKey: String,
+    keywords: List<String> = emptyList(),
+): SettingsSearchEntry = SettingsSearchEntry(
+    id = id,
+    title = title,
+    section = "推荐系统与内容过滤",
+    description = description,
+    destination = Account.RecommendSettings(setting = settingKey),
+    keywords = keywords,
+)
+
+private fun systemEntry(
+    id: String,
+    title: String,
+    description: String,
+    settingKey: String,
+    keywords: List<String> = emptyList(),
+): SettingsSearchEntry = SettingsSearchEntry(
+    id = id,
+    title = title,
+    section = "系统与更新",
+    description = description,
+    destination = Account.SystemAndUpdateSettings(setting = settingKey),
+    keywords = keywords,
+)
+
+private fun notificationEntry(
+    id: String,
+    title: String,
+    description: String,
+    settingKey: String,
+    keywords: List<String> = emptyList(),
+): SettingsSearchEntry = SettingsSearchEntry(
+    id = id,
+    title = title,
+    section = "通知设置",
+    description = description,
+    destination = Notification.NotificationSettings(setting = settingKey),
+    keywords = keywords,
+)
+
+private val settingsSearchEntries = buildList {
+    add(appearanceEntry("appearance.nightMode", "主题模式", "切换浅色、深色或跟随系统。", "nightMode", listOf("夜间模式", "深色模式")))
+    add(appearanceEntry("appearance.dynamicColor", "使用 Material You 动态取色", "Android 12+ 根据系统壁纸取色。", "dynamicColor", listOf("动态颜色")))
+    add(appearanceEntry("appearance.fontScale", "字号与行高", "调整正文阅读字号和行距。", "fontScale", listOf("字体大小", "内容字体")))
+    add(appearanceEntry("appearance.showFeedThumbnail", "显示 Feed 卡片缩略图", "控制信息流卡片图片显示。", "showFeedThumbnail", listOf("图片", "封面")))
+    add(appearanceEntry("appearance.showRefreshFab", "显示刷新 FAB 按钮", "控制首页和列表的浮动刷新按钮。", "showRefreshFab", listOf("刷新按钮", "浮动按钮")))
+    add(appearanceEntry("appearance.feedCardStyle", "信息流样式", "切换卡片或分割线样式。", "feedCardStyle", listOf("Feed", "列表样式")))
+    add(appearanceEntry("appearance.webviewRender", "使用 WebView 显示文章", "切换文章、回答、想法正文渲染方式。", ARTICLE_USE_WEBVIEW_PREFERENCE_KEY))
+    add(appearanceEntry("appearance.titleAutoHide", "自动隐藏回答标题", "阅读时自动收起顶部标题。", "titleAutoHide", listOf("标题栏")))
+    add(appearanceEntry("appearance.autoHideArticleBottomBar", "自动隐藏回答底部按钮", "滚动阅读时自动隐藏底部操作栏。", "autoHideArticleBottomBar"))
+    add(appearanceEntry("appearance.buttonSkipAnswer", "显示跳转下一个回答按钮", "在回答页显示快速跳转按钮。", "buttonSkipAnswer", listOf("下一个回答")))
+    add(appearanceEntry("appearance.pinAnswerDate", "置顶回答日期", "调整回答日期在正文中的位置。", "pinAnswerDate"))
+    add(appearanceEntry("appearance.answerSwitchMode", "回答切换手势", "设置回答之间的上下或左右切换。", "answerSwitchMode", listOf("手势")))
+    add(appearanceEntry("appearance.answerDoubleTapAction", "双击回答动作", "设置双击正文后的默认动作。", ANSWER_DOUBLE_TAP_ACTION_PREFERENCE_KEY, listOf("双击")))
+    add(appearanceEntry("appearance.bottomBar", "底部导航栏", "启动页、底栏显示页面和底栏行为。", APPEARANCE_SETTINGS_BOTTOM_BAR_SECTION_KEY, listOf("启动默认页面", "底部栏")))
+    add(appearanceEntry("appearance.shareAction", "分享操作", "设置分享按钮默认复制、分享或询问。", "shareAction"))
+    add(appearanceEntry("appearance.showSearchHotSearch", "搜索界面显示热搜", "控制搜索页空查询时是否展示热搜。", "showSearchHotSearch", listOf("热搜")))
+    add(appearanceEntry("appearance.showSearchHistory", "记录并显示搜索历史", "控制搜索历史记录和展示。", "showSearchHistory", listOf("搜索记录")))
+    add(appearanceEntry("appearance.customNavHost", "使用自定义导航", "切换实验性的导航实现。", "use_custom_nav_host"))
+    add(appearanceEntry("appearance.predictiveBack", "启用预测性返回", "控制 Android 预测性返回动画。", "enable_predictive_back", listOf("返回手势")))
+    add(appearanceEntry("appearance.duo3", "123Duo3 新 UI", "集中管理 Duo3 视觉和交互开关。", "123Duo3", listOf("新UI", "Duo3")))
+
+    add(recommendEntry("recommend.recommendationMode", "推荐算法", "选择 Web、Android、本地或混合推荐。", "recommendationMode", listOf("推荐来源")))
+    add(recommendEntry("recommend.loginForRecommendation", "推荐内容时登录", "获取推荐内容时是否带登录凭证。", "loginForRecommendation"))
+    add(recommendEntry("recommend.enableQualityFilter", "启用质量过滤规则", "按赞同数、关注数等指标过滤内容。", "enableQualityFilter", listOf("低质量")))
+    add(recommendEntry("recommend.enableContentFilter", "启用智能内容过滤", "过滤重复出现但未点击内容。", "enableContentFilter"))
+    add(recommendEntry("recommend.filterFollowedUserContent", "过滤已关注用户内容", "控制是否过滤已关注用户的内容。", "filterFollowedUserContent"))
+    add(recommendEntry("recommend.enableKeywordBlocking", "启用关键词屏蔽", "按关键词过滤内容。", "enableKeywordBlocking", listOf("关键词")))
+    add(recommendEntry("recommend.enableUserBlocking", "启用用户屏蔽", "按用户过滤内容。", "enableUserBlocking", listOf("作者屏蔽")))
+    add(recommendEntry("recommend.enableTopicBlocking", "启用主题屏蔽", "按命中主题过滤内容。", "enableTopicBlocking"))
+    add(recommendEntry("recommend.topicBlockingThreshold", "主题屏蔽阈值", "设置命中多少个被屏蔽主题后才过滤内容。", "topicBlockingThreshold", listOf("主题阈值")))
+    add(recommendEntry("recommend.blockZhihuAdPlatform", "屏蔽知乎广告平台内容", "过滤知乎广告平台推广内容。", "blockZhihuAdPlatform", listOf("广告")))
+    add(recommendEntry("recommend.blockZhihuSchool", "屏蔽知乎学堂内容", "过滤知乎学堂和教育推广内容。", "blockZhihuSchool", listOf("学堂")))
+    add(recommendEntry("recommend.blockWeChatOfficialAccount", "屏蔽微信公众号文章", "过滤微信公众号外链内容。", "blockWeChatOfficialAccount", listOf("微信")))
+    add(recommendEntry("recommend.blockPaidContent", "屏蔽知乎盐选付费内容", "过滤会员付费内容。", "blockPaidContent", listOf("盐选", "付费")))
+    add(recommendEntry("recommend.reverseBlock", "反向屏蔽", "只保留广告和付费内容的调试模式。", "reverseBlock"))
+    add(
+        SettingsSearchEntry(
+            id = "recommend.blocklist",
+            title = "管理屏蔽列表",
+            section = "推荐系统与内容过滤",
+            description = "管理关键词、用户和主题屏蔽。",
+            destination = Account.RecommendSettings.Blocklist,
+            keywords = listOf("黑名单"),
+        ),
+    )
+    add(
+        SettingsSearchEntry(
+            id = "recommend.blockedHistory",
+            title = "屏蔽记录",
+            section = "推荐系统与内容过滤",
+            description = "查看最近被过滤的内容。",
+            destination = Account.RecommendSettings.BlockedFeedHistory,
+            keywords = listOf("过滤记录"),
+        ),
+    )
+
+    add(systemEntry("system.githubToken", "GitHub Token", "配置更新检查时使用的 GitHub API 令牌。", "githubToken", listOf("限速", "更新检查")))
+    add(systemEntry("system.autoCheckUpdates", "自动检查更新", "应用启动后后台检查新版本。", "autoCheckUpdates", listOf("更新提醒")))
+    add(systemEntry("system.checkNightlyUpdates", "检查 Nightly 版本更新", "检查每日构建版本。", "checkNightlyUpdates", listOf("每日构建")))
+    add(systemEntry("system.allowTelemetry", "允许发送遥测统计数据", "控制匿名使用统计。", "allowTelemetry", listOf("统计", "隐私")))
+    add(systemEntry("system.aigcMarking", "启用 AIGC 标记", "开启后可查看其他用户对内容是否疑似 AIGC 的标记。", AIGC_MARKING_ENABLED_PREFERENCE_KEY, listOf("AI", "AIGC")))
+    add(systemEntry("system.reminder", "防沉迷提醒", "设置连续使用提醒的间隔。", CONTINUOUS_USAGE_REMINDER_INTERVAL_MINUTES_KEY, listOf("连续使用", "休息提醒")))
+
+    add(notificationEntry("notification.autoMarkAsRead", "打开通知自动已读", "进入通知页后自动标记当前批次为已读。", "autoMarkAsRead", listOf("已读")))
+    add(notificationEntry("notification.unreadBadge", "显示未读红点", "控制首页和账号入口的未读角标。", "unreadBadge", listOf("角标", "红点")))
+    add(notificationEntry("notification.systemNotifications", "系统通知", "控制是否向系统发送各类通知。", "systemNotifications", NotificationType.entries.map { it.displayName }))
+    add(notificationEntry("notification.displayInAppNotifications", "应用内显示", "控制通知页展示哪些通知类型。", "displayInAppNotifications", NotificationType.entries.map { it.displayName }))
+
+    add(
+        SettingsSearchEntry(
+            id = "developer.page",
+            title = "开发者选项",
+            section = "开发者",
+            description = "调试、签名、Cookie 和实验入口。",
+            destination = Account.DeveloperSettings,
+            keywords = listOf("Cookie", "调试", "签名请求", "验证登录", "刷新Token"),
+        ),
+    )
+    add(
+        SettingsSearchEntry(
+            id = "about.licenses",
+            title = "开源许可",
+            section = "关于",
+            description = "查看第三方组件许可证。",
+            destination = Account.OpenSourceLicenses,
+            keywords = listOf("许可证"),
+        ),
+    )
+}
+
+/**
+ * 设置搜索页。
+ *
+ * 这里维护的是“可搜索标签 -> 已有设置页 route”的轻量索引，不复制设置项实现。新增设置如果已经支持 `settingKey`
+ * 高亮，应补一条索引；不支持高亮的页面级入口只跳到对应页面。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsSearchScreen() {
+    val navigator = LocalNavigator.current
+    var query by rememberSaveable { mutableStateOf("") }
+    val results = remember(query) {
+        settingsSearchEntries.filter { it.matches(query) }
+    }
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize().nestedScroll(scrollBehavior.nestedScrollConnection),
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        topBar = {
+            LargeTopAppBar(
+                title = { Text("搜索设置项") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navigator.onNavigateBack,
+                        colors = IconButtonDefaults.iconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        ),
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                scrollBehavior = scrollBehavior,
+                colors = TopAppBarDefaults.topAppBarColors().copy(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                    scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                ),
+            )
+        },
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(SETTINGS_SEARCH_RESULTS_TAG)
+                .padding(innerPadding),
+        ) {
+            item {
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = { query = it },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                        .padding(top = 8.dp, bottom = 16.dp)
+                        .testTag(SETTINGS_SEARCH_INPUT_TAG),
+                    leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                    placeholder = { Text("搜索设置名称或关键词") },
+                    singleLine = true,
+                )
+            }
+
+            if (results.isEmpty()) {
+                item {
+                    Text(
+                        text = "没有找到相关设置",
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else {
+                items(
+                    items = results,
+                    key = { it.id },
+                ) { entry ->
+                    SettingItemGroup {
+                        SettingItem(
+                            modifier = Modifier.testTag("settingsSearch.result.${entry.id}"),
+                            title = {
+                                Column {
+                                    Text(entry.title)
+                                    Text(
+                                        text = entry.section,
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = MaterialTheme.colorScheme.primary,
+                                    )
+                                }
+                            },
+                            description = {
+                                Text(entry.description)
+                            },
+                            onClick = { navigator.onNavigate(entry.destination) },
+                            endAction = {
+                                Icon(
+                                    Icons.AutoMirrored.Filled.ArrowForward,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
@@ -154,35 +154,59 @@ private fun notificationEntry(
 )
 
 private val settingsSearchEntries = buildList {
-    add(appearanceEntry("appearance.nightMode", "主题模式", "切换浅色、深色或跟随系统。", "nightMode", listOf("夜间模式", "深色模式")))
-    add(appearanceEntry("appearance.dynamicColor", "使用 Material You 动态取色", "Android 12+ 根据系统壁纸取色。", "dynamicColor", listOf("动态颜色")))
-    add(appearanceEntry("appearance.fontScale", "字号与行高", "调整正文阅读字号和行距。", "fontScale", listOf("字体大小", "内容字体")))
+    add(appearanceEntry("appearance.nightMode", "主题模式", "切换浅色、深色或跟随系统。", "nightMode", listOf("夜间模式", "深色模式", "暗色模式", "浅色模式", "跟随系统")))
+    add(appearanceEntry("appearance.dynamicColor", "使用 Material You 动态取色", "Android 12+ 根据系统壁纸取色。", "dynamicColor", listOf("动态颜色", "壁纸取色", "主题色")))
+    add(appearanceEntry("appearance.fontScale", "字号与行高", "调整正文阅读字号和行距。", "fontScale", listOf("字体大小", "内容字体", "正文字号", "行距")))
     add(appearanceEntry("appearance.showFeedThumbnail", "显示 Feed 卡片缩略图", "控制信息流卡片图片显示。", "showFeedThumbnail", listOf("图片", "封面")))
     add(appearanceEntry("appearance.showRefreshFab", "显示刷新 FAB 按钮", "控制首页和列表的浮动刷新按钮。", "showRefreshFab", listOf("刷新按钮", "浮动按钮")))
-    add(appearanceEntry("appearance.feedCardStyle", "信息流样式", "切换卡片或分割线样式。", "feedCardStyle", listOf("Feed", "列表样式")))
+    add(appearanceEntry("appearance.feedCardStyle", "信息流样式", "切换卡片或分割线样式。", "feedCardStyle", listOf("Feed", "列表样式", "卡片样式", "分割线")))
     add(appearanceEntry("appearance.webviewRender", "使用 WebView 显示文章", "切换文章、回答、想法正文渲染方式。", ARTICLE_USE_WEBVIEW_PREFERENCE_KEY))
     add(appearanceEntry("appearance.titleAutoHide", "自动隐藏回答标题", "阅读时自动收起顶部标题。", "titleAutoHide", listOf("标题栏")))
     add(appearanceEntry("appearance.autoHideArticleBottomBar", "自动隐藏回答底部按钮", "滚动阅读时自动隐藏底部操作栏。", "autoHideArticleBottomBar"))
     add(appearanceEntry("appearance.buttonSkipAnswer", "显示跳转下一个回答按钮", "在回答页显示快速跳转按钮。", "buttonSkipAnswer", listOf("下一个回答")))
     add(appearanceEntry("appearance.pinAnswerDate", "置顶回答日期", "调整回答日期在正文中的位置。", "pinAnswerDate"))
-    add(appearanceEntry("appearance.answerSwitchMode", "回答切换手势", "设置回答之间的上下或左右切换。", "answerSwitchMode", listOf("手势")))
+    add(appearanceEntry("appearance.answerSwitchMode", "回答切换手势", "设置回答之间的上下或左右切换。", "answerSwitchMode", listOf("手势", "上下滑动", "左右滑动", "切换回答")))
     add(appearanceEntry("appearance.answerDoubleTapAction", "双击回答动作", "设置双击正文后的默认动作。", ANSWER_DOUBLE_TAP_ACTION_PREFERENCE_KEY, listOf("双击")))
-    add(appearanceEntry("appearance.bottomBar", "底部导航栏", "启动页、底栏显示页面和底栏行为。", APPEARANCE_SETTINGS_BOTTOM_BAR_SECTION_KEY, listOf("启动默认页面", "底部栏")))
-    add(appearanceEntry("appearance.shareAction", "分享操作", "设置分享按钮默认复制、分享或询问。", "shareAction"))
+    add(
+        appearanceEntry(
+            "appearance.bottomBar",
+            "底部导航栏",
+            "启动页、底栏显示页面和底栏行为。",
+            APPEARANCE_SETTINGS_BOTTOM_BAR_SECTION_KEY,
+            listOf(
+                "启动默认页面",
+                "底部栏",
+                "主页",
+                "首页",
+                "关注",
+                "日报",
+                "热榜",
+                "历史",
+                "浏览历史",
+                "收藏",
+                "收藏夹",
+                "账号",
+                "回到顶部",
+                "双击刷新",
+                "自动隐藏底栏",
+            ),
+        ),
+    )
+    add(appearanceEntry("appearance.shareAction", "分享操作", "设置分享按钮默认复制、分享或询问。", "shareAction", listOf("复制链接", "分享链接", "分享按钮")))
     add(appearanceEntry("appearance.showSearchHotSearch", "搜索界面显示热搜", "控制搜索页空查询时是否展示热搜。", "showSearchHotSearch", listOf("热搜")))
-    add(appearanceEntry("appearance.showSearchHistory", "记录并显示搜索历史", "控制搜索历史记录和展示。", "showSearchHistory", listOf("搜索记录")))
+    add(appearanceEntry("appearance.showSearchHistory", "记录并显示搜索历史", "控制搜索历史记录和展示。", "showSearchHistory", listOf("搜索记录", "历史记录", "清除搜索历史")))
     add(appearanceEntry("appearance.customNavHost", "使用自定义导航", "切换实验性的导航实现。", "use_custom_nav_host"))
     add(appearanceEntry("appearance.predictiveBack", "启用预测性返回", "控制 Android 预测性返回动画。", "enable_predictive_back", listOf("返回手势")))
     add(appearanceEntry("appearance.duo3", "123Duo3 新 UI", "集中管理 Duo3 视觉和交互开关。", "123Duo3", listOf("新UI", "Duo3")))
 
-    add(recommendEntry("recommend.recommendationMode", "推荐算法", "选择 Web、Android、本地或混合推荐。", "recommendationMode", listOf("推荐来源")))
+    add(recommendEntry("recommend.recommendationMode", "推荐算法", "选择 Web、Android、本地或混合推荐。", "recommendationMode", listOf("推荐来源", "Web 推荐", "Android 推荐", "本地推荐", "混合推荐")))
     add(recommendEntry("recommend.loginForRecommendation", "推荐内容时登录", "获取推荐内容时是否带登录凭证。", "loginForRecommendation"))
     add(recommendEntry("recommend.enableQualityFilter", "启用质量过滤规则", "按赞同数、关注数等指标过滤内容。", "enableQualityFilter", listOf("低质量")))
     add(recommendEntry("recommend.enableContentFilter", "启用智能内容过滤", "过滤重复出现但未点击内容。", "enableContentFilter"))
     add(recommendEntry("recommend.filterFollowedUserContent", "过滤已关注用户内容", "控制是否过滤已关注用户的内容。", "filterFollowedUserContent"))
-    add(recommendEntry("recommend.enableKeywordBlocking", "启用关键词屏蔽", "按关键词过滤内容。", "enableKeywordBlocking", listOf("关键词")))
-    add(recommendEntry("recommend.enableUserBlocking", "启用用户屏蔽", "按用户过滤内容。", "enableUserBlocking", listOf("作者屏蔽")))
-    add(recommendEntry("recommend.enableTopicBlocking", "启用主题屏蔽", "按命中主题过滤内容。", "enableTopicBlocking"))
+    add(recommendEntry("recommend.enableKeywordBlocking", "启用关键词屏蔽", "按关键词过滤内容。", "enableKeywordBlocking", listOf("关键词", "屏蔽词")))
+    add(recommendEntry("recommend.enableUserBlocking", "启用用户屏蔽", "按用户过滤内容。", "enableUserBlocking", listOf("作者屏蔽", "屏蔽用户")))
+    add(recommendEntry("recommend.enableTopicBlocking", "启用主题屏蔽", "按命中主题过滤内容。", "enableTopicBlocking", listOf("话题屏蔽", "屏蔽话题")))
     add(recommendEntry("recommend.topicBlockingThreshold", "主题屏蔽阈值", "设置命中多少个被屏蔽主题后才过滤内容。", "topicBlockingThreshold", listOf("主题阈值")))
     add(recommendEntry("recommend.blockZhihuAdPlatform", "屏蔽知乎广告平台内容", "过滤知乎广告平台推广内容。", "blockZhihuAdPlatform", listOf("广告")))
     add(recommendEntry("recommend.blockZhihuSchool", "屏蔽知乎学堂内容", "过滤知乎学堂和教育推广内容。", "blockZhihuSchool", listOf("学堂")))
@@ -196,7 +220,7 @@ private val settingsSearchEntries = buildList {
             section = "推荐系统与内容过滤",
             description = "管理关键词、用户和主题屏蔽。",
             destination = Account.RecommendSettings.Blocklist,
-            keywords = listOf("黑名单"),
+            keywords = listOf("黑名单", "屏蔽词", "屏蔽用户", "屏蔽话题"),
         ),
     )
     add(
@@ -210,15 +234,15 @@ private val settingsSearchEntries = buildList {
         ),
     )
 
-    add(systemEntry("system.githubToken", "GitHub Token", "配置更新检查时使用的 GitHub API 令牌。", "githubToken", listOf("限速", "更新检查")))
+    add(systemEntry("system.githubToken", "GitHub Token", "配置更新检查时使用的 GitHub API 令牌。", "githubToken", listOf("限速", "更新检查", "令牌")))
     add(systemEntry("system.autoCheckUpdates", "自动检查更新", "应用启动后后台检查新版本。", "autoCheckUpdates", listOf("更新提醒")))
     add(systemEntry("system.checkNightlyUpdates", "检查 Nightly 版本更新", "检查每日构建版本。", "checkNightlyUpdates", listOf("每日构建")))
-    add(systemEntry("system.allowTelemetry", "允许发送遥测统计数据", "控制匿名使用统计。", "allowTelemetry", listOf("统计", "隐私")))
+    add(systemEntry("system.allowTelemetry", "允许发送遥测统计数据", "控制匿名使用统计。", "allowTelemetry", listOf("统计", "隐私", "数据收集", "使用数据")))
     add(systemEntry("system.aigcMarking", "启用 AIGC 标记", "开启后可查看其他用户对内容是否疑似 AIGC 的标记。", AIGC_MARKING_ENABLED_PREFERENCE_KEY, listOf("AI", "AIGC")))
     add(systemEntry("system.reminder", "防沉迷提醒", "设置连续使用提醒的间隔。", CONTINUOUS_USAGE_REMINDER_INTERVAL_MINUTES_KEY, listOf("连续使用", "休息提醒")))
 
-    add(notificationEntry("notification.autoMarkAsRead", "打开通知自动已读", "进入通知页后自动标记当前批次为已读。", "autoMarkAsRead", listOf("已读")))
-    add(notificationEntry("notification.unreadBadge", "显示未读红点", "控制首页和账号入口的未读角标。", "unreadBadge", listOf("角标", "红点")))
+    add(notificationEntry("notification.autoMarkAsRead", "打开通知自动已读", "进入通知页后自动标记当前批次为已读。", "autoMarkAsRead", listOf("已读", "标记已读")))
+    add(notificationEntry("notification.unreadBadge", "显示未读红点", "控制首页和账号入口的未读角标。", "unreadBadge", listOf("角标", "红点", "未读数")))
     add(notificationEntry("notification.systemNotifications", "系统通知", "控制是否向系统发送各类通知。", "systemNotifications", NotificationType.entries.map { it.displayName }))
     add(notificationEntry("notification.displayInAppNotifications", "应用内显示", "控制通知页展示哪些通知类型。", "displayInAppNotifications", NotificationType.entries.map { it.displayName }))
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
@@ -47,13 +47,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import com.github.zly2006.zhihu.data.AIGC_MARKING_ENABLED_PREFERENCE_KEY
 import com.github.zly2006.zhihu.navigation.Account
 import com.github.zly2006.zhihu.navigation.LocalNavigator
 import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.navigation.Notification
-import com.github.zly2006.zhihu.shared.aigc.AIGC_MARKING_ENABLED_PREFERENCE_KEY
-import com.github.zly2006.zhihu.shared.notification.NotificationType
-import com.github.zly2006.zhihu.shared.ui.ANSWER_DOUBLE_TAP_ACTION_PREFERENCE_KEY
+import com.github.zly2006.zhihu.notification.NotificationType
+import com.github.zly2006.zhihu.ui.ANSWER_DOUBLE_TAP_ACTION_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.ARTICLE_USE_WEBVIEW_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.components.SettingItem
 import com.github.zly2006.zhihu.ui.components.SettingItemGroup

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -53,6 +54,7 @@ import com.github.zly2006.zhihu.navigation.LocalNavigator
 import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.navigation.Notification
 import com.github.zly2006.zhihu.notification.NotificationType
+import com.github.zly2006.zhihu.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.ui.ANSWER_DOUBLE_TAP_ACTION_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.ARTICLE_USE_WEBVIEW_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.components.SettingItem
@@ -252,9 +254,23 @@ private val settingsSearchEntries = buildList {
 @Composable
 fun SettingsSearchScreen() {
     val navigator = LocalNavigator.current
+    val settings = rememberSettingsStore()
     var query by rememberSaveable { mutableStateOf("") }
-    val results = remember(query) {
-        settingsSearchEntries.filter { it.matches(query) }
+    var developerModeEnabled by remember {
+        mutableStateOf(settings.getBoolean("developer", false))
+    }
+    DisposableEffect(settings) {
+        val unregister = settings.observeKeyChanges { key ->
+            if (key == "developer") {
+                developerModeEnabled = settings.getBoolean("developer", false)
+            }
+        }
+        onDispose(unregister)
+    }
+    val results = remember(query, developerModeEnabled) {
+        settingsSearchEntries
+            .filter { entry -> entry.id != "developer.page" || developerModeEnabled }
+            .filter { entry -> entry.matches(query) }
     }
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
 
@@ -334,7 +350,11 @@ fun SettingsSearchScreen() {
                             description = {
                                 Text(entry.description)
                             },
-                            onClick = { navigator.onNavigate(entry.destination) },
+                            onClick = {
+                                if (entry.id != "developer.page" || settings.getBoolean("developer", false)) {
+                                    navigator.onNavigate(entry.destination)
+                                }
+                            },
                             endAction = {
                                 Icon(
                                     Icons.AutoMirrored.Filled.ArrowForward,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SystemAndUpdateSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SystemAndUpdateSettingsScreen.kt
@@ -100,11 +100,14 @@ const val SYSTEM_SETTINGS_AIGC_MARKING_TAG = "system_settings_aigc_marking"
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SystemAndUpdateSettingsScreen() {
+fun SystemAndUpdateSettingsScreen(
+    setting: String? = null,
+) {
     val settings = rememberSettingsStore()
     val updates = rememberSystemUpdateRuntime()
     val openExternalUrl = rememberExternalUrlOpener()
     val navigator = LocalNavigator.current
+    val highlightedSetting = setting.orEmpty()
 
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
 
@@ -308,6 +311,8 @@ fun SystemAndUpdateSettingsScreen() {
                             "用于访问 GitHub API 时解除限速，提高更新检查的稳定性。留空则使用匿名访问，检查更新可能会失败。",
                         )
                     },
+                    settingKey = "githubToken",
+                    highlightedKey = highlightedSetting,
                     bottomAction = {
                         OutlinedTextField(
                             value = githubToken,
@@ -339,6 +344,8 @@ fun SystemAndUpdateSettingsScreen() {
                         autoCheckUpdates = it
                         updates.setAutoCheckEnabled(it)
                     },
+                    settingKey = "autoCheckUpdates",
+                    highlightedKey = highlightedSetting,
                 )
 
                 var checkNightlyUpdates by remember { mutableStateOf(settings.getBoolean("checkNightlyUpdates", false)) }
@@ -350,6 +357,8 @@ fun SystemAndUpdateSettingsScreen() {
                         checkNightlyUpdates = it
                         settings.putBoolean("checkNightlyUpdates", it)
                     },
+                    settingKey = "checkNightlyUpdates",
+                    highlightedKey = highlightedSetting,
                 )
 
                 var allowTelemetry by remember { mutableStateOf(settings.getBoolean("allowTelemetry", true)) }
@@ -361,6 +370,8 @@ fun SystemAndUpdateSettingsScreen() {
                         allowTelemetry = it
                         settings.putBoolean("allowTelemetry", it)
                     },
+                    settingKey = "allowTelemetry",
+                    highlightedKey = highlightedSetting,
                 )
 
                 var aigcMarkingEnabled by remember {
@@ -380,6 +391,7 @@ fun SystemAndUpdateSettingsScreen() {
                         settings.putBoolean(AIGC_MARKING_ENABLED_PREFERENCE_KEY, it)
                     },
                     settingKey = AIGC_MARKING_ENABLED_PREFERENCE_KEY,
+                    highlightedKey = highlightedSetting,
                 )
             }
 
@@ -440,6 +452,8 @@ fun SystemAndUpdateSettingsScreen() {
                 SettingItem(
                     title = { Text("防沉迷提醒") },
                     description = { Text("你已经连续浏览知乎 N 小时 M 分钟了，休息一下吧。退出后 5 分钟内重开仍视为连续使用。") },
+                    settingKey = CONTINUOUS_USAGE_REMINDER_INTERVAL_MINUTES_KEY,
+                    highlightedKey = highlightedSetting,
                     endAction = {
                         ExposedDropdownMenuBox(
                             expanded = reminderExpanded,


### PR DESCRIPTION
## 摘要

- 将设置搜索分支迁移到最新 `master`
- 在账号页设置区最上方放置“搜索设置项”入口，并移除 supporting 文案
- 新增设置项搜索页，按名称、说明和候选词筛选并跳转到已有设置页面
- 加强候选词覆盖，使“热榜”等页面名称及常用同义表达能命中对应设置

## 变更内容

- 新增 `Account.SettingsSearch` route，并在主导航中注册搜索页
- 搜索入口使用账号页顶部搜索条，不调整其余设置项布局
- 搜索结果复用现有 route 和 `settingKey` 高亮能力，不复制设置项实现
- 为主题、字号、信息流、回答切换、底部导航、搜索历史、推荐模式、屏蔽、通知等设置补充常用候选词
- “热榜”会命中“底部导航栏”，并跳转到对应设置分组
- 开发者入口继续受现有开发者模式开关约束，搜索不能绕过隐藏入口

## 测试

- 新增“热榜”候选词命中底部导航栏并跳转的 Android instrumentation 回归测试
- 保留设置搜索筛选、系统/通知跳转和开发者入口权限测试
- 按用户要求跳过本地验证，本轮验证交由 GitHub CI

## 截图

- 本轮未在本地启动 AVD；UI 与 instrumentation 验证交由 GitHub CI

Resolves #262
