### PR TITLE
feat: 支持调整上下左右滑动回答切换灵敏度

### DIFF
--- a/docs/ai-ui-design-guide.md
+++ b/docs/ai-ui-design-guide.md
@@ -78,6 +78,7 @@ URL 解析集中在 `resolveContent()`。支持知乎问题、回答、文章、
 | `autoHideSkipAnswerButton` | 自动隐藏跳转按钮 | 跳转按钮滚动隐藏 | 仅 `buttonSkipAnswer` 开启时可见 |
 | `pinAnswerDate` | 置顶回答日期 | 回答日期位置 | 影响文章正文布局 |
 | `answerSwitchMode` | 回答切换手势 | `off` / `vertical` / `horizontal` | 会影响转场方向和手势冲突 |
+| `answerSwitchSensitivity` | 回答切换灵敏度 | 上下/左右回答切换触发阈值 | 默认 1.0，数值越高触发距离越短；关闭手势时设置项隐藏 |
 | `answerDoubleTapAction` | 双击回答动作 | 双击正文后的动作 | 可在文章页内动态保存 |
 | `bottom_bar_items` | 底栏页面选择 | 主 pager 页集合和底栏按钮 | 始终经 `normalizeBottomBarSelection()` |
 | `startDestination` | 应用启动默认页面 | 主 pager 初始页 | 只允许选择已显示的底栏项 |

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
@@ -759,6 +759,9 @@ fun ArticleScreen(
     var answerSwitchMode by remember {
         mutableStateOf(articleSettings.answerSwitchMode)
     }
+    var answerSwitchSensitivity by remember {
+        mutableFloatStateOf(articleSettings.answerSwitchSensitivity)
+    }
     var pinAnswerDate by remember { mutableStateOf(articleSettings.pinAnswerDate) }
     val userMessages = rememberUserMessageSink()
 
@@ -876,6 +879,9 @@ fun ArticleScreen(
     }
     LaunchedEffect(articleSettings.answerSwitchMode) {
         answerSwitchMode = articleSettings.answerSwitchMode
+    }
+    LaunchedEffect(articleSettings.answerSwitchSensitivity) {
+        answerSwitchSensitivity = articleSettings.answerSwitchSensitivity
     }
     LaunchedEffect(articleSettings.pinAnswerDate) {
         pinAnswerDate = articleSettings.pinAnswerDate
@@ -1829,6 +1835,7 @@ fun ArticleScreen(
                 isAtTop = { scrollState.value == 0 },
                 isAtBottom = { scrollState.value >= scrollState.maxValue },
                 scrollState = scrollState,
+                answerSwitchSensitivity = answerSwitchSensitivity,
             ) {
                 answerSwitchContent()
             }
@@ -1844,6 +1851,7 @@ fun ArticleScreen(
                 nextContent = nav?.nextAnswer?.let { cached ->
                     { CachedAnswerPreview(cached) }
                 },
+                answerSwitchSensitivity = answerSwitchSensitivity,
             ) {
                 answerSwitchContent()
             }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -47,6 +48,9 @@ import com.github.zly2006.zhihu.shared.platform.UserMessageSink
 import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.ui.ANSWER_DOUBLE_TAP_ACTION_PREFERENCE_KEY
 import com.github.zly2006.zhihu.shared.ui.AnswerDoubleTapAction
+import com.github.zly2006.zhihu.ui.components.ANSWER_SWITCH_SENSITIVITY_PREFERENCE_KEY
+import com.github.zly2006.zhihu.ui.components.DEFAULT_ANSWER_SWITCH_SENSITIVITY
+import com.github.zly2006.zhihu.ui.components.normalizedAnswerSwitchSensitivity
 import com.github.zly2006.zhihu.viewmodel.ArticleViewModel.CachedAnswerContent
 import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
 import com.github.zly2006.zhihu.viewmodel.getOrFetchContentDetail
@@ -145,6 +149,7 @@ class ArticleScreenSettingsState(
     isTitleAutoHide: Boolean,
     autoHideArticleBottomBar: Boolean,
     answerSwitchMode: String,
+    answerSwitchSensitivity: Float,
     pinAnswerDate: Boolean,
     useDuo3ArticleActions: Boolean,
     buttonSkipAnswer: Boolean,
@@ -156,6 +161,7 @@ class ArticleScreenSettingsState(
     var isTitleAutoHide by mutableStateOf(isTitleAutoHide)
     var autoHideArticleBottomBar by mutableStateOf(autoHideArticleBottomBar)
     var answerSwitchMode by mutableStateOf(answerSwitchMode)
+    var answerSwitchSensitivity by mutableFloatStateOf(answerSwitchSensitivity)
     var pinAnswerDate by mutableStateOf(pinAnswerDate)
     var useDuo3ArticleActions by mutableStateOf(useDuo3ArticleActions)
     var buttonSkipAnswer by mutableStateOf(buttonSkipAnswer)
@@ -183,6 +189,12 @@ fun rememberArticleScreenSettingsState(): ArticleScreenSettingsState {
             isTitleAutoHide = settings.getBoolean("titleAutoHide", false),
             autoHideArticleBottomBar = settings.getBoolean("autoHideArticleBottomBar", false),
             answerSwitchMode = settings.getString("answerSwitchMode", "vertical"),
+            answerSwitchSensitivity = normalizedAnswerSwitchSensitivity(
+                settings.getFloat(
+                    ANSWER_SWITCH_SENSITIVITY_PREFERENCE_KEY,
+                    DEFAULT_ANSWER_SWITCH_SENSITIVITY,
+                ),
+            ),
             pinAnswerDate = settings.getBoolean("pinAnswerDate", false),
             useDuo3ArticleActions = settings.getBoolean("duo3_article_actions", false),
             buttonSkipAnswer = settings.getBoolean("buttonSkipAnswer", true),
@@ -210,6 +222,12 @@ fun rememberArticleScreenSettingsState(): ArticleScreenSettingsState {
                 "autoHideSkipAnswerButton" -> state.autoHideSkipAnswerButton = settings.getBoolean(key, true)
                 "answerSwitchMode" -> {
                     state.answerSwitchMode = settings.getString(key, "vertical")
+                }
+
+                ANSWER_SWITCH_SENSITIVITY_PREFERENCE_KEY -> {
+                    state.answerSwitchSensitivity = normalizedAnswerSwitchSensitivity(
+                        settings.getFloat(key, DEFAULT_ANSWER_SWITCH_SENSITIVITY),
+                    )
                 }
 
                 "pinAnswerDate" -> state.pinAnswerDate = settings.getBoolean(key, false)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/AnswerHorizontalPager.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/AnswerHorizontalPager.kt
@@ -58,14 +58,17 @@ fun AnswerHorizontalOverscroll(
     onNavigateNext: () -> Unit,
     previousContent: (@Composable () -> Unit)?,
     nextContent: (@Composable () -> Unit)?,
+    answerSwitchSensitivity: Float = DEFAULT_ANSWER_SWITCH_SENSITIVITY,
     content: @Composable () -> Unit,
 ) {
     val density = LocalDensity.current
     val hapticFeedback = LocalHapticFeedback.current
     val coroutineScope = rememberCoroutineScope()
 
-    val maxOverscrollPx = with(density) { MAX_HORIZONTAL_OVERSCROLL_DP.toPx() }
-    val triggerThresholdPx = with(density) { HORIZONTAL_TRIGGER_THRESHOLD_DP.toPx() }
+    val maxOverscrollPx = with(density) { MAX_HORIZONTAL_OVERSCROLL_DP.dp.toPx() }
+    val triggerThresholdPx = with(density) {
+        (HORIZONTAL_TRIGGER_THRESHOLD_DP / normalizedAnswerSwitchSensitivity(answerSwitchSensitivity)).dp.toPx()
+    }
 
     val overscrollOffset = remember { Animatable(0f) }
     var hasTriggeredHaptic by remember { mutableStateOf(false) }
@@ -77,7 +80,7 @@ fun AnswerHorizontalOverscroll(
             .fillMaxSize()
             .clipToBounds()
             .onSizeChanged { containerWidthPx = it.width.toFloat() }
-            .pointerInput(canGoPrevious, canGoNext) {
+            .pointerInput(canGoPrevious, canGoNext, triggerThresholdPx) {
                 detectHorizontalDragGestures(
                     onDragStart = {
                         rawDragAccumulator = 0f
@@ -189,6 +192,6 @@ fun AnswerHorizontalOverscroll(
     }
 }
 
-private val MAX_HORIZONTAL_OVERSCROLL_DP = 300.dp
-private val HORIZONTAL_TRIGGER_THRESHOLD_DP = 46.dp
+private const val MAX_HORIZONTAL_OVERSCROLL_DP = 300f
+private const val HORIZONTAL_TRIGGER_THRESHOLD_DP = 46f
 private const val HORIZONTAL_DAMPING_FACTOR = 1.2f

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/AnswerSwitchSensitivity.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/AnswerSwitchSensitivity.kt
@@ -1,0 +1,28 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.ui.components
+
+const val ANSWER_SWITCH_SENSITIVITY_PREFERENCE_KEY = "answerSwitchSensitivity"
+const val DEFAULT_ANSWER_SWITCH_SENSITIVITY = 1f
+const val MIN_ANSWER_SWITCH_SENSITIVITY = 0.5f
+const val MAX_ANSWER_SWITCH_SENSITIVITY = 3f
+
+internal fun normalizedAnswerSwitchSensitivity(value: Float): Float = when {
+    value.isNaN() -> DEFAULT_ANSWER_SWITCH_SENSITIVITY
+    else -> value.coerceIn(MIN_ANSWER_SWITCH_SENSITIVITY, MAX_ANSWER_SWITCH_SENSITIVITY)
+}

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/AnswerVerticalOverscroll.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/AnswerVerticalOverscroll.kt
@@ -95,6 +95,7 @@ fun AnswerVerticalOverscroll(
     isAtTop: () -> Boolean,
     isAtBottom: () -> Boolean,
     scrollState: ScrollState,
+    answerSwitchSensitivity: Float = DEFAULT_ANSWER_SWITCH_SENSITIVITY,
     isContentNonScrollable: Boolean = scrollState.maxValue == 0,
     content: @Composable () -> Unit,
 ) {
@@ -103,7 +104,9 @@ fun AnswerVerticalOverscroll(
     val coroutineScope = rememberCoroutineScope()
 
     val maxOverscrollPx = with(density) { MAX_OVERSCROLL_DP.dp.toPx() }
-    val triggerThresholdPx = with(density) { TRIGGER_THRESHOLD_DP.dp.toPx() }
+    val triggerThresholdPx = with(density) {
+        (TRIGGER_THRESHOLD_DP / normalizedAnswerSwitchSensitivity(answerSwitchSensitivity)).dp.toPx()
+    }
 
     val overscrollOffset = remember { Animatable(0f) }
     var hasTriggeredHaptic by remember { mutableStateOf(false) }
@@ -114,6 +117,7 @@ fun AnswerVerticalOverscroll(
     val currentCanGoNext by rememberUpdatedState(nextAnswer != null)
     val currentOnNavigatePrevious by rememberUpdatedState(onNavigatePrevious)
     val currentOnNavigateNext by rememberUpdatedState(onNavigateNext)
+    val currentTriggerThresholdPx by rememberUpdatedState(triggerThresholdPx)
 
     val nestedScrollConnection = remember {
         object : NestedScrollConnection {
@@ -136,7 +140,7 @@ fun AnswerVerticalOverscroll(
                             dampingFactor = DAMPING_FACTOR,
                         )
                         coroutineScope.launch { overscrollOffset.snapTo(newOffset) }
-                        if (hasTriggeredHaptic && abs(newOffset) < triggerThresholdPx) {
+                        if (hasTriggeredHaptic && abs(newOffset) < currentTriggerThresholdPx) {
                             hasTriggeredHaptic = false
                         }
                         return Offset(0f, delta)
@@ -170,7 +174,7 @@ fun AnswerVerticalOverscroll(
                         dampingFactor = DAMPING_FACTOR,
                     )
                     coroutineScope.launch { overscrollOffset.snapTo(newOffset) }
-                    if (!hasTriggeredHaptic && abs(newOffset) >= triggerThresholdPx) {
+                    if (!hasTriggeredHaptic && abs(newOffset) >= currentTriggerThresholdPx) {
                         hasTriggeredHaptic = true
                         hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                     }
@@ -183,7 +187,7 @@ fun AnswerVerticalOverscroll(
                 if (overscrollOffset.value != 0f) {
                     val currentOffset = overscrollOffset.value
                     var didNavigate = false
-                    if (abs(currentOffset) >= triggerThresholdPx) {
+                    if (abs(currentOffset) >= currentTriggerThresholdPx) {
                         if (currentOffset > 0 && currentCanGoPrevious) {
                             currentOnNavigatePrevious()
                             didNavigate = true
@@ -263,11 +267,11 @@ fun AnswerVerticalOverscroll(
                                             dampingFactor = DAMPING_FACTOR,
                                         )
                                         coroutineScope.launch { overscrollOffset.snapTo(newOffset) }
-                                        if (!hasTriggeredHaptic && abs(newOffset) >= triggerThresholdPx) {
+                                        if (!hasTriggeredHaptic && abs(newOffset) >= currentTriggerThresholdPx) {
                                             hasTriggeredHaptic = true
                                             hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                         }
-                                        if (hasTriggeredHaptic && abs(newOffset) < triggerThresholdPx) {
+                                        if (hasTriggeredHaptic && abs(newOffset) < currentTriggerThresholdPx) {
                                             hasTriggeredHaptic = false
                                         }
                                     }
@@ -275,7 +279,7 @@ fun AnswerVerticalOverscroll(
 
                                 val currentOffset = overscrollOffset.value
                                 var didNavigate = false
-                                if (abs(currentOffset) >= triggerThresholdPx) {
+                                if (abs(currentOffset) >= currentTriggerThresholdPx) {
                                     if (currentOffset > 0 && currentCanGoPrevious) {
                                         currentOnNavigatePrevious()
                                         didNavigate = true

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
@@ -100,11 +100,16 @@ import com.github.zly2006.zhihu.shared.ui.ANSWER_DOUBLE_TAP_ACTION_PREFERENCE_KE
 import com.github.zly2006.zhihu.shared.ui.AnswerDoubleTapAction
 import com.github.zly2006.zhihu.theme.ThemeManager
 import com.github.zly2006.zhihu.ui.ARTICLE_USE_WEBVIEW_PREFERENCE_KEY
+import com.github.zly2006.zhihu.ui.components.ANSWER_SWITCH_SENSITIVITY_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.components.ColorPickerDialog
+import com.github.zly2006.zhihu.ui.components.DEFAULT_ANSWER_SWITCH_SENSITIVITY
+import com.github.zly2006.zhihu.ui.components.MAX_ANSWER_SWITCH_SENSITIVITY
+import com.github.zly2006.zhihu.ui.components.MIN_ANSWER_SWITCH_SENSITIVITY
 import com.github.zly2006.zhihu.ui.components.SettingItem
 import com.github.zly2006.zhihu.ui.components.SettingItemGroup
 import com.github.zly2006.zhihu.ui.components.SettingItemOverall
 import com.github.zly2006.zhihu.ui.components.SettingItemWithSwitch
+import com.github.zly2006.zhihu.ui.components.normalizedAnswerSwitchSensitivity
 import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
 import kotlin.time.Duration.Companion.milliseconds
@@ -116,6 +121,7 @@ const val PREF_BLOCK_SPACING = "contentBlockSpacing"
 const val APPEARANCE_SETTINGS_SCROLL_TAG = "appearanceSettings.scroll"
 const val APPEARANCE_SETTINGS_START_DESTINATION_TAG = "appearanceSettings.startDestination"
 const val APPEARANCE_SETTINGS_ANSWER_DOUBLE_TAP_TAG = "appearanceSettings.answerDoubleTap"
+const val APPEARANCE_SETTINGS_ANSWER_SWITCH_SENSITIVITY_TAG = "appearanceSettings.answerSwitchSensitivity"
 const val APPEARANCE_SETTINGS_USE_WEBVIEW_TAG = "appearanceSettings.useWebView"
 const val APPEARANCE_SETTINGS_WEBVIEW_FONT_TAG = "appearanceSettings.webViewFont"
 const val APPEARANCE_SETTINGS_WEBVIEW_OPTIONS_TAG = "appearanceSettings.webViewOptions"
@@ -832,6 +838,44 @@ fun AppearanceSettingsScreen(
                         }
                     },
                 )
+
+                var answerSwitchSensitivity by remember {
+                    mutableStateOf(
+                        normalizedAnswerSwitchSensitivity(
+                            settings.getFloat(
+                                ANSWER_SWITCH_SENSITIVITY_PREFERENCE_KEY,
+                                DEFAULT_ANSWER_SWITCH_SENSITIVITY,
+                            ),
+                        ),
+                    )
+                }
+                AnimatedVisibility(answerSwitchMode.value != "off") {
+                    SettingItem(
+                        title = { Text("回答切换灵敏度") },
+                        description = {
+                            Text("当前 ${(answerSwitchSensitivity * 10).roundToInt() / 10f}x，数值越高，滑动越短；同时作用于上下和左右切换。")
+                        },
+                        settingKey = ANSWER_SWITCH_SENSITIVITY_PREFERENCE_KEY,
+                        highlightedKey = settingKey,
+                        bringIntoViewRequester = requesterFor(ANSWER_SWITCH_SENSITIVITY_PREFERENCE_KEY),
+                        bottomAction = {
+                            Slider(
+                                value = answerSwitchSensitivity,
+                                onValueChange = {
+                                    val sensitivity = (it * 10).roundToInt() / 10f
+                                    answerSwitchSensitivity = sensitivity
+                                    settings.putFloat(ANSWER_SWITCH_SENSITIVITY_PREFERENCE_KEY, sensitivity)
+                                },
+                                valueRange = MIN_ANSWER_SWITCH_SENSITIVITY..MAX_ANSWER_SWITCH_SENSITIVITY,
+                                steps = 24,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 8.dp)
+                                    .testTag(APPEARANCE_SETTINGS_ANSWER_SWITCH_SENSITIVITY_TAG),
+                            )
+                        },
+                    )
+                }
 
                 var answerDoubleTapExpanded by remember { mutableStateOf(false) }
                 val answerDoubleTapAction = remember {


### PR DESCRIPTION
## 变更
- 新增“回答切换灵敏度”设置，默认 1.0x，范围 0.5x-3.0x。
- 横向和纵向回答切换直接按当前灵敏度换算触发阈值，数值越高触发滑动距离越短。
- 文章页设置监听新增灵敏度 key；设置修改后，横向/纵向手势处理都会使用最新触发阈值。
- 补充 UI 设计文档中的设置 key 说明。

## 验证
- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- off AVD：`status`/`boot-check` 通过；安装 Lite Debug APK、恢复 `account.json`、启动应用；用 `ui-test` 进入“账号 -> 外观与阅读体验”，确认“回答切换灵敏度”、默认 `1.0x` 文案和 `appearanceSettings.answerSwitchSensitivity` slider 可见。

## 截图
截图来自实际运行的 Lite Debug APK + off AVD。

![回答切换灵敏度设置](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-501/answer-switch-sensitivity.png)

Resolves #466
