### PR TITLE
fix: 修复外部广告链接跳转知乎++报错

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
@@ -286,7 +286,9 @@ data class Pin(
 
 fun resolveContent(url: String): NavDestination? = runCatching { resolveContent(Url(url)) }.getOrNull()
 
-fun resolveContent(url: Url): NavDestination? {
+fun resolveContent(url: Url): NavDestination? = resolveContent(url, redirectDepth = 0)
+
+private fun resolveContent(url: Url, redirectDepth: Int): NavDestination? {
     val segments = url.segments
     if (url.protocol.name == "http" || url.protocol.name == "https") {
         if (url.host == "zhihu.com" || url.host == "www.zhihu.com") {
@@ -312,6 +314,25 @@ fun resolveContent(url: Url): NavDestination? {
             ) {
                 val articleId = segments[2].toLong()
                 return Article(type = ArticleType.Article, id = articleId)
+            } else if (segments.size == 2 &&
+                segments[0] == "p"
+            ) {
+                val articleId = segments[1].toLong()
+                return Article(type = ArticleType.Article, id = articleId)
+            } else if (segments.size == 4 &&
+                segments[0] == "appview" &&
+                segments[1] == "v2" &&
+                segments[2] == "answer"
+            ) {
+                val answerId = segments[3].toLong()
+                return Article(type = ArticleType.Answer, id = answerId)
+            } else if (segments.size == 4 &&
+                segments[0] == "appview" &&
+                segments[1] == "v2" &&
+                segments[2] == "article"
+            ) {
+                val articleId = segments[3].toLong()
+                return Article(type = ArticleType.Article, id = articleId)
             } else if (segments.size == 2 && segments[0] == "people") {
                 val urlToken = segments[1]
                 if (urlToken.length == 32 && urlToken.all { it in '0'..'9' || it in 'a'..'f' }) {
@@ -333,6 +354,9 @@ fun resolveContent(url: Url): NavDestination? {
                 val query = url.parameters["q"] ?: ""
                 return Search(query)
             }
+            if (segments.size >= 2 && segments[0] == "market" && segments[1] == "paid_column") {
+                resolveRedirectTarget(url, redirectDepth, "source")?.let { return it }
+            }
             Log.w("NavDestination", "Cannot resolve content from url: $url")
         } else if (url.host == "zhuanlan.zhihu.com") {
             if (segments.size == 2 &&
@@ -343,8 +367,7 @@ fun resolveContent(url: Url): NavDestination? {
             }
             Log.w("NavDestination", "Cannot resolve content from url: $url")
         } else if (url.host == "link.zhihu.com") {
-            val target = url.parameters["target"] ?: return null
-            return runCatching { Url(target) }.getOrNull()?.let(::resolveContent)
+            return resolveRedirectTarget(url, redirectDepth, "target", "target_url")
         }
     }
     if (url.protocol.name == "zhihu") {
@@ -369,4 +392,16 @@ fun resolveContent(url: Url): NavDestination? {
         Log.w("NavDestination", "Cannot resolve content from url: $url")
     }
     return null
+}
+
+private fun resolveRedirectTarget(url: Url, redirectDepth: Int, vararg parameterNames: String): NavDestination? {
+    if (redirectDepth >= 3) return null
+    return parameterNames.asSequence()
+        .mapNotNull(url.parameters::get)
+        .firstNotNullOfOrNull { target ->
+            val normalizedTarget = if (target.startsWith("//")) "https:$target" else target
+            runCatching { Url(normalizedTarget) }
+                .getOrNull()
+                ?.let { resolveContent(it, redirectDepth + 1) }
+        }
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
@@ -396,7 +396,8 @@ private fun resolveContent(url: Url, redirectDepth: Int): NavDestination? {
 
 private fun resolveRedirectTarget(url: Url, redirectDepth: Int, vararg parameterNames: String): NavDestination? {
     if (redirectDepth >= 3) return null
-    return parameterNames.asSequence()
+    return parameterNames
+        .asSequence()
         .mapNotNull(url.parameters::get)
         .firstNotNullOfOrNull { target ->
             val normalizedTarget = if (target.startsWith("//")) "https:$target" else target

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/navigation/NavDestinationTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/navigation/NavDestinationTest.kt
@@ -140,7 +140,8 @@ class NavDestinationTest {
     @Test
     fun ignoresRedirectTargetBeyondDepthGuardFromCommonCode() {
         val articleUrl = "https://www.zhihu.com/p/987654321"
-        val thirdRedirect = "https://link.zhihu.com/?target=${articleUrl.encodeURLParameter()}"
+        val fourthRedirect = "https://link.zhihu.com/?target=${articleUrl.encodeURLParameter()}"
+        val thirdRedirect = "https://link.zhihu.com/?target=${fourthRedirect.encodeURLParameter()}"
         val secondRedirect = "https://link.zhihu.com/?target=${thirdRedirect.encodeURLParameter()}"
         val firstRedirect = "https://link.zhihu.com/?target=${secondRedirect.encodeURLParameter()}"
 

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/navigation/NavDestinationTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/navigation/NavDestinationTest.kt
@@ -89,6 +89,18 @@ class NavDestinationTest {
     }
 
     @Test
+    fun resolvesProtocolRelativeZhihuAdSourceFromCommonCode() {
+        val destination = resolveContent(
+            "https://www.zhihu.com/market/paid_column/example.html" +
+                "?source=//www.zhihu.com/appview/v2/answer/3309625617",
+        )
+
+        val article = assertIs<Article>(destination)
+        assertEquals(ArticleType.Answer, article.type)
+        assertEquals(3309625617L, article.id)
+    }
+
+    @Test
     fun resolvesZhihuRedirectTargetToAdSourceFromCommonCode() {
         val destination = resolveContent(
             "https://link.zhihu.com/?target=" +

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/navigation/NavDestinationTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/navigation/NavDestinationTest.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 
 class NavDestinationTest {
     private val json = Json {
@@ -45,5 +46,84 @@ class NavDestinationTest {
         val article = assertIs<Article>(destination)
         assertEquals(ArticleType.Answer, article.type)
         assertEquals(42L, article.id)
+    }
+
+    @Test
+    fun resolvesMobileArticleUrlFromCommonCode() {
+        val destination = resolveContent("https://www.zhihu.com/p/123")
+
+        val article = assertIs<Article>(destination)
+        assertEquals(ArticleType.Article, article.type)
+        assertEquals(123L, article.id)
+    }
+
+    @Test
+    fun resolvesZhihuAdSourceToAnswerFromCommonCode() {
+        val destination = resolveContent(
+            "https://www.zhihu.com/market/paid_column/example.html" +
+                "?source=https%3A%2F%2Fwww.zhihu.com%2Fappview%2Fv2%2Fanswer%2F3309625617%3Futm_campaign%3Dad",
+        )
+
+        val article = assertIs<Article>(destination)
+        assertEquals(ArticleType.Answer, article.type)
+        assertEquals(3309625617L, article.id)
+    }
+
+    @Test
+    fun resolvesZhihuRedirectTargetToAdSourceFromCommonCode() {
+        val destination = resolveContent(
+            "https://link.zhihu.com/?target=" +
+                "https%3A%2F%2Fwww.zhihu.com%2Fmarket%2Fpaid_column%2Fexample.html%3Fsource%3D" +
+                "https%253A%252F%252Fwww.zhihu.com%252Fappview%252Fv2%252Fanswer%252F3309625617",
+        )
+
+        val article = assertIs<Article>(destination)
+        assertEquals(ArticleType.Answer, article.type)
+        assertEquals(3309625617L, article.id)
+    }
+
+    @Test
+    fun resolvesLaterZhihuAdSourceWhenEarlierTargetIsExternalFromCommonCode() {
+        val destination = resolveContent(
+            "https://www.zhihu.com/market/paid_column/example.html" +
+                "?url=https%3A%2F%2Fexample.com%2Flanding" +
+                "&source=https%3A%2F%2Fwww.zhihu.com%2Fappview%2Fv2%2Farticle%2F123456",
+        )
+
+        val article = assertIs<Article>(destination)
+        assertEquals(ArticleType.Article, article.type)
+        assertEquals(123456L, article.id)
+    }
+
+    @Test
+    fun resolvesZhihuRedirectTargetUrlToArticleFromCommonCode() {
+        val destination = resolveContent(
+            "https://link.zhihu.com/?target_url=https%3A%2F%2Fwww.zhihu.com%2Fp%2F987654321",
+        )
+
+        val article = assertIs<Article>(destination)
+        assertEquals(ArticleType.Article, article.type)
+        assertEquals(987654321L, article.id)
+    }
+
+    @Test
+    fun ignoresExternalRedirectTargetFromCommonCode() {
+        assertNull(resolveContent("https://link.zhihu.com/?target=https%3A%2F%2Fexample.com%2Fquestion%2F1"))
+    }
+
+    @Test
+    fun ignoresUngroundedZhihuRedirectParametersFromCommonCode() {
+        assertNull(
+            resolveContent(
+                "https://www.zhihu.com/not-a-content-page" +
+                    "?source=https%3A%2F%2Fwww.zhihu.com%2Fappview%2Fv2%2Fanswer%2F3309625617",
+            ),
+        )
+        assertNull(
+            resolveContent(
+                "https://xg.zhihu.com/ad" +
+                    "?target=https%3A%2F%2Fwww.zhihu.com%2Fp%2F987654321",
+            ),
+        )
     }
 }

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/navigation/NavDestinationTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/navigation/NavDestinationTest.kt
@@ -17,6 +17,7 @@
 
 package com.github.zly2006.zhihu.navigation
 
+import io.ktor.http.encodeURLParameter
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -101,7 +102,7 @@ class NavDestinationTest {
     }
 
     @Test
-    fun resolvesLaterZhihuAdSourceWhenEarlierTargetIsExternalFromCommonCode() {
+    fun resolvesZhihuAdSourceWhenUrlParameterIsExternalFromCommonCode() {
         val destination = resolveContent(
             "https://www.zhihu.com/market/paid_column/example.html" +
                 "?url=https%3A%2F%2Fexample.com%2Flanding" +
@@ -122,6 +123,28 @@ class NavDestinationTest {
         val article = assertIs<Article>(destination)
         assertEquals(ArticleType.Article, article.type)
         assertEquals(987654321L, article.id)
+    }
+
+    @Test
+    fun resolvesProtocolRelativeRedirectTargetFromCommonCode() {
+        val destination = resolveContent(
+            "https://link.zhihu.com/?target=" +
+                "//www.zhihu.com/appview/v2/article/123456".encodeURLParameter(),
+        )
+
+        val article = assertIs<Article>(destination)
+        assertEquals(ArticleType.Article, article.type)
+        assertEquals(123456L, article.id)
+    }
+
+    @Test
+    fun ignoresRedirectTargetBeyondDepthGuardFromCommonCode() {
+        val articleUrl = "https://www.zhihu.com/p/987654321"
+        val thirdRedirect = "https://link.zhihu.com/?target=${articleUrl.encodeURLParameter()}"
+        val secondRedirect = "https://link.zhihu.com/?target=${thirdRedirect.encodeURLParameter()}"
+        val firstRedirect = "https://link.zhihu.com/?target=${secondRedirect.encodeURLParameter()}"
+
+        assertNull(resolveContent(firstRedirect))
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/navigation/NavDestinationTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/navigation/NavDestinationTest.kt
@@ -58,6 +58,24 @@ class NavDestinationTest {
     }
 
     @Test
+    fun resolvesAppViewAnswerUrlFromCommonCode() {
+        val destination = resolveContent("https://www.zhihu.com/appview/v2/answer/3309625617")
+
+        val article = assertIs<Article>(destination)
+        assertEquals(ArticleType.Answer, article.type)
+        assertEquals(3309625617L, article.id)
+    }
+
+    @Test
+    fun resolvesAppViewArticleUrlFromCommonCode() {
+        val destination = resolveContent("https://www.zhihu.com/appview/v2/article/123456")
+
+        val article = assertIs<Article>(destination)
+        assertEquals(ArticleType.Article, article.type)
+        assertEquals(123456L, article.id)
+    }
+
+    @Test
     fun resolvesZhihuAdSourceToAnswerFromCommonCode() {
         val destination = resolveContent(
             "https://www.zhihu.com/market/paid_column/example.html" +


### PR DESCRIPTION
## 背景
- 修复外部广告链接拉起知乎++后出现 `Unsupported URL` 的问题。
- 当前问题主要出在 deeplink 解析只认直达内容页，不会继续解析广告落地页和知乎跳转页里的真实内容目标。

## 修改
- 为 `resolveContent(Url)` 增加受限递归解析，支持在 redirect 参数里继续解析知乎内容目标。
- 补齐 `www.zhihu.com/p/<id>`、`www.zhihu.com/appview/v2/answer/<id>`、`www.zhihu.com/appview/v2/article/<id>` 这几类广告链路里常见的内容 URL。
- 对 `www.zhihu.com/market/paid_column/...` 仅在 `source` 参数可落到真实知乎内容时继续跳转，避免把任意带 query 的页面都当成内容路由。
- 对 `link.zhihu.com` 同时支持 `target` / `target_url`，并新增对应回归测试。

## Focused Cleanup
- 按 `$zhihu-pp-ai-slop-cleaner` 跑了 low-call scan 和 similar-function scan。
- low-call 命中了 `resolveRedirectTarget`；已人工复查并保留：它不是薄包装，而是承载 redirect 参数优先级、scheme 归一化和递归深度限制的解析步骤。
- similar-function scan 没有命中本次改动文件里的重复 helper。
- `git diff --check` 通过，未引入空白或 patch 格式问题。

## 验证
- 已执行非 Gradle 检查：
  - `git diff --check`
  - `python3 .agents/skills/zhihu-pp-ai-slop-cleaner/scripts/scan_low_call_functions.py --root . --max-calls 2 --output /tmp/zhihu_low_functions_issue424.tsv`
  - `python3 .agents/skills/zhihu-pp-ai-slop-cleaner/scripts/find_similar_kotlin_functions.py --root . --threshold 0.82 --output /tmp/zhihu_similar_functions_issue424.tsv`
- 本地 **未继续** 运行 `assembleLiteDebug` / `ktlintFormat` / `NavDestination` Gradle 测试：在这台机器上，Gradle 9 即使传 `--no-daemon` 仍会 fork single-use `GradleDaemon`，会和并行 worktree 验证冲突。
- 这次以 GitHub CI 作为正式的 Gradle 构建、格式化和测试验证面。

## 风险
- 目前广告落地页只对有明确知乎内容目标的 `source` / `target` / `target_url` 做递归解析；如果后续发现还有别的广告参数名，需要再补有证据的定向分支。

Resolves #424
