### PR TITLE
fix: 修复 Lite Release 开源许可页面崩溃

### DIFF
--- a/app/src/main/res/raw/aboutlibraries_keep.xml
+++ b/app/src/main/res/raw/aboutlibraries_keep.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@raw/aboutlibraries" />


### PR DESCRIPTION
## 变更

- 新增 Android resource shrink keep 配置，保留 `@raw/aboutlibraries`。
- 修复 Lite Release 点击“开源许可”时 AboutLibraries 无法通过 raw resource 读取 `aboutlibraries.json` 导致的崩溃。

## 根因

`liteRelease` 启用 R8 和资源压缩后，AboutLibraries 依赖运行时按 `raw/aboutlibraries` 查找资源；资源未被显式 keep 时会拿到无效 resource id，随后 `LibrariesContainer` 因缺少库数据抛出异常。

## 验证

- 修复前已用远端 off AVD 复现：点击“账号 → 开源许可”后出现 `Invalid resource ID 0x00000000` 和 AboutLibraries fatal。
- 修复后已在实际运行的 Lite Release APK + 远端 off AVD 验证：页面正常显示 AboutLibraries 条目，包括 `AboutLibraries Compose Material 3 Library`、`Activity` 等。
- 已执行：`./gradlew assembleLiteDebug`
- 已执行：`./gradlew assembleLiteRelease`
- 已执行：`./gradlew ktlintFormat`

## 截图

本 PR 不改布局或样式。修复后已在远端 off AVD 实际进入“开源许可”页面并通过 UI dump 验证条目可见；尝试补截图时 headless AVD 的 `screencap` 只返回黑色 Surface，因此没有上传错误截图。
