### PR TITLE
feat: 让 Markdown 导出更精准

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
@@ -66,14 +66,17 @@ import com.hrm.markdown.parser.ast.Node as MarkdownNode
 private var parsingDocument: Document? = null
 private const val ZHIHU_EQUATION_URL_PREFIX = "https://www.zhihu.com/equation?tex="
 
-fun htmlToMdAst(html: String): Document {
+fun htmlToMdAst(
+    html: String,
+    noNativeBlock: Boolean = false,
+): Document {
     val document = Document()
     parsingDocument = document
     Ksoup
         .parseBodyFragment(html)
         .body()
         .childNodes()
-        .convertNodesToBlocks()
+        .convertNodesToBlocks(noNativeBlock)
         .forEach(document::appendChild)
     document.footnoteDefinitions.forEach { (_, definition) ->
         document.appendChild(definition)
@@ -96,7 +99,7 @@ private fun MarkdownNode.collectPreviewImageUrls(): List<String> = when (this) {
     else -> emptyList()
 }
 
-private fun List<HtmlNode>.convertNodesToBlocks(): List<MarkdownNode> {
+private fun List<HtmlNode>.convertNodesToBlocks(noNativeBlock: Boolean): List<MarkdownNode> {
     val blocks = mutableListOf<MarkdownNode>()
     var currentParagraph: Paragraph? = null
 
@@ -127,7 +130,7 @@ private fun List<HtmlNode>.convertNodesToBlocks(): List<MarkdownNode> {
                     }
                 }
 
-                val blockNode = convertElementToBlock(node)
+                val blockNode = convertElementToBlock(node, noNativeBlock)
                 if (blockNode.isNotEmpty()) {
                     blocks.addAll(blockNode)
                     currentParagraph = null
@@ -199,7 +202,10 @@ private fun Element.isBlockBoundary(): Boolean = when (tagName().lowercase()) {
     else -> false
 }
 
-private fun convertElementToBlock(element: Element): List<MarkdownNode> = when (element.tagName().lowercase()) {
+private fun convertElementToBlock(
+    element: Element,
+    noNativeBlock: Boolean,
+): List<MarkdownNode> = when (element.tagName().lowercase()) {
     "h1", "h2", "h3", "h4", "h5", "h6" -> listOf(
         Heading(level = element.tagName()[1].digitToInt()).apply {
             appendChildren(extractInlineChildren(element))
@@ -223,7 +229,7 @@ private fun convertElementToBlock(element: Element): List<MarkdownNode> = when (
                 ?.let { formula -> listOf(MathBlock(formula)) }
                 ?: listOfNotNull(createBlockImage(image))
         } else {
-            if (element.selectFirst("span.highlight-wrap") != null) {
+            if (!noNativeBlock && element.selectFirst("span.highlight-wrap") != null) {
                 // 含有知乎的划线高亮结构，需要单独处理
                 // TODO: 暂不考虑其他可能的结构，直接尝试解析整个段落为SegmentedTextParagraph
                 parseSegmentTextParagraph(element)?.let { paragraph ->
@@ -254,15 +260,15 @@ private fun convertElementToBlock(element: Element): List<MarkdownNode> = when (
 
     "blockquote" -> listOf(
         BlockQuote().apply {
-            element.childNodes().convertNodesToBlocks().forEach(::appendChild)
+            element.childNodes().convertNodesToBlocks(noNativeBlock).forEach(::appendChild)
         },
     )
 
     "pre" -> listOf(createCodeBlock(element))
 
-    "ul" -> listOf(createListBlock(element, ordered = false))
+    "ul" -> listOf(createListBlock(element, ordered = false, noNativeBlock = noNativeBlock))
 
-    "ol" -> listOf(createListBlock(element, ordered = true))
+    "ol" -> listOf(createListBlock(element, ordered = true, noNativeBlock = noNativeBlock))
 
     "hr" -> listOf(ThematicBreak())
 
@@ -273,12 +279,16 @@ private fun convertElementToBlock(element: Element): List<MarkdownNode> = when (
     "table" -> listOf(createTableBlock(element))
 
     "div" -> {
-        element.childNodes().convertNodesToBlocks()
+        element.childNodes().convertNodesToBlocks(noNativeBlock)
     }
 
     "a" -> {
         if (element.attr("class").contains("video-box")) {
-            listOfNotNull(createVideoBoxBlock(element))
+            if (noNativeBlock) {
+                listOfNotNull(createVideoBoxLinkBlock(element))
+            } else {
+                listOfNotNull(createVideoBoxBlock(element))
+            }
         } else {
             emptyList()
         }
@@ -310,6 +320,7 @@ private fun parseLanguageFromClassName(classNames: Set<String>): String? {
 private fun createListBlock(
     element: Element,
     ordered: Boolean,
+    noNativeBlock: Boolean,
 ): ListBlock = ListBlock(
     ordered = ordered,
     startNumber = element.attr("start").toIntOrNull() ?: 1,
@@ -317,7 +328,7 @@ private fun createListBlock(
     element.select("> li").forEach { listItemElement ->
         appendChild(
             ListItem().apply {
-                val children = listItemElement.childNodes().convertNodesToBlocks()
+                val children = listItemElement.childNodes().convertNodesToBlocks(noNativeBlock)
                 if (children.isEmpty()) {
                     appendChild(
                         Paragraph().apply {
@@ -383,6 +394,24 @@ private fun createVideoBoxBlock(element: Element): MarkdownNode? {
         RenderVideoBox(
             videoId = videoId,
             thumbnailUrl = thumbnailUrl,
+        )
+    }
+}
+
+private fun createVideoBoxLinkBlock(element: Element): MarkdownNode? {
+    val href = element.attr("href").ifBlank {
+        element
+            .attr("data-lens-id")
+            .toLongOrNull()
+            ?.let { "https://www.zhihu.com/video/$it" }
+            .orEmpty()
+    }
+    if (href.isBlank()) return null
+    return Paragraph().apply {
+        appendChild(
+            Link(destination = normalizeLinkDestination(href)).apply {
+                appendChild(Text("视频"))
+            },
         )
     }
 }
@@ -499,6 +528,8 @@ private fun extractInlineNode(node: HtmlNode): List<MarkdownNode> = when (node) 
 
         "mark" -> listOf(Highlight().apply { appendChildren(extractInlineChildren(node)) })
 
+        "span" -> extractInlineChildren(node)
+
         "sub" -> listOf(Subscript().apply { appendChildren(extractInlineChildren(node)) })
 
         "sup" -> {
@@ -531,13 +562,8 @@ private fun extractInlineNode(node: HtmlNode): List<MarkdownNode> = when (node) 
 
         "a" -> {
             val href = node.attr("href")
-            val destination = if (href.contains("link.zhihu.com")) {
-                runCatching { Url(href).parameters["target"] }.getOrNull() ?: href
-            } else {
-                href
-            }
             listOf(
-                Link(destination = destination).apply {
+                Link(destination = normalizeLinkDestination(href)).apply {
                     appendChildren(
                         extractInlineChildren(node).ifEmpty {
                             listOf(
@@ -599,6 +625,13 @@ private fun extractInlineNode(node: HtmlNode): List<MarkdownNode> = when (node) 
 
     else -> emptyList()
 }
+
+private fun normalizeLinkDestination(href: String): String =
+    if (href.contains("link.zhihu.com")) {
+        runCatching { Url(href).parameters["target"] }.getOrNull()?.takeIf { it.isNotBlank() } ?: href
+    } else {
+        href
+    }
 
 private fun ContainerNode.appendChildren(children: List<MarkdownNode>) {
     children.forEach(::appendChild)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModel.kt
@@ -26,9 +26,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.fleeksoft.ksoup.Ksoup
-import com.fleeksoft.ksoup.nodes.Element
-import com.fleeksoft.ksoup.nodes.TextNode
+import com.github.zly2006.zhihu.markdown.htmlToMdAst
+import com.github.zly2006.zhihu.markdown.toMarkdown
 import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.ArticleType
 import com.github.zly2006.zhihu.navigation.CollectionAnswerNavigator
@@ -1040,155 +1039,18 @@ class ArticleViewModel(
     private fun requireExportSourceContent(): DataHolder.Content = exportSourceContent
         ?: throw IllegalStateException("内容未加载完成")
 
-    // 转换为Markdown格式
     fun convertToMarkdown(): String {
         val sb = StringBuilder()
 
-        // 标题
         sb.append("# $title\n\n")
 
-        // 作者信息
         sb.append("**作者**: $authorName\n\n")
         if (authorBio.isNotEmpty()) {
             sb.append("**简介**: $authorBio\n\n")
         }
 
-        // 分隔线
         sb.append("---\n\n")
-
-        // 内容 - 解析 HTML 并转换为 Markdown
-        val document = Ksoup.parse(content)
-        sb.append(htmlToMarkdown(document.body()))
-
-        return sb.toString()
-    }
-
-    // HTML 转 Markdown 的递归函数
-    private fun htmlToMarkdown(element: Element): String {
-        val sb = StringBuilder()
-
-        for (node in element.childNodes()) {
-            when (node) {
-                is Element -> {
-                    when (node.tagName().lowercase()) {
-                        "h1" -> sb.append("# ${node.text()}\n\n")
-                        "h2" -> sb.append("## ${node.text()}\n\n")
-                        "h3" -> sb.append("### ${node.text()}\n\n")
-                        "h4" -> sb.append("#### ${node.text()}\n\n")
-                        "h5" -> sb.append("##### ${node.text()}\n\n")
-                        "h6" -> sb.append("###### ${node.text()}\n\n")
-                        "p" -> sb.append("${htmlToMarkdown(node)}\n\n")
-                        "br" -> sb.append("\n")
-                        "strong", "b" -> sb.append("**${node.text()}**")
-                        "em", "i" -> sb.append("*${node.text()}*")
-                        "u" -> sb.append("_${node.text()}_")
-                        "code" -> sb.append("`${node.text()}`")
-                        "pre" -> sb.append("```\n${node.text()}\n```\n\n")
-                        "blockquote" -> {
-                            val lines = htmlToMarkdown(node).trim().split("\n")
-                            for (line in lines) {
-                                sb.append("> $line\n")
-                            }
-                            sb.append("\n")
-                        }
-                        "ul", "ol" -> {
-                            val items = node.select("li")
-                            items.forEachIndexed { index, item ->
-                                val prefix = if (node.tagName() == "ul") "- " else "${index + 1}. "
-                                sb.append("$prefix${htmlToMarkdown(item).trim()}\n")
-                            }
-                            sb.append("\n")
-                        }
-                        "li" -> sb.append(htmlToMarkdown(node))
-                        "a" -> {
-                            val href = node.attr("href")
-                            val text = node.text()
-                            if (href.isNotEmpty()) {
-                                sb.append("[$text]($href)")
-                            } else {
-                                sb.append(text)
-                            }
-                        }
-                        "img" -> {
-                            val src = node.attr("src").ifEmpty { node.attr("data-actualsrc") }
-                            val alt = node.attr("alt").ifEmpty { "image" }
-                            if (src.isNotEmpty()) {
-                                sb.append("![$alt]($src)\n\n")
-                            }
-                        }
-                        "figure" -> {
-                            // 知乎的图片通常在 figure 标签中
-                            val img = node.selectFirst("img")
-                            if (img != null) {
-                                val src = img.attr("src").ifEmpty { img.attr("data-actualsrc") }
-                                val alt = img.attr("alt").ifEmpty { "image" }
-                                if (src.isNotEmpty()) {
-                                    sb.append("![$alt]($src)\n\n")
-                                }
-                            } else {
-                                sb.append(htmlToMarkdown(node))
-                            }
-                        }
-                        "hr" -> sb.append("---\n\n")
-                        "table" -> {
-                            // 简单的表格处理
-                            val rows = node.select("tr")
-                            if (rows.isNotEmpty()) {
-                                // 表头
-                                val headerCells = rows[0].select("th, td")
-                                if (headerCells.isNotEmpty()) {
-                                    sb.append("| ")
-                                    headerCells.forEach { cell ->
-                                        sb.append("${cell.text()} | ")
-                                    }
-                                    sb.append("\n")
-                                    // 分隔线
-                                    sb.append("| ")
-                                    headerCells.forEach { _ ->
-                                        sb.append("--- | ")
-                                    }
-                                    sb.append("\n")
-                                }
-                                // 表格内容
-                                for (i in 1 until rows.size) {
-                                    val cells = rows[i].select("td")
-                                    if (cells.isNotEmpty()) {
-                                        sb.append("| ")
-                                        cells.forEach { cell ->
-                                            sb.append("${cell.text()} | ")
-                                        }
-                                        sb.append("\n")
-                                    }
-                                }
-                                sb.append("\n")
-                            }
-                        }
-                        "div", "span" -> {
-                            // 检查是否是知乎的特殊标签
-                            val className = node.attr("class")
-                            if (className.contains("highlight")) {
-                                // 代码块
-                                val code = node.selectFirst("code")
-                                if (code != null) {
-                                    sb.append("```\n${code.text()}\n```\n\n")
-                                } else {
-                                    sb.append(htmlToMarkdown(node))
-                                }
-                            } else {
-                                sb.append(htmlToMarkdown(node))
-                            }
-                        }
-                        else -> sb.append(htmlToMarkdown(node))
-                    }
-                }
-                is TextNode -> {
-                    val text = node.text()
-                    if (text.isNotBlank()) {
-                        sb.append(text)
-                    }
-                }
-            }
-        }
+        sb.append(htmlToMdAst(content, noNativeBlock = true).toMarkdown())
 
         return sb.toString()
     }

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/markdown/MdAstTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/markdown/MdAstTest.kt
@@ -49,6 +49,45 @@ class MdAstTest {
     }
 
     @Test
+    fun video_box_anchor_should_convert_to_link_when_native_blocks_disabled() {
+        val document = htmlToMdAst(
+            """
+            <a class="video-box" href="https://link.zhihu.com/?target=https%3A//www.zhihu.com/video/2029631316597973958" data-lens-id="2029631316597973958">
+              <img src="https://example.com/cover.jpg" />
+            </a>
+            """.trimIndent(),
+            noNativeBlock = true,
+        )
+
+        assertFalse(document.allNodes().any { it is NativeBlock })
+        assertEquals("[视频](https://www.zhihu.com/video/2029631316597973958)", document.toMarkdown())
+    }
+
+    @Test
+    fun highlighted_paragraph_should_skip_segmented_native_block_when_native_blocks_disabled() {
+        val document = htmlToMdAst(
+            """
+            <p data-pid="seg-1"><span class="highlight-wrap other has-comments"
+                data-highlight-id="abc"
+                data-highlight-like-count="5"
+                data-highlight-comment-count="1"
+                data-highlight-my-comment-count="0"
+                data-highlight-is-like="true"
+                data-highlight-is-span="false"
+                data-highlight-content-id="42"
+                data-highlight-content-type="answer"
+                data-highlight-pid="seg-1"
+                data-highlight-start-offset="0"
+                data-highlight-end-offset="7">第一句需要划线</span>，第二句保持原样。</p>
+            """.trimIndent(),
+            noNativeBlock = true,
+        )
+
+        assertFalse(document.allNodes().any { it is NativeBlock })
+        assertEquals("第一句需要划线，第二句保持原样。", document.toMarkdown())
+    }
+
+    @Test
     fun inline_equation_in_list_item_should_stay_in_single_paragraph() {
         val document = htmlToMdAst(
             """

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModelExportTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/ArticleViewModelExportTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.viewmodel
+
+import com.github.zly2006.zhihu.navigation.Article
+import com.github.zly2006.zhihu.navigation.ArticleType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ArticleViewModelExportTest {
+    @Test
+    fun convert_to_markdown_should_reuse_md_ast_html_conversion() {
+        val viewModel = ArticleViewModel(
+            article = Article(type = ArticleType.Answer, id = 1L),
+            httpClient = null,
+        )
+        viewModel.title = "导出标题"
+        viewModel.authorName = "导出作者"
+        viewModel.authorBio = "导出简介"
+        viewModel.content =
+            """
+            <p>正文包含脚注<sup data-draft-type="reference" data-numero="1" data-text="参考资料" data-url="https://example.com/ref">[1]</sup> 和 <a href="https://link.zhihu.com/?target=https%3A%2F%2Fexample.com%2Ftarget">链接</a>。</p>
+            <a class="video-box" href="https://link.zhihu.com/?target=https%3A//www.zhihu.com/video/2029631316597973958" data-lens-id="2029631316597973958">
+              <img src="https://example.com/cover.jpg" />
+            </a>
+            """.trimIndent()
+
+        assertEquals(
+            """
+            # 导出标题
+
+            **作者**: 导出作者
+
+            **简介**: 导出简介
+
+            ---
+
+            正文包含脚注[^1] 和 [链接](https://example.com/target)。
+
+            [视频](https://www.zhihu.com/video/2029631316597973958)
+
+            [^1]: 参考资料[https://example.com/ref](https://example.com/ref)
+            """.trimIndent(),
+            viewModel.convertToMarkdown(),
+        )
+    }
+}


### PR DESCRIPTION
## 变更内容

- 让复制 Markdown 复用 `htmlToMdAst(...).toMarkdown()`，移除导出路径里手写 HTML 递归转换。
- 给 `htmlToMdAst` 增加 `noNativeBlock` 参数，默认行为不变；导出 Markdown 显式禁用 NativeBlock。
- `noNativeBlock = true` 时，划线高亮按普通文本继续解析，视频卡片降级为普通 Markdown 链接。
- 增加 MdAst 和导出 Markdown 的 JVM 回归测试。

## 验证

- `./gradlew --no-configuration-cache :shared:jvmTest --tests 'com.github.zly2006.zhihu.markdown.MdAstTest.video_box_anchor_should_convert_to_link_when_native_blocks_disabled' --tests 'com.github.zly2006.zhihu.markdown.MdAstTest.highlighted_paragraph_should_skip_segmented_native_block_when_native_blocks_disabled' --tests 'com.github.zly2006.zhihu.viewmodel.ArticleViewModelExportTest'`\n- `./gradlew --no-configuration-cache assembleLiteDebug`\n- `./gradlew --no-configuration-cache :shared:ktlintFormat`\n\n## 备注\n\n- 不涉及 UI、布局或样式改动，无需截图。\n- 全量 `ktlintFormat` 之前会触发 `shared-local-db` iOS 编译并因 `BlockedContentRecord.kt:50` 的 `serialization` 未解析失败；本 PR 相关的 shared 格式化已单独通过。