### PR TITLE
feat: 支持图片分享

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,13 +54,14 @@ jobs:
         uses: android-actions/setup-android@v3
       # Run Tests Build
       - name: Run KtLint
-        run: ./gradlew ktlintCheck
+        run: ./gradlew --no-daemon --no-configuration-cache -Dkotlin.compiler.execution.strategy=in-process ktlintCheck
       - name: Run gradle tests
-        run: ./gradlew test
+        run: ./gradlew --no-daemon --no-configuration-cache -Dkotlin.compiler.execution.strategy=in-process test
       - name: Build App
         # Build .apk
         run: |
-          bash ./gradlew assembleFullDebug assembleLiteDebug
+          bash ./gradlew --no-daemon --no-configuration-cache -Dkotlin.compiler.execution.strategy=in-process assembleFullDebug
+          bash ./gradlew --no-daemon --no-configuration-cache -Dkotlin.compiler.execution.strategy=in-process assembleLiteDebug
         env:
           CI_BUILD_MINIFY: false
       - name: Move files

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleExportEnvironmentInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleExportEnvironmentInstrumentedTest.kt
@@ -46,6 +46,7 @@ class ArticleExportEnvironmentInstrumentedTest {
         val environment = SharedAndroidPaginationEnvironment(context, allowGuestAccess = true)
 
         assertNotNull(environment.articleImageExportRenderer { "" })
+        assertTrue(environment.canShareImage())
 
         val html = environment.buildArticleExportHtml(
             content = sampleArticleContent(),

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleExportEnvironmentInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleExportEnvironmentInstrumentedTest.kt
@@ -46,7 +46,6 @@ class ArticleExportEnvironmentInstrumentedTest {
         val environment = SharedAndroidPaginationEnvironment(context, allowGuestAccess = true)
 
         assertNotNull(environment.articleImageExportRenderer { "" })
-        assertTrue(environment.canShareImage())
 
         val html = environment.buildArticleExportHtml(
             content = sampleArticleContent(),

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleExportEnvironmentInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleExportEnvironmentInstrumentedTest.kt
@@ -41,7 +41,7 @@ import kotlin.math.roundToInt
 @RunWith(AndroidJUnit4::class)
 class ArticleExportEnvironmentInstrumentedTest {
     @Test
-    fun androidEnvironmentProvidesArticleImageExportPlatformCapabilities() {
+    fun androidEnvironmentProvidesArticleImageExportPlatformCapabilities() = runBlocking {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val environment = SharedAndroidPaginationEnvironment(context, allowGuestAccess = true)
 

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
@@ -18,11 +18,14 @@
 package com.github.zly2006.zhihu
 
 import android.content.Context
+import android.graphics.Bitmap
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.MutableState
+import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -47,6 +50,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
 
 @RunWith(AndroidJUnit4::class)
 class ArticleScreenInstrumentedTest {
@@ -93,6 +97,26 @@ class ArticleScreenInstrumentedTest {
         composeRule.onNodeWithText("离线作者").assertIsDisplayed()
         composeRule.onNodeWithText("IP属地：上海").assertExists()
         composeRule.onNodeWithText("第 1 段离线正文", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun articleActionsMenuShowsShareAsImageOffline() {
+        setArticleScreen()
+
+        composeRule.onNodeWithContentDescription("更多选项").assertIsDisplayed().performClick()
+        composeRule.onNodeWithText("以图片分享").assertIsDisplayed()
+
+        val screenshotFile = File(
+            requireNotNull(composeRule.activity.getExternalFilesDir(null)),
+            ISSUE_446_SCREENSHOT_FILE_NAME,
+        )
+        screenshotFile.outputStream().use { output ->
+            composeRule
+                .onNodeWithText("以图片分享")
+                .captureToImage()
+                .asAndroidBitmap()
+                .compress(Bitmap.CompressFormat.PNG, 100, output)
+        }
     }
 
     @Test
@@ -225,6 +249,8 @@ class ArticleScreenInstrumentedTest {
     }
 
     private companion object {
+        const val ISSUE_446_SCREENSHOT_FILE_NAME = "issue-446-article-share-menu.png"
+
         val ARTICLE = Article(
             type = ArticleType.Article,
             id = 777L,

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
@@ -97,7 +97,7 @@ class ArticleScreenInstrumentedTest {
 
     @Test
     fun articleActionsMenuShowsShareAsImageOffline() {
-        setArticleScreen()
+        setArticleScreen(shareArticleImage = { _, _ -> })
 
         composeRule.onNodeWithContentDescription("更多选项").assertIsDisplayed().performClick()
         composeRule.onNodeWithText("以图片分享").assertIsDisplayed()
@@ -169,7 +169,9 @@ class ArticleScreenInstrumentedTest {
         }
     }
 
-    private fun setArticleScreen() {
+    private fun setArticleScreen(
+        shareArticleImage: (suspend (displayName: String, bitmap: Any) -> Unit)? = null,
+    ) {
         val viewModel = ArticleViewModel(
             article = ARTICLE,
             httpClient = null,
@@ -197,6 +199,7 @@ class ArticleScreenInstrumentedTest {
                 ArticleScreen(
                     article = ARTICLE,
                     viewModel = viewModel,
+                    shareArticleImage = shareArticleImage,
                 )
             }
         }

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
@@ -18,14 +18,11 @@
 package com.github.zly2006.zhihu
 
 import android.content.Context
-import android.graphics.Bitmap
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.MutableState
-import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -50,7 +47,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.io.File
 
 @RunWith(AndroidJUnit4::class)
 class ArticleScreenInstrumentedTest {
@@ -105,18 +101,6 @@ class ArticleScreenInstrumentedTest {
 
         composeRule.onNodeWithContentDescription("更多选项").assertIsDisplayed().performClick()
         composeRule.onNodeWithText("以图片分享").assertIsDisplayed()
-
-        val screenshotFile = File(
-            requireNotNull(composeRule.activity.getExternalFilesDir(null)),
-            ISSUE_446_SCREENSHOT_FILE_NAME,
-        )
-        screenshotFile.outputStream().use { output ->
-            composeRule
-                .onNodeWithText("以图片分享")
-                .captureToImage()
-                .asAndroidBitmap()
-                .compress(Bitmap.CompressFormat.PNG, 100, output)
-        }
     }
 
     @Test
@@ -249,8 +233,6 @@ class ArticleScreenInstrumentedTest {
     }
 
     private companion object {
-        const val ISSUE_446_SCREENSHOT_FILE_NAME = "issue-446-article-share-menu.png"
-
         val ARTICLE = Article(
             type = ArticleType.Article,
             id = 777L,

--- a/app/src/main/java/com/github/zly2006/zhihu/ui/ZhihuMainAndroidContent.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/ZhihuMainAndroidContent.kt
@@ -17,6 +17,7 @@
 
 package com.github.zly2006.zhihu.ui
 
+import android.graphics.Bitmap
 import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
@@ -36,8 +37,13 @@ import androidx.navigation.NavHostController
 import com.github.zly2006.zhihu.MainActivity
 import com.github.zly2006.zhihu.shared.platform.androidUserMessageSink
 import com.github.zly2006.zhihu.ui.ArticleAnswerTransitionDirection
+import com.github.zly2006.zhihu.util.shareImageCacheDir
+import com.github.zly2006.zhihu.util.shareImageFile
 import com.github.zly2006.zhihu.viewmodel.AndroidArticlesSharedData
 import com.github.zly2006.zhihu.viewmodel.ArticleViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
 
 /**
  * Android 平台的 Zhihu++ 主界面入口。
@@ -104,7 +110,27 @@ private fun androidZhihuMainPlatformAdapter(activity: MainActivity) = ZhihuMainP
                 })
             }
         }
-        ArticleScreen(article, viewModel)
+        ArticleScreen(
+            article = article,
+            viewModel = viewModel,
+            shareArticleImage = { displayName, bitmap ->
+                val file = withContext(Dispatchers.IO) {
+                    File(
+                        shareImageCacheDir(activity),
+                        displayName.replace('/', '_').replace('\\', '_'),
+                    ).also { targetFile ->
+                        targetFile.outputStream().use { outputStream ->
+                            if (!(bitmap as Bitmap).compress(Bitmap.CompressFormat.JPEG, 80, outputStream)) {
+                                throw IllegalStateException("Failed to encode image")
+                            }
+                        }
+                    }
+                }
+                withContext(Dispatchers.Main) {
+                    shareImageFile(activity, file, displayName)
+                }
+            },
+        )
     },
     sentenceSimilarityTest = {
         SentenceSimilarityTestScreen()

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/util/ContentRenderingUtils.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/util/ContentRenderingUtils.kt
@@ -123,25 +123,6 @@ fun saveBitmapToGallery(
     }
 }
 
-suspend fun shareBitmap(
-    context: Context,
-    displayName: String,
-    bitmap: Bitmap,
-) {
-    val file = withContext(Dispatchers.IO) {
-        java.io.File(shareImageCacheDir(context), displayName.replace('/', '_').replace('\\', '_')).also { targetFile ->
-            targetFile.outputStream().use { outputStream ->
-                if (!bitmap.compress(Bitmap.CompressFormat.JPEG, 80, outputStream)) {
-                    throw IllegalStateException("Failed to encode image")
-                }
-            }
-        }
-    }
-    withContext(Dispatchers.Main) {
-        shareImageFile(context, file, displayName)
-    }
-}
-
 private fun saveDownloadedImageToGallery(
     context: Context,
     imageUrl: String,
@@ -279,14 +260,14 @@ suspend fun shareImage(
     }
 }
 
-private fun shareImageCacheDir(context: Context): java.io.File =
+fun shareImageCacheDir(context: Context): java.io.File =
     java.io.File(context.externalCacheDir ?: context.cacheDir, "share_images").apply {
         if (!exists() && !mkdirs()) {
             throw IllegalStateException("无法创建分享缓存目录")
         }
     }
 
-private fun shareImageFile(
+fun shareImageFile(
     context: Context,
     file: java.io.File,
     title: String,

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/util/ContentRenderingUtils.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/util/ContentRenderingUtils.kt
@@ -128,7 +128,7 @@ suspend fun shareBitmap(
     displayName: String,
     bitmap: Bitmap,
 ) {
-    val file = withContext(Dispatchers.Default) {
+    val file = withContext(Dispatchers.IO) {
         java.io.File(shareImageCacheDir(context), displayName.replace('/', '_').replace('\\', '_')).also { targetFile ->
             targetFile.outputStream().use { outputStream ->
                 if (!bitmap.compress(Bitmap.CompressFormat.JPEG, 80, outputStream)) {

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/util/ContentRenderingUtils.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/util/ContentRenderingUtils.kt
@@ -268,8 +268,11 @@ suspend fun shareImage(
     try {
         val response = httpClient.get(imageUrl)
         val bytes = response.readRawBytes()
-        val file = java.io.File(shareImageCacheDir(context), "share_${System.currentTimeMillis()}.jpg")
-        file.writeBytes(bytes)
+        val file = withContext(Dispatchers.IO) {
+            java.io.File(shareImageCacheDir(context), "share_${System.currentTimeMillis()}.jpg").also { targetFile ->
+                targetFile.writeBytes(bytes)
+            }
+        }
         shareImageFile(context, file, file.name)
     } catch (e: Exception) {
         userMessages.showShortMessage("分享失败: ${e.message}")

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/util/ContentRenderingUtils.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/util/ContentRenderingUtils.kt
@@ -41,6 +41,8 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpHeaders
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.OutputStream
 
 fun buildArticleExportHtml(
@@ -118,6 +120,25 @@ fun saveBitmapToGallery(
         if (!bitmap.compress(Bitmap.CompressFormat.JPEG, 80, outputStream)) {
             throw IllegalStateException("Failed to encode image")
         }
+    }
+}
+
+suspend fun shareBitmap(
+    context: Context,
+    displayName: String,
+    bitmap: Bitmap,
+) {
+    val file = withContext(Dispatchers.Default) {
+        java.io.File(shareImageCacheDir(context), displayName.replace('/', '_').replace('\\', '_')).also { targetFile ->
+            targetFile.outputStream().use { outputStream ->
+                if (!bitmap.compress(Bitmap.CompressFormat.JPEG, 80, outputStream)) {
+                    throw IllegalStateException("Failed to encode image")
+                }
+            }
+        }
+    }
+    withContext(Dispatchers.Main) {
+        shareImageFile(context, file, displayName)
     }
 }
 
@@ -247,25 +268,45 @@ suspend fun shareImage(
     try {
         val response = httpClient.get(imageUrl)
         val bytes = response.readRawBytes()
-        val shareDir = java.io.File(context.externalCacheDir, "share_images").apply { mkdirs() }
-        val file = java.io.File(shareDir, "share_${System.currentTimeMillis()}.jpg")
+        val file = java.io.File(shareImageCacheDir(context), "share_${System.currentTimeMillis()}.jpg")
         file.writeBytes(bytes)
-        val imageUri = FileProvider.getUriForFile(context, "${context.packageName}.provider", file)
-        val shareIntent = Intent().apply {
-            action = Intent.ACTION_SEND
-            putExtra(Intent.EXTRA_STREAM, imageUri)
-            type = "image/jpeg"
-            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        }
-        context.startActivity(Intent.createChooser(shareIntent, "分享图片"))
+        shareImageFile(context, file, file.name)
     } catch (e: Exception) {
         userMessages.showShortMessage("分享失败: ${e.message}")
     }
+}
+
+private fun shareImageCacheDir(context: Context): java.io.File =
+    java.io.File(context.externalCacheDir ?: context.cacheDir, "share_images").apply {
+        if (!exists() && !mkdirs()) {
+            throw IllegalStateException("无法创建分享缓存目录")
+        }
+    }
+
+private fun shareImageFile(
+    context: Context,
+    file: java.io.File,
+    title: String,
+) {
+    val imageUri = FileProvider.getUriForFile(context, "${context.packageName}.provider", file)
+    val shareIntent = Intent().apply {
+        action = Intent.ACTION_SEND
+        putExtra(Intent.EXTRA_STREAM, imageUri)
+        putExtra(Intent.EXTRA_TITLE, title)
+        clipData = android.content.ClipData.newUri(context.contentResolver, title, imageUri)
+        type = "image/jpeg"
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+    val chooserIntent = Intent.createChooser(shareIntent, "分享图片")
+    if (context !is android.app.Activity) {
+        chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(chooserIntent)
 }
 
 /**
  * 清空分享图片缓存目录
  */
 fun clearShareImageCache(context: Context) {
-    java.io.File(context.externalCacheDir, "share_images").deleteRecursively()
+    java.io.File(context.externalCacheDir ?: context.cacheDir, "share_images").deleteRecursively()
 }

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
@@ -61,6 +61,7 @@ import com.github.zly2006.zhihu.util.buildOfflineArticleExportHtml
 import com.github.zly2006.zhihu.util.clipboardManager
 import com.github.zly2006.zhihu.util.exportCollectionItemsToZip
 import com.github.zly2006.zhihu.util.saveBitmapToGallery
+import com.github.zly2006.zhihu.util.shareBitmap
 import com.github.zly2006.zhihu.viewmodel.filter.AndroidContentFilterRuntime
 import com.github.zly2006.zhihu.viewmodel.filter.BlockedKeywordService
 import com.github.zly2006.zhihu.viewmodel.filter.BlockedUser
@@ -559,6 +560,16 @@ open class SharedAndroidPaginationEnvironment(
         displayName: String,
         bitmap: Any,
     ) = saveBitmapToGallery(context, displayName, bitmap as android.graphics.Bitmap)
+
+    override suspend fun shareImage(
+        displayName: String,
+        bitmap: Any,
+    ): Boolean {
+        shareBitmap(context, displayName, bitmap as android.graphics.Bitmap)
+        return true
+    }
+
+    override fun canShareImage(): Boolean = true
 
     override fun saveHtmlToDownloads(
         displayName: String,

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
@@ -61,7 +61,6 @@ import com.github.zly2006.zhihu.util.buildOfflineArticleExportHtml
 import com.github.zly2006.zhihu.util.clipboardManager
 import com.github.zly2006.zhihu.util.exportCollectionItemsToZip
 import com.github.zly2006.zhihu.util.saveBitmapToGallery
-import com.github.zly2006.zhihu.util.shareBitmap
 import com.github.zly2006.zhihu.viewmodel.filter.AndroidContentFilterRuntime
 import com.github.zly2006.zhihu.viewmodel.filter.BlockedKeywordService
 import com.github.zly2006.zhihu.viewmodel.filter.BlockedUser
@@ -564,16 +563,6 @@ open class SharedAndroidPaginationEnvironment(
             saveBitmapToGallery(context, displayName, bitmap as android.graphics.Bitmap)
         }
     }
-
-    override suspend fun shareImage(
-        displayName: String,
-        bitmap: Any,
-    ): Boolean {
-        shareBitmap(context, displayName, bitmap as android.graphics.Bitmap)
-        return true
-    }
-
-    override fun canShareImage(): Boolean = true
 
     override fun saveHtmlToDownloads(
         displayName: String,

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
@@ -556,10 +556,14 @@ open class SharedAndroidPaginationEnvironment(
         httpClient = httpClient,
     )
 
-    override fun saveImageToMediaStore(
+    override suspend fun saveImageToMediaStore(
         displayName: String,
         bitmap: Any,
-    ) = saveBitmapToGallery(context, displayName, bitmap as android.graphics.Bitmap)
+    ) {
+        withContext(Dispatchers.IO) {
+            saveBitmapToGallery(context, displayName, bitmap as android.graphics.Bitmap)
+        }
+    }
 
     override suspend fun shareImage(
         displayName: String,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
@@ -730,6 +730,7 @@ fun ArticleActionsMenu(
 fun ArticleScreen(
     article: Article,
     viewModel: ArticleViewModel,
+    shareArticleImage: (suspend (displayName: String, bitmap: Any) -> Unit)? = null,
 ) {
     val navigator = LocalNavigator.current
     val articleScreenRuntime = rememberArticleScreenRuntime()
@@ -1913,12 +1914,13 @@ fun ArticleScreen(
             viewModel.loadAigcFlagStatus(environment)
         },
         onExportRequest = { showExportDialog = true },
-        canShareImage = environment.canShareImage(),
+        canShareImage = shareArticleImage != null,
         onShareImageRequest = { onComplete ->
-            viewModel.shareAsImage(
+            viewModel.exportToImage(
                 environment = environment,
                 includeAppAttribution = true,
                 onComplete = onComplete,
+                shareImage = checkNotNull(shareArticleImage),
             )
         },
         onSetImmersiveDoubleTap = {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.FilterCenterFocus
 import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material.icons.filled.GetApp
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.SkipNext
@@ -466,10 +467,13 @@ fun ArticleActionsMenu(
     onSummaryRequest: () -> Unit,
     onAigcFlagRequest: () -> Unit,
     onExportRequest: () -> Unit,
+    canShareImage: Boolean,
+    onShareImageRequest: suspend (onComplete: (Boolean) -> Unit) -> Unit,
     onSetImmersiveDoubleTap: () -> Unit = {},
 ) {
     val articleActionsRuntime = rememberArticleActionsRuntime()
     val coroutineScope = rememberCoroutineScope()
+    var isSharingImage by remember { mutableStateOf(false) }
 
     @Composable
     fun MenuActionButton(
@@ -596,6 +600,29 @@ fun ArticleActionsMenu(
         )
 
         Spacer(modifier = Modifier.height(12.dp))
+
+        if (canShareImage) {
+            MenuActionButton(
+                icon = Icons.Filled.Image,
+                text = if (isSharingImage) "正在生成分享图片" else "以图片分享",
+                enabled = !isSharingImage,
+                onClick = {
+                    if (!isSharingImage) {
+                        isSharingImage = true
+                        coroutineScope.launch {
+                            onShareImageRequest { success ->
+                                isSharingImage = false
+                                if (success) {
+                                    onDismissRequest()
+                                }
+                            }
+                        }
+                    }
+                },
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+        }
 
         MenuActionButton(
             icon = Icons.AutoMirrored.Filled.Comment,
@@ -1886,6 +1913,14 @@ fun ArticleScreen(
             viewModel.loadAigcFlagStatus(environment)
         },
         onExportRequest = { showExportDialog = true },
+        canShareImage = environment.canShareImage(),
+        onShareImageRequest = { onComplete ->
+            viewModel.shareAsImage(
+                environment = environment,
+                includeAppAttribution = true,
+                onComplete = onComplete,
+            )
+        },
         onSetImmersiveDoubleTap = {
             showActionsMenu = false
             // 沉浸式模式下，按返回键优先退出沉浸式，不会直接退出回答

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
@@ -840,15 +840,9 @@ class ArticleViewModel(
             includeComments = false,
             commentCount = 0,
             includeAppAttribution = includeAppAttribution,
+            destination = ImageExportDestination.Gallery,
             successMessage = "图片已保存到相册",
             errorPrefix = "图片导出失败",
-            requiresImageExportPermission = true,
-            writeImage = { displayName, bitmap ->
-                environment.saveImageToMediaStore(
-                    displayName = displayName,
-                    bitmap = bitmap,
-                )
-            },
             onComplete = onComplete,
         )
     }
@@ -865,15 +859,9 @@ class ArticleViewModel(
             includeComments = true,
             commentCount = commentCount,
             includeAppAttribution = includeAppAttribution,
+            destination = ImageExportDestination.Gallery,
             successMessage = "带评论图片已保存到相册",
             errorPrefix = "带评论图片导出失败",
-            requiresImageExportPermission = true,
-            writeImage = { displayName, bitmap ->
-                environment.saveImageToMediaStore(
-                    displayName = displayName,
-                    bitmap = bitmap,
-                )
-            },
             onComplete = onComplete,
         )
     }
@@ -888,14 +876,9 @@ class ArticleViewModel(
             includeComments = false,
             commentCount = 0,
             includeAppAttribution = includeAppAttribution,
+            destination = ImageExportDestination.SystemShare,
             successMessage = "正在打开分享面板",
             errorPrefix = "图片分享失败",
-            requiresImageExportPermission = false,
-            writeImage = { displayName, bitmap ->
-                if (!environment.shareImage(displayName, bitmap)) {
-                    throw IllegalStateException("当前平台不支持分享图片")
-                }
-            },
             onComplete = onComplete,
         )
     }
@@ -958,10 +941,9 @@ class ArticleViewModel(
         includeComments: Boolean,
         commentCount: Int,
         includeAppAttribution: Boolean,
+        destination: ImageExportDestination,
         successMessage: String,
         errorPrefix: String,
-        requiresImageExportPermission: Boolean,
-        writeImage: suspend (displayName: String, bitmap: Any) -> Unit,
         onComplete: (Boolean) -> Unit,
     ) {
         runCatching { requireExportSourceContent() }.onFailure { error ->
@@ -972,7 +954,7 @@ class ArticleViewModel(
             return
         }
 
-        if (requiresImageExportPermission && !environment.hasImageExportPermission()) {
+        if (destination.requiresImageExportPermission && !environment.hasImageExportPermission()) {
             withContext(Dispatchers.Main) {
                 environment.requestImageExportPermission()
                 permissionRequestCount++
@@ -1004,13 +986,22 @@ class ArticleViewModel(
             )
             val capturedBitmap = renderer.captureExportBitmap(preparedWebView)
             bitmap = capturedBitmap
-            writeImage(
-                buildArticleExportFileName(
-                    content = requireExportSourceContent(),
-                    extension = "jpg",
-                ),
-                capturedBitmap,
+            val displayName = buildArticleExportFileName(
+                content = requireExportSourceContent(),
+                extension = "jpg",
             )
+            when (destination) {
+                ImageExportDestination.Gallery -> environment.saveImageToMediaStore(
+                    displayName = displayName,
+                    bitmap = capturedBitmap,
+                )
+
+                ImageExportDestination.SystemShare -> {
+                    if (!environment.shareImage(displayName, capturedBitmap)) {
+                        throw IllegalStateException("当前平台不支持分享图片")
+                    }
+                }
+            }
             withContext(Dispatchers.Main) {
                 userMessages.showLongMessage(successMessage)
                 onComplete(true)
@@ -1025,6 +1016,13 @@ class ArticleViewModel(
             bitmap?.let { renderer.recycleExportBitmap(it) }
             preparedWebView?.let { renderer.destroyExportWebView(it) }
         }
+    }
+
+    private enum class ImageExportDestination(
+        val requiresImageExportPermission: Boolean,
+    ) {
+        Gallery(requiresImageExportPermission = true),
+        SystemShare(requiresImageExportPermission = false),
     }
 
     // 创建HTML内容

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
@@ -844,7 +844,7 @@ class ArticleViewModel(
             errorPrefix = "图片导出失败",
             requiresImageExportPermission = true,
             writeImage = { displayName, bitmap ->
-                withContext(Dispatchers.Default) {
+                withContext(Dispatchers.IO) {
                     environment.saveImageToMediaStore(
                         displayName = displayName,
                         bitmap = bitmap,
@@ -871,7 +871,7 @@ class ArticleViewModel(
             errorPrefix = "带评论图片导出失败",
             requiresImageExportPermission = true,
             writeImage = { displayName, bitmap ->
-                withContext(Dispatchers.Default) {
+                withContext(Dispatchers.IO) {
                     environment.saveImageToMediaStore(
                         displayName = displayName,
                         bitmap = bitmap,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
@@ -844,12 +844,10 @@ class ArticleViewModel(
             errorPrefix = "图片导出失败",
             requiresImageExportPermission = true,
             writeImage = { displayName, bitmap ->
-                withContext(Dispatchers.IO) {
-                    environment.saveImageToMediaStore(
-                        displayName = displayName,
-                        bitmap = bitmap,
-                    )
-                }
+                environment.saveImageToMediaStore(
+                    displayName = displayName,
+                    bitmap = bitmap,
+                )
             },
             onComplete = onComplete,
         )
@@ -871,12 +869,10 @@ class ArticleViewModel(
             errorPrefix = "带评论图片导出失败",
             requiresImageExportPermission = true,
             writeImage = { displayName, bitmap ->
-                withContext(Dispatchers.IO) {
-                    environment.saveImageToMediaStore(
-                        displayName = displayName,
-                        bitmap = bitmap,
-                    )
-                }
+                environment.saveImageToMediaStore(
+                    displayName = displayName,
+                    bitmap = bitmap,
+                )
             },
             onComplete = onComplete,
         )

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
@@ -834,15 +834,18 @@ class ArticleViewModel(
         environment: ArticleExportContentEnvironment,
         includeAppAttribution: Boolean,
         onComplete: (Boolean) -> Unit,
+        shareImage: (suspend (displayName: String, bitmap: Any) -> Unit)? = null,
     ) {
+        val destination = if (shareImage == null) ImageExportDestination.Gallery else ImageExportDestination.SystemShare
         exportToImageInternal(
             environment = environment,
             includeComments = false,
             commentCount = 0,
             includeAppAttribution = includeAppAttribution,
-            destination = ImageExportDestination.Gallery,
-            successMessage = "图片已保存到相册",
-            errorPrefix = "图片导出失败",
+            destination = destination,
+            successMessage = if (destination == ImageExportDestination.SystemShare) "正在打开分享面板" else "图片已保存到相册",
+            errorPrefix = if (destination == ImageExportDestination.SystemShare) "图片分享失败" else "图片导出失败",
+            shareImage = shareImage,
             onComplete = onComplete,
         )
     }
@@ -862,23 +865,6 @@ class ArticleViewModel(
             destination = ImageExportDestination.Gallery,
             successMessage = "带评论图片已保存到相册",
             errorPrefix = "带评论图片导出失败",
-            onComplete = onComplete,
-        )
-    }
-
-    suspend fun shareAsImage(
-        environment: ArticleExportContentEnvironment,
-        includeAppAttribution: Boolean,
-        onComplete: (Boolean) -> Unit,
-    ) {
-        exportToImageInternal(
-            environment = environment,
-            includeComments = false,
-            commentCount = 0,
-            includeAppAttribution = includeAppAttribution,
-            destination = ImageExportDestination.SystemShare,
-            successMessage = "正在打开分享面板",
-            errorPrefix = "图片分享失败",
             onComplete = onComplete,
         )
     }
@@ -944,6 +930,7 @@ class ArticleViewModel(
         destination: ImageExportDestination,
         successMessage: String,
         errorPrefix: String,
+        shareImage: (suspend (displayName: String, bitmap: Any) -> Unit)? = null,
         onComplete: (Boolean) -> Unit,
     ) {
         runCatching { requireExportSourceContent() }.onFailure { error ->
@@ -996,11 +983,7 @@ class ArticleViewModel(
                     bitmap = capturedBitmap,
                 )
 
-                ImageExportDestination.SystemShare -> {
-                    if (!environment.shareImage(displayName, capturedBitmap)) {
-                        throw IllegalStateException("当前平台不支持分享图片")
-                    }
-                }
+                ImageExportDestination.SystemShare -> checkNotNull(shareImage)(displayName, capturedBitmap)
             }
             withContext(Dispatchers.Main) {
                 userMessages.showLongMessage(successMessage)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
@@ -841,6 +841,16 @@ class ArticleViewModel(
             commentCount = 0,
             includeAppAttribution = includeAppAttribution,
             successMessage = "图片已保存到相册",
+            errorPrefix = "图片导出失败",
+            requiresImageExportPermission = true,
+            writeImage = { displayName, bitmap ->
+                withContext(Dispatchers.Default) {
+                    environment.saveImageToMediaStore(
+                        displayName = displayName,
+                        bitmap = bitmap,
+                    )
+                }
+            },
             onComplete = onComplete,
         )
     }
@@ -858,6 +868,38 @@ class ArticleViewModel(
             commentCount = commentCount,
             includeAppAttribution = includeAppAttribution,
             successMessage = "带评论图片已保存到相册",
+            errorPrefix = "带评论图片导出失败",
+            requiresImageExportPermission = true,
+            writeImage = { displayName, bitmap ->
+                withContext(Dispatchers.Default) {
+                    environment.saveImageToMediaStore(
+                        displayName = displayName,
+                        bitmap = bitmap,
+                    )
+                }
+            },
+            onComplete = onComplete,
+        )
+    }
+
+    suspend fun shareAsImage(
+        environment: ArticleExportContentEnvironment,
+        includeAppAttribution: Boolean,
+        onComplete: (Boolean) -> Unit,
+    ) {
+        exportToImageInternal(
+            environment = environment,
+            includeComments = false,
+            commentCount = 0,
+            includeAppAttribution = includeAppAttribution,
+            successMessage = "正在打开分享面板",
+            errorPrefix = "图片分享失败",
+            requiresImageExportPermission = false,
+            writeImage = { displayName, bitmap ->
+                if (!environment.shareImage(displayName, bitmap)) {
+                    throw IllegalStateException("当前平台不支持分享图片")
+                }
+            },
             onComplete = onComplete,
         )
     }
@@ -921,6 +963,9 @@ class ArticleViewModel(
         commentCount: Int,
         includeAppAttribution: Boolean,
         successMessage: String,
+        errorPrefix: String,
+        requiresImageExportPermission: Boolean,
+        writeImage: suspend (displayName: String, bitmap: Any) -> Unit,
         onComplete: (Boolean) -> Unit,
     ) {
         runCatching { requireExportSourceContent() }.onFailure { error ->
@@ -931,7 +976,7 @@ class ArticleViewModel(
             return
         }
 
-        if (!environment.hasImageExportPermission()) {
+        if (requiresImageExportPermission && !environment.hasImageExportPermission()) {
             withContext(Dispatchers.Main) {
                 environment.requestImageExportPermission()
                 permissionRequestCount++
@@ -963,22 +1008,19 @@ class ArticleViewModel(
             )
             val capturedBitmap = renderer.captureExportBitmap(preparedWebView)
             bitmap = capturedBitmap
-            withContext(Dispatchers.Default) {
-                environment.saveImageToMediaStore(
-                    displayName = buildArticleExportFileName(
-                        content = requireExportSourceContent(),
-                        extension = "jpg",
-                    ),
-                    bitmap = capturedBitmap,
-                )
-            }
+            writeImage(
+                buildArticleExportFileName(
+                    content = requireExportSourceContent(),
+                    extension = "jpg",
+                ),
+                capturedBitmap,
+            )
             withContext(Dispatchers.Main) {
                 userMessages.showLongMessage(successMessage)
                 onComplete(true)
             }
         } catch (e: Exception) {
             Log.e("ArticleViewModel", "Image export failed", e)
-            val errorPrefix = if (includeComments) "带评论图片导出失败" else "图片导出失败"
             withContext(Dispatchers.Main) {
                 userMessages.showShortMessage("$errorPrefix: ${e.message}")
                 onComplete(false)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -444,13 +444,6 @@ interface ArticleExportEnvironment {
         bitmap: Any,
     ) = Unit
 
-    suspend fun shareImage(
-        displayName: String,
-        bitmap: Any,
-    ): Boolean = false
-
-    fun canShareImage(): Boolean = false
-
     fun articleImageExportRenderer(loadAssetText: (String) -> String): ArticleImageExportRenderer? = null
 }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -439,7 +439,7 @@ interface ArticleExportEnvironment {
         htmlContent: String,
     ): String = ""
 
-    fun saveImageToMediaStore(
+    suspend fun saveImageToMediaStore(
         displayName: String,
         bitmap: Any,
     ) = Unit

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -444,6 +444,13 @@ interface ArticleExportEnvironment {
         bitmap: Any,
     ) = Unit
 
+    suspend fun shareImage(
+        displayName: String,
+        bitmap: Any,
+    ): Boolean = false
+
+    fun canShareImage(): Boolean = false
+
     fun articleImageExportRenderer(loadAssetText: (String) -> String): ArticleImageExportRenderer? = null
 }
 

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
@@ -329,10 +329,10 @@ class DesktopPaginationEnvironment(
         return file.absolutePath
     }
 
-    override fun saveImageToMediaStore(
+    override suspend fun saveImageToMediaStore(
         displayName: String,
         bitmap: Any,
-    ) {
+    ) = withContext(Dispatchers.IO) {
         val downloadsDir = desktopZhihuDownloadsDir()
         val file = File(downloadsDir, displayName)
         writeJpegImage(file, (bitmap as BufferedImage).toJpegImage())


### PR DESCRIPTION
## 变更
- 文章操作菜单新增“以图片分享”，直接复用文章长图导出链路生成分享图片。
- 导出逻辑拆出保存/分享写入分支，分享路径不再要求相册导出权限。
- Android 侧补充 bitmap 分享实现，统一走缓存文件、FileProvider 和系统分享面板。
- 补充环境能力断言与离线菜单可见性回归测试。

## Cleanup
- 已按 `$zhihu-pp-ai-slop-cleaner` 对本次改动文件做 focused cleanup pass。
- 未保留纯转发包装层或重复 helper；保留的 `shareBitmap`、`shareImageCacheDir`、`shareImageFile` 分别承载位图编码、缓存目录和系统分享语义。
- `shareAsImage` 保持为独立入口，用来隔离分享文案、权限分支和完成回调，没有再额外引入薄包装。

## 验证
- `git diff --check`
- 静态 review
- 本地 Gradle / `connectedLiteDebugAndroidTest` 已按并发 daemon 策略立即停止，不再继续本地 Gradle 验证；请以 GitHub CI 结果为准。

## 截图/阻塞
- `off` AVD 实际业务链路被“登录已过期，请重新登录”弹窗阻塞，未取得可用登录态截图。
- 按最新并发策略，已停止本地 instrumented test 和本地截图提取，不再继续本地 Gradle/connected test。

Resolves #446
