### PR TITLE
fix: 修复回答列表分页重复 include 和缺 data 崩溃

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -53,6 +53,7 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
+import io.ktor.http.Url
 import io.ktor.http.contentType
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -63,7 +64,6 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
@@ -111,11 +111,14 @@ abstract class PaginationViewModel<T : Any>(
     protected open suspend fun fetchFeeds(environment: PaginationEnvironment) {
         try {
             val url = lastPaging?.next ?: initialUrl
+            val requestUrl = url.replace("http://", "https://")
 
             @Suppress("HttpUrlsUsage")
-            val json = environment.fetchJson(url.replace("http://", "https://"), include)!!
+            val json = environment.fetchJson(requestUrl, include)
+                ?: throw MissingFeedDataException(requestUrl, emptySet(), "<empty response>")
 
-            val jsonArray = json["data"]!!.jsonArray
+            val jsonArray = json["data"] as? JsonArray
+                ?: throw MissingFeedDataException(requestUrl, json.keys, json.toString().take(MISSING_FEED_DATA_BODY_PREFIX_LENGTH))
             processResponse(
                 environment,
                 jsonArray.mapNotNull {
@@ -171,6 +174,16 @@ abstract class PaginationViewModel<T : Any>(
         }
     }
 }
+
+private const val MISSING_FEED_DATA_BODY_PREFIX_LENGTH = 500
+
+internal class MissingFeedDataException(
+    url: String,
+    topLevelKeys: Set<String>,
+    bodyPrefix: String,
+) : IllegalStateException(
+        "Feed response is missing a top-level data array. url=$url, topLevelKeys=${topLevelKeys.sorted()}, bodyPrefix=$bodyPrefix",
+    )
 
 open class ArticleAnswerSwitchData :
     ViewModel(),
@@ -242,7 +255,7 @@ interface ZhihuApiEnvironment {
         ) {
             method = HttpMethod.Get
             signZhihuFetchRequest(cookies)
-            if (include.isNotEmpty()) {
+            if (shouldAppendIncludeParameter(url, include)) {
                 parameter("include", include)
             }
         }
@@ -263,6 +276,11 @@ interface ZhihuApiEnvironment {
         Log.e(tag ?: "PaginationViewModel", "Failed to decode item: $item", error)
     }
 }
+
+internal fun shouldAppendIncludeParameter(
+    url: String,
+    include: String,
+): Boolean = include.isNotEmpty() && !Url(url).parameters.contains("include")
 
 suspend fun ZhihuApiEnvironment.fetchContentDetail(destination: NavDestination): DataHolder.Content? =
     runCatching {

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModelTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for Android.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.viewmodel
+
+import com.github.zly2006.zhihu.shared.data.installZhihuCommonClientConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.reflect.typeOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class PaginationViewModelTest {
+    @Test
+    fun fetchJsonAddsIncludeForInitialUrl() = runTest {
+        val requestedUrls = mutableListOf<String>()
+        val environment = mockApiEnvironment(requestedUrls)
+
+        environment.fetchJson(
+            url = "https://www.zhihu.com/api/v4/members/test/answers?sort_by=voteups",
+            include = "data[*].content",
+        )
+
+        val includes = Url(requestedUrls.single()).parameters.getAll("include")
+        assertEquals(listOf("data[*].content"), includes)
+    }
+
+    @Test
+    fun fetchJsonDoesNotDuplicateIncludeFromPagingNext() = runTest {
+        val requestedUrls = mutableListOf<String>()
+        val environment = mockApiEnvironment(requestedUrls)
+
+        environment.fetchJson(
+            url = "https://www.zhihu.com/api/v4/members/test/answers?include=data[*].content&limit=20&offset=20",
+            include = "data[*].content",
+        )
+
+        val includes = Url(requestedUrls.single()).parameters.getAll("include")
+        assertEquals(listOf("data[*].content"), includes)
+    }
+
+    @Test
+    fun fetchFeedsReportsMissingDataInsteadOfThrowingNullPointerException() = runTest {
+        val environment = CapturingPaginationEnvironment(
+            response = buildJsonObject {
+                put("paging", buildJsonObject {})
+                put("error", "risk control")
+            },
+        )
+
+        TestPaginationViewModel().fetchOnce(environment)
+
+        val error = assertNotNull(environment.recordedError)
+        assertTrue(error is MissingFeedDataException)
+        assertTrue(error.message.orEmpty().contains("topLevelKeys=[error, paging]"))
+        assertTrue(error.message.orEmpty().contains("bodyPrefix="))
+    }
+
+    private fun mockApiEnvironment(requestedUrls: MutableList<String>) = object : ZhihuApiEnvironment {
+        private val client = HttpClient(
+            MockEngine { request ->
+                requestedUrls += request.url.toString()
+                respond(
+                    content = """{"data":[]}""",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        ) {
+            installZhihuCommonClientConfig(
+                cookies = mutableMapOf(),
+                userAgent = "test-agent",
+            )
+        }
+
+        override fun httpClient(): HttpClient = client
+
+        override fun authenticatedCookies(): Map<String, String> = emptyMap()
+
+        override suspend fun handleFetchFailure(
+            tag: String?,
+            error: Exception,
+        ): Unit = throw error
+    }
+
+    private class TestPaginationViewModel : PaginationViewModel<String>(typeOf<String>()) {
+        override val initialUrl: String = "https://www.zhihu.com/api/v4/test"
+
+        suspend fun fetchOnce(environment: PaginationEnvironment) {
+            fetchFeeds(environment)
+        }
+    }
+
+    private class CapturingPaginationEnvironment(
+        private val response: JsonObject?,
+    ) : PaginationEnvironment {
+        var recordedError: Exception? = null
+
+        override fun httpClient(): HttpClient = error("not used")
+
+        override fun authenticatedCookies(): Map<String, String> = emptyMap()
+
+        override suspend fun fetchJson(
+            url: String,
+            include: String,
+        ): JsonObject? = response
+
+        override suspend fun handleFetchFailure(
+            tag: String?,
+            error: Exception,
+        ) {
+            recordedError = error
+        }
+    }
+}


### PR DESCRIPTION
## 背景
用户上报回答列表 `Failed to fetch feeds`，release 栈 retrace 到 `PaginationViewModel.kt` 中直接读取 `json["data"]!!` 的位置。继续复现时发现，查看某人回答列表并深分页时，`paging.next` 已经带有 `include`，请求层又继续追加 `include`，导致 URL 随分页不断增长，最终服务端返回 HTML 400。

## 修改
- `paging.next` 已包含 `include` 时不再重复追加 `include`，避免回答列表深分页 URL 持续增长。
- `fetchFeeds` 对空响应、缺失或非数组 `data` 抛出带 URL、顶层 key 和响应前缀的诊断异常，替代原来的 NPE。
- 增加 common 单测覆盖初始 URL 追加 `include`、next URL 不重复追加 `include`、缺 `data` 不再抛 NPE。

## 验证
- `./gradlew :shared:jvmTest --tests 'com.github.zly2006.zhihu.viewmodel.PaginationViewModelTest'`
- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- off AVD 安装修复后的 `app-lite-debug.apk`，注入账号后打开 `https://www.zhihu.com/people/zhang-jia-wei`，滚动 95 次；应用进程未再出现 `Failed to fetch feeds` / `Request Line is too large` / `NoTransformationFoundException` / `FATAL EXCEPTION`。

Resolves #472
