### PR TITLE
fix: 修复分页 include 参数重复追加及 data 字段缺失防御性错误

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -115,7 +115,10 @@ abstract class PaginationViewModel<T : Any>(
             @Suppress("HttpUrlsUsage")
             val json = environment.fetchJson(url.replace("http://", "https://"), include)!!
 
-            val jsonArray = json["data"]!!.jsonArray
+            val jsonArray = (json["data"]
+                ?: throw IllegalStateException(
+                    "PaginationViewModel: response from $url missing 'data'; got keys: ${json.keys}",
+                )).jsonArray
             processResponse(
                 environment,
                 jsonArray.mapNotNull {
@@ -240,7 +243,9 @@ interface ZhihuApiEnvironment {
             method = HttpMethod.Get
             url {
                 protocol = URLProtocol.HTTPS
-                if (include.isNotEmpty()) {
+                // Skip appending 'include' when paging.next already carries it to
+                // avoid growing the URL unboundedly across pages (400 Request Line too large).
+                if (include.isNotEmpty() && !url.contains("include=")) {
                     parameters["include"] = include
                 }
             }


### PR DESCRIPTION
## Summary

- 修复 `ZhihuApiEnvironment.fetchJson` 中 `include` 参数重复追加问题：当 `paging.next` URL 已经携带 `include=` 时跳过追加，避免随翻页 URL 不断增长最终触发服务端 400。
- 修复 `PaginationViewModel.fetchFeeds` 中 `json["data"]!!` 的上下文缺失 NPE：替换为空值检查，抛出包含请求 URL 和响应顶层 key 的 `IllegalStateException`，使崩溃日志直接显示响应异常结构。

## Why this matters

Issue #472 报告了两个独立的 `Failed to fetch feeds` 根因：

1. 深度翻页（7+ 页）时 `paging.next` 已含 `include` 参数，每页追加一次导致 URL 过长，服务端返回 400 `Request Line is too large`。
2. 特定网络或 Cookie 状态下服务端返回缺少 `data` 键的 200 响应，触发 `json["data"]!!` NPE，崩溃堆栈只显示混淆后行号而无上下文。

## Testing

- 首页分页第一次请求：`include` 参数正常追加。
- 后续页请求：`paging.next` 已含 `include=` 时不再重复追加，URL 长度稳定。
- 构造缺少 `data` 键的合成响应时，错误信息包含请求 URL 和实际顶层 key 列表，而非上下文缺失的 NPE。
- 现有 `SearchViewModelUrlTest` 测试不受影响。

Fixes #472