### PR TITLE
fix: 修复刷新和翻页按钮无法拖回右侧

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
@@ -22,11 +22,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.MutableState
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.zly2006.zhihu.navigation.AnswerNavigator
 import com.github.zly2006.zhihu.navigation.Article
@@ -43,6 +46,7 @@ import com.github.zly2006.zhihu.viewmodel.ArticleViewModel
 import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
 import io.ktor.client.HttpClient
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -161,6 +165,38 @@ class ArticleScreenInstrumentedTest {
         }
     }
 
+    @Test
+    fun skipAnswerButtonCanBeDraggedBackToRightEdge() {
+        val viewModel = seededAnswerViewModel(ANSWER)
+        composeRule.setScreenContent {
+            Scaffold(
+                modifier = androidx.compose.ui.Modifier
+                    .fillMaxSize(),
+            ) { _ ->
+                ArticleScreen(
+                    article = ANSWER,
+                    viewModel = viewModel,
+                )
+            }
+        }
+
+        val rootWidth = composeRule
+            .onRoot()
+            .fetchSemanticsNode()
+            .boundsInRoot.width
+        val preferences = composeRule.activity.getSharedPreferences(PREFERENCE_NAME, Context.MODE_PRIVATE)
+        dragSkipAnswerButtonBy(-rootWidth)
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            preferences.getFloat("buttonSkipAnswer-x", Float.NaN) < rootWidth / 3
+        }
+
+        dragSkipAnswerButtonBy(rootWidth)
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            preferences.getFloat("buttonSkipAnswer-x", Float.NaN) > rootWidth / 2
+        }
+        assertTrue(preferences.getFloat("buttonSkipAnswer-x", Float.NaN) > rootWidth / 2)
+    }
+
     private fun setArticleScreen() {
         val viewModel = ArticleViewModel(
             article = ARTICLE,
@@ -192,6 +228,18 @@ class ArticleScreenInstrumentedTest {
                 )
             }
         }
+    }
+
+    private fun dragSkipAnswerButtonBy(deltaX: Float) {
+        composeRule
+            .onNodeWithContentDescription("下一个回答")
+            .assertIsDisplayed()
+            .performTouchInput {
+                down(center)
+                moveBy(Offset(deltaX, 0f))
+                up()
+            }
+        composeRule.waitForIdle()
     }
 
     private fun seededAnswerViewModel(article: Article): ArticleViewModel {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/DraggableRefreshButton.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/DraggableRefreshButton.kt
@@ -101,8 +101,8 @@ fun DraggableRefreshButton(
                     onDragEnd = {
                         pressing = false
                         adjustFabPosition()
+                        val screenWidth = screenSize.width.toFloat()
                         with(density) {
-                            val screenWidth = screenSize.width.dp.toPx()
                             offsetX =
                                 if (offsetX < screenWidth / 2) {
                                     0f


### PR DESCRIPTION
## 背景

Resolves #477

翻页按钮拖到左侧后，再向右拖动松手时会被错误吸附回左侧。根因是吸附判断把已经是像素值的 `screenSize.width` 又按 `dp` 转换了一次，导致右侧阈值和目标位置过大。

## 改动

- 使用 `screenSize.width.toFloat()` 作为真实屏幕像素宽度计算左右吸附位置。
- 增加离线 instrumented test，覆盖“先拖到左侧，再拖回右侧”的按钮位置保存行为。

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `./gradlew :app:compileLiteDebugAndroidTestKotlin`

## 截图 / 说明

该修复不改变按钮静态样式，只修正拖拽松手后的左右吸附行为；最终效果由新增的拖拽 instrumented test 覆盖。