### PR TITLE
feat: 新增音量翻页键支持、悬浮按钮透明度设置、统一文本内容缩放

### DIFF
--- a/app/src/main/java/com/github/zly2006/zhihu/MainActivity.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/MainActivity.kt
@@ -115,6 +115,7 @@ class MainActivity :
     }
 
     val sharedData by viewModels<SharedData>()
+    val pageTurnFlow = kotlinx.coroutines.flow.MutableSharedFlow<Int>(extraBufferCapacity = 1)
     override val articleNavController: NavHostController
         get() = navController
     override val articleAnswerSwitchState: ArticleAnswerSwitchState
@@ -255,9 +256,17 @@ class MainActivity :
 
         setContent {
             navController = rememberNavController()
-            ZhihuTheme {
-                Box(Modifier.semantics { testTagsAsResourceId = true }) {
-                    AndroidZhihuMain(navController = navController)
+            androidx.compose.runtime.CompositionLocalProvider(
+                com.github.zly2006.zhihu.ui.components.LocalPageTurnChannel provides pageTurnFlow,
+            ) {
+                ZhihuTheme {
+                    Box(
+                        Modifier.semantics { testTagsAsResourceId = true },
+                    ) {
+                        AndroidZhihuMain(navController = navController)
+                        com.github.zly2006.zhihu.ui.components
+                            .PageTurnFab()
+                    }
                 }
             }
         }
@@ -384,6 +393,36 @@ class MainActivity :
     override fun onStop() {
         continuousUsageReminderManager.onAppBackground()
         super.onStop()
+    }
+
+    private var longPressConsumed = false
+
+    private fun pageTurnDirection(keyCode: Int): Int? = when (keyCode) {
+        android.view.KeyEvent.KEYCODE_PAGE_DOWN -> 1
+        android.view.KeyEvent.KEYCODE_PAGE_UP -> -1
+        android.view.KeyEvent.KEYCODE_VOLUME_DOWN ->
+            if (androidSettingsStore(this).getBoolean("volumeKeyPageTurn", false)) 1 else null
+        android.view.KeyEvent.KEYCODE_VOLUME_UP ->
+            if (androidSettingsStore(this).getBoolean("volumeKeyPageTurn", false)) -1 else null
+        else -> null
+    }
+
+    override fun dispatchKeyEvent(event: android.view.KeyEvent): Boolean {
+        val direction = pageTurnDirection(event.keyCode) ?: return super.dispatchKeyEvent(event)
+        if (event.action == android.view.KeyEvent.ACTION_DOWN) {
+            if (event.isLongPress) {
+                longPressConsumed = true
+                pageTurnFlow.tryEmit(if (direction > 0) Int.MAX_VALUE else Int.MIN_VALUE)
+            } else if (event.repeatCount == 0) {
+                longPressConsumed = false
+            }
+        } else if (event.action == android.view.KeyEvent.ACTION_UP) {
+            if (!longPressConsumed) {
+                pageTurnFlow.tryEmit(direction)
+            }
+            longPressConsumed = false
+        }
+        return true
     }
 
     override val developerRuntimeInfo: DeveloperRuntimeInfo

--- a/docs/page-turn-architecture.md
+++ b/docs/page-turn-architecture.md
@@ -1,0 +1,75 @@
+# 翻页键支持架构
+
+## 事件流
+
+```
+┌──────────────┐    ┌──────────────┐
+│ 实体按键      │    │ 悬浮翻页按钮  │
+│ (PAGE_DOWN   │    │ (FAB)        │
+│  VOLUME_DOWN │    │              │
+│  等)         │    │              │
+└──────┬───────┘    └──────┬───────┘
+       │                   │
+       ▼                   ▼
+  MainActivity         pageTurnFlow
+  .dispatchKeyEvent     .tryEmit(±1)
+       │                   │
+       ▼                   │
+  pageTurnFlow ◄───────────┘
+  MutableSharedFlow<Int>
+       │
+       ├──► 各屏幕的 PageTurnEffect (scrollBy)
+       ├──► ZhihuMain (底部栏显/隐)
+       └──► CommentScreen (弹层内翻页)
+```
+
+## 事件值语义
+
+| 值 | 含义 |
+|---|---|
+| `1` | 下翻一页（视口的 N%） |
+| `-1` | 上翻一页 |
+| `Int.MAX_VALUE` | 长按跳到底部 |
+| `Int.MIN_VALUE` | 长按跳到顶部 |
+
+## 涉及的文件和职责
+
+### 1. 事件产生层
+
+- **`MainActivity.kt`** — `dispatchKeyEvent` 拦截实体按键，通过 `pageTurnDirection()` 判断是否是翻页键，短按在 `ACTION_UP` 时发射 ±1，长按在 `ACTION_DOWN` 时发射 `±MAX_VALUE`。`longPressConsumed` 标志防止长按后松手再触发短按。
+
+- **`DraggablePageTurnButtons.kt`** — 定义 `pageTurnFlow`（`MutableSharedFlow`）、`LocalPageTurnChannel`（CompositionLocal）、`pageTurnFabVisible`（FAB 可见性）、`pageTurnModalDepth`（弹层计数）。FAB 点击时直接 `tryEmit(±1)`。
+
+### 2. 事件消费层 — 滚动
+
+- **`PageTurnScrollEffect`**（`DraggablePageTurnButtons.kt`）— 适用于 `ScrollState`（如 `ArticleScreen` 的 `Column + verticalScroll`）。收集 `LocalPageTurnChannel`，根据方向调用 `scrollState.scrollTo()` 或 `scrollState.scrollBy(viewport * percent)`。
+
+- **`PageTurnLazyListEffect`**（`DraggablePageTurnButtons.kt`）— 适用于 `LazyListState`（如 `PaginatedList`、`CommentScreen`、`DailyScreen`）。逻辑类似，但用 `listState.scrollBy()` / `listState.scrollToItem()`。
+
+- 每个需要翻页的屏幕只需一行调用：
+
+```kotlin
+PageTurnLazyListEffect(listState, pageTurnPercent, guideState)
+// 或
+PageTurnScrollEffect(scrollState, pageTurnPercent, ...)
+```
+
+### 3. 事件消费层 — UI 联动
+
+- **`ZhihuMain.kt`** — 监听 `LocalPageTurnChannel` 更新 `isBottomBarVisible`，使 FAB/实体键翻页时底部导航栏的隐藏行为与触屏一致。（程序化 `scrollBy` 不经过 `NestedScrollConnection`，所以需要单独监听。）
+
+### 4. 弹层翻页隔离
+
+- **`CommentScreenComponent.kt`** — 评论弹层打开/关闭时 `pageTurnModalDepth++/--`。弹层使用 `usePlatformWindow = false` 以便翻页事件能传递进来（平台 Dialog 窗口会拦截按键事件且遮挡 FAB）。
+
+- **`PageTurnLazyListEffect`** 默认 `skip = pageTurnModalDepth > 0`，弹层下方的页面自动停止响应翻页。评论弹层自己的 `CommentScreen` 传入 `skip = false` 来接管翻页。子评论打开时，父评论传入 `skip = childSheetVisible` 让出控制权。
+
+### 5. 翻页引导线
+
+- **`PageTurnGuideState`**（`DraggablePageTurnButtons.kt`）— 持有 `lastDirection` 和 `isScrolling`，供 `PageTurnGuideOverlay` 绘制翻页方向指示线。
+
+### 6. 段评弹层修复
+
+- **`RenderMarkdown.kt`** — 增加 `onOpenSegmentComment` 回调，允许调用方将段评弹层提升到外层渲染。
+- **`ArticleScreen.kt`** — 使用该回调将段评 `CommentScreenComponent` 渲染在 `Scaffold` 外层，避免在滚动容器内渲染导致弹层和 FAB 失效。
+

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/RenderMarkdown.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/RenderMarkdown.kt
@@ -246,6 +246,7 @@ fun RenderMarkdown(
     enableScroll: Boolean = true,
     header: (@Composable () -> Unit)? = null,
     footer: (@Composable () -> Unit)? = null,
+    onOpenSegmentComment: ((SegmentCommentHolder) -> Unit)? = null,
 ) {
     val document = remember(html) { htmlToMdAst(html) }
     RenderMarkdownDocument(
@@ -256,6 +257,7 @@ fun RenderMarkdown(
         enableScroll = enableScroll,
         header = header,
         footer = footer,
+        onOpenSegmentComment = onOpenSegmentComment,
     )
 }
 
@@ -290,6 +292,7 @@ private fun RenderMarkdownDocument(
     enableScroll: Boolean,
     header: (@Composable () -> Unit)?,
     footer: (@Composable () -> Unit)?,
+    onOpenSegmentComment: ((SegmentCommentHolder) -> Unit)? = null,
 ) {
     val imageUrls = remember(document) { document.previewImageUrls() }
     val navigator = LocalNavigator.current
@@ -312,8 +315,11 @@ private fun RenderMarkdownDocument(
     )
     var segmentCommentTarget by remember { mutableStateOf<SegmentCommentHolder?>(null) }
     var segmentActionSheetState by remember { mutableStateOf<SegmentActionSheetState?>(null) }
+    val segmentCommentCallback = onOpenSegmentComment ?: { target: SegmentCommentHolder ->
+        segmentCommentTarget = target
+    }
     CompositionLocalProvider(
-        LocalSegmentCommentHost provides { target -> segmentCommentTarget = target },
+        LocalSegmentCommentHost provides segmentCommentCallback,
         LocalSegmentActionSheetHost provides { state -> segmentActionSheetState = state },
     ) {
         Box(modifier = modifier) {
@@ -341,12 +347,14 @@ private fun RenderMarkdownDocument(
             }
         }
     }
-    segmentCommentTarget?.let { target ->
-        CommentScreenComponent(
-            showComments = true,
-            onDismiss = { segmentCommentTarget = null },
-            content = target,
-        )
+    if (onOpenSegmentComment == null) {
+        segmentCommentTarget?.let { target ->
+            CommentScreenComponent(
+                showComments = true,
+                onDismiss = { segmentCommentTarget = null },
+                content = target,
+            )
+        }
     }
     segmentActionSheetState?.let { state ->
         SegmentActionSheet(state)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/AccountSettingScreen.kt
@@ -73,6 +73,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
@@ -87,6 +88,7 @@ import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.platform.rememberSystemUrlOpener
 import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
 import com.github.zly2006.zhihu.shared.util.Log
+import com.github.zly2006.zhihu.ui.components.PageTurnScrollEffect
 import com.github.zly2006.zhihu.ui.components.SettingItem
 import com.github.zly2006.zhihu.ui.components.SettingItemGroup
 import com.github.zly2006.zhihu.ui.subscreens.BOTTOM_BAR_ITEMS_PREFERENCE_KEY
@@ -172,12 +174,16 @@ fun AccountSettingScreen(
         modifier = Modifier.fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
     ) { padding ->
+        val scrollState = rememberScrollState()
+        var viewportHeight by remember { mutableIntStateOf(0) }
+        PageTurnScrollEffect(scrollState, viewportHeight)
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(innerPadding)
                 .testTag(ACCOUNT_SETTINGS_SCROLL_TAG)
-                .verticalScroll(rememberScrollState())
+                .onSizeChanged { viewportHeight = it.height }
+                .verticalScroll(scrollState)
                 .padding(padding),
         ) {
             LaunchedEffect(data.login, refreshAccountProfileOnEnter) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.gestures.BringIntoViewSpec
 import androidx.compose.foundation.gestures.LocalBringIntoViewSpec
 import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -129,9 +130,11 @@ import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.ArticleType
 import com.github.zly2006.zhihu.navigation.LocalNavigator
 import com.github.zly2006.zhihu.navigation.Question
+import com.github.zly2006.zhihu.navigation.SegmentCommentHolder
 import com.github.zly2006.zhihu.shared.data.Person
 import com.github.zly2006.zhihu.shared.data.ZhihuPaging
 import com.github.zly2006.zhihu.shared.platform.PlatformBackHandler
+import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
 import com.github.zly2006.zhihu.shared.ui.AnswerDoubleTapAction
 import com.github.zly2006.zhihu.shared.util.formatCompactCount
@@ -143,12 +146,18 @@ import com.github.zly2006.zhihu.ui.components.CollectionDialogComponent
 import com.github.zly2006.zhihu.ui.components.CommentScreenComponent
 import com.github.zly2006.zhihu.ui.components.DraggableRefreshButton
 import com.github.zly2006.zhihu.ui.components.ExportDialogComponent
+import com.github.zly2006.zhihu.ui.components.LocalPageTurnChannel
 import com.github.zly2006.zhihu.ui.components.MyModalBottomSheet
+import com.github.zly2006.zhihu.ui.components.PageTurnGuideOverlay
 import com.github.zly2006.zhihu.ui.components.VerticalReadingProgressBar
 import com.github.zly2006.zhihu.ui.components.VotersSheet
 import com.github.zly2006.zhihu.ui.components.ZhihuTwoRowsTopAppBar
+import com.github.zly2006.zhihu.ui.components.pageTurnModalDepth
 import com.github.zly2006.zhihu.ui.components.rememberPreferCollapsedExitUntilCollapsedScrollBehavior
 import com.github.zly2006.zhihu.ui.components.rememberShareDialogRuntime
+import com.github.zly2006.zhihu.ui.subscreens.DEFAULT_PAGE_TURN_PERCENT
+import com.github.zly2006.zhihu.ui.subscreens.PREF_PAGE_TURN_PERCENT
+import com.github.zly2006.zhihu.ui.subscreens.PREF_SHOW_PAGE_TURN_GUIDE
 import com.github.zly2006.zhihu.util.smoothGradient
 import com.github.zly2006.zhihu.viewmodel.ArticleViewModel
 import com.github.zly2006.zhihu.viewmodel.ArticleViewModel.CachedAnswerContent
@@ -773,8 +782,19 @@ fun ArticleScreen(
     var navigatingToNextAnswer by remember { mutableStateOf(false) }
     val density = LocalDensity.current
     val scrollDeltaThreshold = with(density) { ScrollThresholdDp.toPx() }
+    var pageKeyViewportHeight by remember { mutableIntStateOf(0) }
+    var lastPageTurnDirection by remember { mutableIntStateOf(0) }
+    var isPageTurnScrolling by remember { mutableStateOf(false) }
+    val pageKeySettings = rememberSettingsStore()
+    val pageTurnPercent = remember { pageKeySettings.getInt(PREF_PAGE_TURN_PERCENT, DEFAULT_PAGE_TURN_PERCENT) }
+    val showPageTurnGuide = remember { pageKeySettings.getBoolean(PREF_SHOW_PAGE_TURN_GUIDE, false) }
+
+    if (showPageTurnGuide && lastPageTurnDirection != 0 && scrollState.isScrollInProgress && !isPageTurnScrolling) {
+        lastPageTurnDirection = 0
+    }
     var topBarHeight by remember { mutableIntStateOf(0) }
     var showComments by rememberSaveable(article.type, article.id) { mutableStateOf(false) }
+    var segmentCommentTarget by remember { mutableStateOf<SegmentCommentHolder?>(null) }
     var showCollectionDialog by remember { mutableStateOf(false) }
     var showActionsMenu by remember { mutableStateOf(false) }
     var showSummaryDialog by remember { mutableStateOf(false) }
@@ -806,6 +826,43 @@ fun ArticleScreen(
             contentToken = article.id.toString(),
             contentTypeName = article.type.name.lowercase(),
         )
+    }
+
+    val pageTurnChannel = LocalPageTurnChannel.current
+    LaunchedEffect(pageTurnChannel) {
+        pageTurnChannel.collect { direction ->
+            if (pageTurnModalDepth.intValue > 0) return@collect
+            lastPageTurnDirection = direction.coerceIn(-1, 1)
+            isPageTurnScrolling = true
+            try {
+                when (direction) {
+                    Int.MAX_VALUE -> {
+                        scrollState.scrollTo(scrollState.maxValue)
+                        if (isTitleAutoHide && topBarHeightPx > 0f) topBarOffset.snapTo(-topBarHeightPx)
+                    }
+                    Int.MIN_VALUE -> {
+                        scrollState.scrollTo(0)
+                        topBarOffset.snapTo(0f)
+                    }
+                    else -> {
+                        if (isTitleAutoHide && topBarHeightPx > 0f && direction > 0) {
+                            topBarOffset.snapTo(-topBarHeightPx)
+                        }
+                        val visibleTopBar = (topBarHeightPx + topBarOffset.value).coerceAtLeast(0f)
+                        val visibleBottomBar = (bottomBarHeightPx - bottomBarOffset.value).coerceAtLeast(0f)
+                        val effectiveViewport = pageKeyViewportHeight - visibleTopBar.toInt() - visibleBottomBar.toInt()
+                        if (effectiveViewport > 0) {
+                            scrollState.scrollBy(effectiveViewport * pageTurnPercent / 100f * direction)
+                        }
+                        if (direction < 0 && scrollState.value == 0 && isTitleAutoHide) {
+                            topBarOffset.snapTo(0f)
+                        }
+                    }
+                }
+            } finally {
+                isPageTurnScrolling = false
+            }
+        }
     }
 
     fun upVoteFromDoubleTap() {
@@ -1197,6 +1254,19 @@ fun ArticleScreen(
         LaunchedEffect(scrollState.maxValue) {
             if (scrollState.maxValue != Int.MAX_VALUE) {
                 scrollStateMaxValue = max(scrollState.maxValue, scrollStateMaxValue)
+            }
+        }
+        LaunchedEffect(pageTurnChannel) {
+            pageTurnChannel.collect { direction ->
+                if (pageTurnModalDepth.intValue > 0) return@collect
+                val state = scrollBehavior.state
+                if (direction > 0 || direction == Int.MAX_VALUE) {
+                    state.heightOffset = state.heightOffsetLimit
+                } else if (direction == Int.MIN_VALUE) {
+                    state.heightOffset = 0f
+                } else if (direction < 0 && scrollState.value == 0) {
+                    state.heightOffset = 0f
+                }
             }
         }
         Scaffold(
@@ -1649,7 +1719,10 @@ fun ArticleScreen(
             },
         ) { innerPadding ->
             CompositionLocalProvider(LocalBringIntoViewSpec provides articleBringIntoViewSpec) {
-                Box {
+                Box(
+                    modifier = Modifier
+                        .onSizeChanged { pageKeyViewportHeight = it.height },
+                ) {
                     Column(
                         modifier = Modifier
                             .padding(horizontal = 16.dp)
@@ -1801,6 +1874,7 @@ fun ArticleScreen(
                                         }
                                         Spacer(modifier = Modifier.height((16 + 36).dp))
                                     },
+                                    onOpenSegmentComment = { segmentCommentTarget = it },
                                 )
                             }
                         }
@@ -1857,10 +1931,10 @@ fun ArticleScreen(
                 onNavigatePrevious = navigateToPrevious,
                 onNavigateNext = navigateToNext,
                 previousContent = nav?.previousAnswer?.let { cached ->
-                    { CachedAnswerPreview(cached) }
+                    { CachedAnswerPreview(cached) { segmentCommentTarget = it } }
                 },
                 nextContent = nav?.nextAnswer?.let { cached ->
-                    { CachedAnswerPreview(cached) }
+                    { CachedAnswerPreview(cached) { segmentCommentTarget = it } }
                 },
                 answerSwitchSensitivity = answerSwitchSensitivity,
             ) {
@@ -1916,6 +1990,17 @@ fun ArticleScreen(
                     Icon(Icons.Filled.SkipNext, contentDescription = "下一个回答")
                 }
             }
+        }
+
+        if (showPageTurnGuide) {
+            val visibleTopBar = (topBarHeightPx + topBarOffset.value).coerceAtLeast(0f)
+            val visibleBottomBar = (bottomBarHeightPx - bottomBarOffset.value).coerceAtLeast(0f)
+            PageTurnGuideOverlay(
+                pageTurnPercent,
+                topInsetPx = visibleTopBar,
+                bottomInsetPx = visibleBottomBar,
+                lastDirection = lastPageTurnDirection,
+            )
         }
     }
 
@@ -1991,6 +2076,13 @@ fun ArticleScreen(
         onDismiss = { showComments = false },
         content = article,
     )
+    segmentCommentTarget?.let { target ->
+        CommentScreenComponent(
+            showComments = true,
+            onDismiss = { segmentCommentTarget = null },
+            content = target,
+        )
+    }
     VotersSheet(
         show = showVoters,
         title = "${formatCompactCount(viewModel.votersTotal)} 人赞同了该回答",
@@ -2101,6 +2193,7 @@ fun ArticleScreen(
 @Composable
 private fun CachedAnswerPreview(
     cached: CachedAnswerContent,
+    onOpenSegmentComment: (SegmentCommentHolder) -> Unit = {},
 ) {
     Scaffold(
         modifier = Modifier
@@ -2247,6 +2340,7 @@ private fun CachedAnswerPreview(
                     enableScroll = false,
                     header = {},
                     footer = {},
+                    onOpenSegmentComment = onOpenSegmentComment,
                 )
             }
             Spacer(modifier = Modifier.height((16 + 36).dp))

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CommentScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CommentScreen.kt
@@ -131,8 +131,11 @@ import com.github.zly2006.zhihu.shared.platform.rememberExternalUrlOpener
 import com.github.zly2006.zhihu.shared.platform.rememberImagePreviewOpener
 import com.github.zly2006.zhihu.shared.platform.rememberImageSaver
 import com.github.zly2006.zhihu.shared.platform.rememberImageSharer
+import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.util.twoDigitString
 import com.github.zly2006.zhihu.shared.viewmodel.CommentItem
+import com.github.zly2006.zhihu.ui.subscreens.PREF_FONT_SIZE
+import com.github.zly2006.zhihu.ui.subscreens.PREF_LINE_HEIGHT
 import com.github.zly2006.zhihu.viewmodel.comment.BaseCommentViewModel
 import com.github.zly2006.zhihu.viewmodel.comment.ChildCommentViewModel
 import com.github.zly2006.zhihu.viewmodel.comment.CommentSortOrder
@@ -1047,11 +1050,16 @@ private fun CommentItem(
                 val inlineContent = rememberCommentEmojiInlineContent(emojisUsed)
 
                 Column {
+                    val settings = rememberSettingsStore()
+                    val fontSizePercent = remember { settings.getInt(PREF_FONT_SIZE, 100) }
+                    val lineHeightPercent = remember { settings.getInt(PREF_LINE_HEIGHT, 160) }
                     SelectionContainer(
                         modifier = Modifier.commentSelectionWorkaround(),
                     ) {
                         Text(
                             text = string,
+                            fontSize = 16.sp * fontSizePercent / 100,
+                            lineHeight = 16.sp * fontSizePercent / 100 * lineHeightPercent / 100,
                             inlineContent = inlineContent,
                         )
                     }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CommentScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CommentScreen.kt
@@ -134,8 +134,14 @@ import com.github.zly2006.zhihu.shared.platform.rememberImageSharer
 import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.util.twoDigitString
 import com.github.zly2006.zhihu.shared.viewmodel.CommentItem
+import com.github.zly2006.zhihu.ui.components.PageTurnGuideOverlay
+import com.github.zly2006.zhihu.ui.components.PageTurnGuideState
+import com.github.zly2006.zhihu.ui.components.PageTurnLazyListEffect
+import com.github.zly2006.zhihu.ui.subscreens.DEFAULT_PAGE_TURN_PERCENT
 import com.github.zly2006.zhihu.ui.subscreens.PREF_FONT_SIZE
 import com.github.zly2006.zhihu.ui.subscreens.PREF_LINE_HEIGHT
+import com.github.zly2006.zhihu.ui.subscreens.PREF_PAGE_TURN_PERCENT
+import com.github.zly2006.zhihu.ui.subscreens.PREF_SHOW_PAGE_TURN_GUIDE
 import com.github.zly2006.zhihu.viewmodel.comment.BaseCommentViewModel
 import com.github.zly2006.zhihu.viewmodel.comment.ChildCommentViewModel
 import com.github.zly2006.zhihu.viewmodel.comment.CommentSortOrder
@@ -417,6 +423,7 @@ fun CommentScreen(
     onChildCommentClick: (CommentModel) -> Unit,
     listState: LazyListState = rememberLazyListState(),
     testOverrides: CommentScreenTestOverrides? = null,
+    skipPageTurn: Boolean = false,
 ) {
     val paginationEnvironment = rememberPaginationEnvironment(allowGuestAccess = false)
     var commentInput by remember { mutableStateOf("") }
@@ -473,6 +480,15 @@ fun CommentScreen(
         }
     }
     val coroutineScope = rememberCoroutineScope()
+    val pageKeySettings = rememberSettingsStore()
+    val pageTurnPercent = remember { pageKeySettings.getInt(PREF_PAGE_TURN_PERCENT, DEFAULT_PAGE_TURN_PERCENT) }
+    val showPageTurnGuide = remember { pageKeySettings.getBoolean(PREF_SHOW_PAGE_TURN_GUIDE, false) }
+    val guideState = remember { PageTurnGuideState() }
+    PageTurnLazyListEffect(listState, pageTurnPercent, guideState, skip = skipPageTurn)
+
+    if (showPageTurnGuide && guideState.lastDirection != 0 && listState.isScrollInProgress && !guideState.isScrolling) {
+        guideState.lastDirection = 0
+    }
 
     // 提交评论函数
     fun submitComment() {
@@ -791,8 +807,34 @@ fun CommentScreen(
                                         }
                                     }
                                 }
+
+                                if (viewModel.isEnd && viewModel.allData.isNotEmpty()) {
+                                    item(key = "end_indicator") {
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(vertical = 12.dp),
+                                            contentAlignment = Alignment.Center,
+                                        ) {
+                                            Text(
+                                                "— · —",
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                                fontSize = 14.sp,
+                                            )
+                                        }
+                                    }
+                                }
                             }
                         }
+                    }
+
+                    if (showPageTurnGuide) {
+                        PageTurnGuideOverlay(
+                            pageTurnPercent,
+                            topInsetPx = listState.layoutInfo.beforeContentPadding.toFloat(),
+                            bottomInsetPx = listState.layoutInfo.afterContentPadding.toFloat(),
+                            lastDirection = guideState.lastDirection,
+                        )
                     }
                 }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/DailyScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/DailyScreen.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -82,11 +83,18 @@ import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.navigation.resolveContent
 import com.github.zly2006.zhihu.shared.data.DailySection
 import com.github.zly2006.zhihu.shared.data.DailyStory
+import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.ui.TopLevelReselectAction
 import com.github.zly2006.zhihu.shared.ui.topLevelReselectAction
 import com.github.zly2006.zhihu.shared.util.formatDailyDate
 import com.github.zly2006.zhihu.shared.util.twoDigitString
 import com.github.zly2006.zhihu.shared.viewmodel.DailyViewModel
+import com.github.zly2006.zhihu.ui.components.PageTurnGuideOverlay
+import com.github.zly2006.zhihu.ui.components.PageTurnGuideState
+import com.github.zly2006.zhihu.ui.components.PageTurnLazyListEffect
+import com.github.zly2006.zhihu.ui.subscreens.DEFAULT_PAGE_TURN_PERCENT
+import com.github.zly2006.zhihu.ui.subscreens.PREF_PAGE_TURN_PERCENT
+import com.github.zly2006.zhihu.ui.subscreens.PREF_SHOW_PAGE_TURN_GUIDE
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -112,6 +120,7 @@ import kotlin.time.Instant
 fun DailyScreen(
     scrollToTopTrigger: Int = 0,
     isActive: Boolean = true,
+    outerBottomPadding: Dp = 0.dp,
 ) {
     val navigator = LocalNavigator.current
     val httpClient = rememberZhihuHttpClient()
@@ -123,6 +132,16 @@ fun DailyScreen(
     var pendingDateSelection by remember { mutableStateOf<String?>(null) }
     val scope = rememberCoroutineScope()
     val listState = rememberLazyListState()
+    val dailySettings = rememberSettingsStore()
+    val showPageTurnGuide = remember { dailySettings.getBoolean(PREF_SHOW_PAGE_TURN_GUIDE, false) }
+    val pageTurnPercent = remember { dailySettings.getInt(PREF_PAGE_TURN_PERCENT, DEFAULT_PAGE_TURN_PERCENT) }
+    val guideState = remember { PageTurnGuideState() }
+    PageTurnLazyListEffect(listState, pageTurnPercent, guideState)
+
+    if (showPageTurnGuide && guideState.lastDirection != 0 && listState.isScrollInProgress && !guideState.isScrolling) {
+        guideState.lastDirection = 0
+    }
+
     var cachedScrollToTopTrigger by remember { mutableIntStateOf(scrollToTopTrigger) }
     LaunchedEffect(listState, viewModel.sections) {
         currentViewingDate = resolveViewingDate(
@@ -318,7 +337,10 @@ fun DailyScreen(
                         modifier = Modifier
                             .fillMaxSize()
                             .testTag(DAILY_SCREEN_LIST_TAG),
-                        contentPadding = PaddingValues(vertical = 8.dp),
+                        contentPadding = PaddingValues(
+                            top = 8.dp,
+                            bottom = 8.dp + outerBottomPadding,
+                        ),
                     ) {
                         viewModel.sections.forEach { section ->
                             // 日期分组标题。
@@ -364,6 +386,15 @@ fun DailyScreen(
                         }
                     }
                 }
+            }
+
+            if (showPageTurnGuide) {
+                PageTurnGuideOverlay(
+                    pageTurnPercent,
+                    topInsetPx = listState.layoutInfo.beforeContentPadding.toFloat(),
+                    bottomInsetPx = listState.layoutInfo.afterContentPadding.toFloat(),
+                    lastDirection = guideState.lastDirection,
+                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -120,6 +121,7 @@ import com.github.zly2006.zhihu.ui.components.FeedPullToRefresh
 import com.github.zly2006.zhihu.ui.components.MyModalBottomSheet
 import com.github.zly2006.zhihu.ui.components.PaginatedList
 import com.github.zly2006.zhihu.ui.components.ProgressIndicatorFooter
+import com.github.zly2006.zhihu.ui.components.fabOpacityPercent
 import com.github.zly2006.zhihu.ui.components.rememberFeedBlockActions
 import com.github.zly2006.zhihu.viewmodel.feed.BaseFeedViewModel
 import com.github.zly2006.zhihu.viewmodel.feed.HomeFeedInteractionViewModel
@@ -779,10 +781,18 @@ fun HomeScreen(
                     Spacer(modifier = Modifier.height(12.dp))
                 }
             }
+            val createFabOpacity = fabOpacityPercent.intValue / 100f
             FloatingActionButton(
                 modifier = Modifier.testTag(HOME_CREATE_FAB_TAG),
                 onClick = { showCreateMenu = !showCreateMenu },
                 shape = CircleShape,
+                containerColor = FloatingActionButtonDefaults.containerColor.copy(alpha = createFabOpacity),
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = createFabOpacity),
+                elevation = if (createFabOpacity < 1f) {
+                    FloatingActionButtonDefaults.elevation(0.dp, 0.dp, 0.dp, 0.dp)
+                } else {
+                    FloatingActionButtonDefaults.elevation()
+                },
             ) {
                 Icon(Icons.Default.Add, contentDescription = "创作")
             }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/OnlineHistoryScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/OnlineHistoryScreen.kt
@@ -17,6 +17,7 @@
 
 package com.github.zly2006.zhihu.ui
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -42,6 +43,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.zly2006.zhihu.navigation.History
 import com.github.zly2006.zhihu.navigation.LocalNavigator
@@ -69,6 +72,7 @@ const val ONLINE_HISTORY_OVERFLOW_TAG = "online_history_overflow"
 fun OnlineHistoryScreen(
     scrollToTopTrigger: Int = 0,
     isActive: Boolean = true,
+    outerBottomPadding: Dp = 0.dp,
 ) {
     val navigator = LocalNavigator.current
     val viewModel: OnlineHistoryViewModel = viewModel { OnlineHistoryViewModel() }
@@ -179,6 +183,7 @@ fun OnlineHistoryScreen(
                     .testTag("online_history_list"),
                 items = viewModel.displayItems,
                 listState = listState,
+                contentPadding = PaddingValues(bottom = outerBottomPadding),
                 onLoadMore = { viewModel.loadMore(paginationEnvironment) },
                 isEnd = { viewModel.isEnd },
             ) { item ->

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -112,6 +112,7 @@ import com.github.zly2006.zhihu.navigation.TopLevelDestination
 import com.github.zly2006.zhihu.navigation.WriteAnswer
 import com.github.zly2006.zhihu.navigation.WritePin
 import com.github.zly2006.zhihu.shared.filter.ContentOpenFrom
+import com.github.zly2006.zhihu.ui.components.LocalPageTurnChannel
 import com.github.zly2006.zhihu.ui.subscreens.AppearanceSettingsScreen
 import com.github.zly2006.zhihu.ui.subscreens.BlockedFeedHistoryScreen
 import com.github.zly2006.zhihu.ui.subscreens.ColorSchemeScreen
@@ -206,7 +207,7 @@ fun ZhihuMain(
     }
 
     var scrollToTopTrigger by remember { mutableIntStateOf(0) }
-    // 滚动时自动隐藏底部导航栏
+    // 滚动时自动隐藏底部导航栏（触屏滑动 + 翻页键/FAB）
     var isBottomBarVisible by remember { mutableStateOf(true) }
     val bottomBarScrollConnection = remember {
         object : NestedScrollConnection {
@@ -216,6 +217,16 @@ fun ZhihuMain(
                     available.y > 3f -> isBottomBarVisible = true
                 }
                 return Offset.Zero
+            }
+        }
+    }
+    // 程序化 scrollBy 不经过 NestedScrollConnection，需要单独监听翻页事件
+    val pageTurnChannel = LocalPageTurnChannel.current
+    LaunchedEffect(pageTurnChannel) {
+        pageTurnChannel.collect { direction ->
+            when {
+                direction > 0 || direction == Int.MAX_VALUE -> isBottomBarVisible = false
+                direction < 0 || direction == Int.MIN_VALUE -> isBottomBarVisible = true
             }
         }
     }
@@ -598,10 +609,12 @@ private fun MainTabsPager(
             MainTabPage.DailyPage -> DailyScreen(
                 scrollToTopTrigger = scrollToTopTrigger,
                 isActive = pagerState.currentPage == pageIndex,
+                outerBottomPadding = innerPadding.calculateBottomPadding(),
             )
             MainTabPage.OnlineHistoryPage -> OnlineHistoryScreen(
                 scrollToTopTrigger = scrollToTopTrigger,
                 isActive = pagerState.currentPage == pageIndex,
+                outerBottomPadding = innerPadding.calculateBottomPadding(),
             )
             MainTabPage.MyCollectionsPage -> MyCollectionsTopLevelPage()
             MainTabPage.AccountPage -> AccountSettingScreen(innerPadding)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CommentScreenComponent.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CommentScreenComponent.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -92,6 +93,13 @@ fun CommentScreenComponent(
         onDismiss()
     }
 
+    val childSheetVisible = showComments && activeChildComment != null && childTarget != null
+
+    DisposableEffect(showComments) {
+        if (showComments) pageTurnModalDepth.intValue++
+        onDispose { if (showComments) pageTurnModalDepth.intValue-- }
+    }
+
     if (showComments) {
         MyModalBottomSheet(
             onDismissRequest = { dismissRootComments() },
@@ -102,17 +110,22 @@ fun CommentScreenComponent(
                 shouldDismissOnClickOutside = true,
             ),
             dragHandle = { DragHandleTitle("评论") },
-            usePlatformWindow = content !is Article,
+            usePlatformWindow = false,
         ) {
             CommentScreen(
                 content = { content },
                 onChildCommentClick = { activeChildComment = it },
                 listState = rootListState,
+                skipPageTurn = childSheetVisible,
             )
         }
     }
+    DisposableEffect(childSheetVisible) {
+        if (childSheetVisible) pageTurnModalDepth.intValue++
+        onDispose { if (childSheetVisible) pageTurnModalDepth.intValue-- }
+    }
 
-    if (showComments && activeChildComment != null && childTarget != null) {
+    if (childSheetVisible) {
         MyModalBottomSheet(
             onDismissRequest = { activeChildComment = null },
             sheetState = childSheetState,
@@ -122,7 +135,7 @@ fun CommentScreenComponent(
                 shouldDismissOnClickOutside = true,
             ),
             dragHandle = { DragHandleTitle("回复") },
-            usePlatformWindow = childTarget.article !is Article,
+            usePlatformWindow = false,
         ) {
             CommentScreen(
                 content = { childTarget },

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/DraggablePageTurnButtons.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/DraggablePageTurnButtons.kt
@@ -64,7 +64,9 @@ import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
+import com.github.zly2006.zhihu.ui.subscreens.DEFAULT_FAB_OPACITY
 import com.github.zly2006.zhihu.ui.subscreens.DEFAULT_PAGE_TURN_PERCENT
+import com.github.zly2006.zhihu.ui.subscreens.PREF_FAB_OPACITY
 import com.github.zly2006.zhihu.ui.subscreens.PREF_PAGE_TURN_PERCENT
 import com.github.zly2006.zhihu.ui.subscreens.PREF_SHOW_PAGE_TURN_FAB
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -85,6 +87,9 @@ val pageTurnModalDepth = androidx.compose.runtime.mutableIntStateOf(0)
 
 /** 翻页悬浮按钮的全局可见性，由设置页开关直接写入，PageTurnFab 读取。 */
 val pageTurnFabVisible = androidx.compose.runtime.mutableStateOf(false)
+
+/** 所有悬浮按钮的透明度百分比（10–100），由设置页写入，各 FAB 读取。 */
+val fabOpacityPercent = androidx.compose.runtime.mutableIntStateOf(100)
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -119,6 +124,9 @@ fun DraggablePageTurnButtons(
 
     val hapticFeedback = LocalHapticFeedback.current
 
+    val opacityFraction = fabOpacityPercent.intValue / 100f
+    val fabColor = FloatingActionButtonDefaults.containerColor.copy(alpha = opacityFraction)
+    val iconTint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = opacityFraction)
     Column(
         modifier = modifier
             .offset { IntOffset(offsetX.roundToInt(), offsetY.roundToInt()) }
@@ -156,7 +164,7 @@ fun DraggablePageTurnButtons(
     ) {
         Surface(
             shape = CircleShape,
-            color = FloatingActionButtonDefaults.containerColor,
+            color = fabColor,
             modifier = Modifier
                 .size(buttonSize)
                 .combinedClickable(
@@ -167,13 +175,13 @@ fun DraggablePageTurnButtons(
                 ),
         ) {
             Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-                Icon(Icons.Default.KeyboardArrowUp, contentDescription = "上翻页")
+                Icon(Icons.Default.KeyboardArrowUp, contentDescription = "上翻页", tint = iconTint)
             }
         }
         Spacer(modifier = Modifier.height(4.dp))
         Surface(
             shape = CircleShape,
-            color = FloatingActionButtonDefaults.containerColor,
+            color = fabColor,
             modifier = Modifier
                 .size(buttonSize)
                 .combinedClickable(
@@ -184,7 +192,7 @@ fun DraggablePageTurnButtons(
                 ),
         ) {
             Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-                Icon(Icons.Default.KeyboardArrowDown, contentDescription = "下翻页")
+                Icon(Icons.Default.KeyboardArrowDown, contentDescription = "下翻页", tint = iconTint)
             }
         }
     }
@@ -202,6 +210,7 @@ fun PageTurnFab(
     val settings = rememberSettingsStore()
     LaunchedEffect(Unit) {
         pageTurnFabVisible.value = settings.getBoolean(PREF_SHOW_PAGE_TURN_FAB, false)
+        fabOpacityPercent.intValue = settings.getInt(PREF_FAB_OPACITY, DEFAULT_FAB_OPACITY).coerceIn(10, 100)
     }
     if (!pageTurnFabVisible.value) return
     val channel = LocalPageTurnChannel.current

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/DraggablePageTurnButtons.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/DraggablePageTurnButtons.kt
@@ -1,0 +1,374 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.TopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
+import com.github.zly2006.zhihu.ui.subscreens.DEFAULT_PAGE_TURN_PERCENT
+import com.github.zly2006.zhihu.ui.subscreens.PREF_PAGE_TURN_PERCENT
+import com.github.zly2006.zhihu.ui.subscreens.PREF_SHOW_PAGE_TURN_FAB
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlin.math.roundToInt
+
+/**
+ * Activity 层翻页事件流。+1 下翻，-1 上翻，[Int.MAX_VALUE] 跳底，[Int.MIN_VALUE] 跳顶。
+ * Activity 拦截按键后 tryEmit，悬浮翻页按钮也直接 tryEmit，各屏幕 collect 执行滚动。
+ */
+val LocalPageTurnChannel: androidx.compose.runtime.ProvidableCompositionLocal<MutableSharedFlow<Int>> =
+    staticCompositionLocalOf { MutableSharedFlow(extraBufferCapacity = 1) }
+
+/**
+ * 当前是否有模态弹层（如评论底部弹层）正在接管翻页事件。
+ * 底层页面的翻页收集器应在此值 > 0 时跳过处理，避免穿透滚动。
+ */
+val pageTurnModalDepth = androidx.compose.runtime.mutableIntStateOf(0)
+
+/** 翻页悬浮按钮的全局可见性，由设置页开关直接写入，PageTurnFab 读取。 */
+val pageTurnFabVisible = androidx.compose.runtime.mutableStateOf(false)
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun DraggablePageTurnButtons(
+    onPageUp: () -> Unit,
+    onPageDown: () -> Unit,
+    onLongPressUp: () -> Unit = {},
+    onLongPressDown: () -> Unit = {},
+    modifier: Modifier = Modifier,
+    preferenceName: String = "fabPageTurn",
+) {
+    val density = LocalDensity.current
+    val screenSize = LocalWindowInfo.current.containerSize
+    val settings = rememberSettingsStore()
+
+    var pressing by remember { mutableStateOf(false) }
+
+    val buttonSize = 40.dp
+    val columnHeight = buttonSize * 2 + 4.dp
+    val defaultY = with(density) { screenSize.height - columnHeight.toPx() - 80.dp.toPx() }
+    var offsetX by remember { mutableFloatStateOf(settings.getFloat("$preferenceName-x", 0f)) }
+    var offsetY by remember { mutableFloatStateOf(settings.getFloat("$preferenceName-y", defaultY)) }
+
+    fun adjustPosition() {
+        with(density) {
+            offsetX = offsetX.coerceIn(0f, screenSize.width - buttonSize.toPx())
+            offsetY = offsetY.coerceIn(0f, screenSize.height - columnHeight.toPx())
+        }
+    }
+
+    adjustPosition()
+
+    val hapticFeedback = LocalHapticFeedback.current
+
+    Column(
+        modifier = modifier
+            .offset { IntOffset(offsetX.roundToInt(), offsetY.roundToInt()) }
+            .pointerInput(Unit) {
+                detectDragGestures(
+                    onDragStart = {
+                        pressing = true
+                        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                    },
+                    onDragEnd = {
+                        pressing = false
+                        adjustPosition()
+                        val screenWidth = screenSize.width.toFloat()
+                        with(density) {
+                            offsetX =
+                                if (offsetX < screenWidth / 2) {
+                                    0f
+                                } else {
+                                    screenWidth - buttonSize.toPx()
+                                }
+                        }
+                        settings.putFloat("$preferenceName-x", offsetX)
+                        settings.putFloat("$preferenceName-y", offsetY)
+                    },
+                    onDrag = { change, dragAmount ->
+                        change.consume()
+                        if (pressing) {
+                            offsetX += dragAmount.x
+                            offsetY += dragAmount.y
+                            adjustPosition()
+                        }
+                    },
+                )
+            },
+    ) {
+        Surface(
+            shape = CircleShape,
+            color = FloatingActionButtonDefaults.containerColor,
+            modifier = Modifier
+                .size(buttonSize)
+                .combinedClickable(
+                    onClick = onPageUp,
+                    onLongClick = onLongPressUp,
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                ),
+        ) {
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                Icon(Icons.Default.KeyboardArrowUp, contentDescription = "上翻页")
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Surface(
+            shape = CircleShape,
+            color = FloatingActionButtonDefaults.containerColor,
+            modifier = Modifier
+                .size(buttonSize)
+                .combinedClickable(
+                    onClick = onPageDown,
+                    onLongClick = onLongPressDown,
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                ),
+        ) {
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                Icon(Icons.Default.KeyboardArrowDown, contentDescription = "下翻页")
+            }
+        }
+    }
+}
+
+/**
+ * 读取设置后有条件地渲染翻页 FAB，点击时通过 [LocalPageTurnChannel] 发送方向。
+ * 应放在不随列表滚动移动的层级（通常是 Scaffold 内容区最外层 Box）。
+ */
+@Composable
+fun PageTurnFab(
+    modifier: Modifier = Modifier,
+    preferenceName: String = "fabPageTurn",
+) {
+    val settings = rememberSettingsStore()
+    LaunchedEffect(Unit) {
+        pageTurnFabVisible.value = settings.getBoolean(PREF_SHOW_PAGE_TURN_FAB, false)
+    }
+    if (!pageTurnFabVisible.value) return
+    val channel = LocalPageTurnChannel.current
+    DraggablePageTurnButtons(
+        onPageUp = { channel.tryEmit(-1) },
+        onPageDown = { channel.tryEmit(1) },
+        onLongPressUp = { channel.tryEmit(Int.MIN_VALUE) },
+        onLongPressDown = { channel.tryEmit(Int.MAX_VALUE) },
+        modifier = modifier,
+        preferenceName = preferenceName,
+    )
+}
+
+/**
+ * 为使用 [ScrollState] 的页面接入翻页事件。
+ * 在 composable 中调用一次即可，会自动收集 [LocalPageTurnChannel] 并滚动。
+ * [viewportHeight] 为可见区域高度（像素），可通过 Modifier.onSizeChanged 获取。
+ * [topBarState] 可选，传入可收起标题栏的 TopAppBarState：
+ * 下翻/跳底时自动收起，跳顶或上翻到达顶部时展开，普通上翻不展开。
+ * 翻页距离会扣除标题栏收起产生的高度变化量，避免重复滚动。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PageTurnScrollEffect(
+    scrollState: ScrollState,
+    viewportHeight: Int,
+    topBarState: TopAppBarState? = null,
+) {
+    val settings = rememberSettingsStore()
+    val pageTurnPercent = remember { settings.getInt(PREF_PAGE_TURN_PERCENT, DEFAULT_PAGE_TURN_PERCENT) }
+    val channel = LocalPageTurnChannel.current
+    val currentViewportHeight by rememberUpdatedState(viewportHeight)
+    LaunchedEffect(channel) {
+        channel.collect { direction ->
+            if (pageTurnModalDepth.intValue > 0) return@collect
+            var barCollapseDelta = 0f
+            if (topBarState != null) {
+                val oldOffset = topBarState.heightOffset
+                if (direction > 0 || direction == Int.MAX_VALUE) {
+                    topBarState.heightOffset = topBarState.heightOffsetLimit
+                } else if (direction == Int.MIN_VALUE) {
+                    topBarState.heightOffset = 0f
+                }
+                barCollapseDelta = topBarState.heightOffset - oldOffset
+            }
+            when (direction) {
+                Int.MAX_VALUE -> scrollState.scrollTo(scrollState.maxValue)
+                Int.MIN_VALUE -> scrollState.scrollTo(0)
+                else -> if (currentViewportHeight > 0) {
+                    val afterCollapseViewport = currentViewportHeight - barCollapseDelta
+                    val scrollAmount = afterCollapseViewport * pageTurnPercent / 100f * direction + barCollapseDelta
+                    scrollState.scrollBy(scrollAmount)
+                    if (topBarState != null && direction < 0 && scrollState.value == 0) {
+                        topBarState.heightOffset = 0f
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * 为使用 [LazyListState] 的页面接入翻页事件。
+ * viewport 从 [listState].layoutInfo 自动计算，无需外部传入。
+ * [topBarState] 可选，传入可收起标题栏的 TopAppBarState：
+ * 下翻/跳底时自动收起，跳顶或上翻到达顶部时展开。
+ * 返回 [PageTurnGuideState] 供翻页引导线使用。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PageTurnLazyListEffect(
+    listState: LazyListState,
+    pageTurnPercent: Int,
+    guideState: PageTurnGuideState = remember { PageTurnGuideState() },
+    skip: Boolean = pageTurnModalDepth.intValue > 0,
+    topBarState: TopAppBarState? = null,
+) {
+    val channel = LocalPageTurnChannel.current
+    val currentSkip by rememberUpdatedState(skip)
+    LaunchedEffect(channel) {
+        channel.collect { direction ->
+            if (currentSkip) return@collect
+            guideState.lastDirection = direction.coerceIn(-1, 1)
+            guideState.isScrolling = true
+            try {
+                if (topBarState != null) {
+                    if (direction > 0 || direction == Int.MAX_VALUE) {
+                        topBarState.heightOffset = topBarState.heightOffsetLimit
+                    } else if (direction == Int.MIN_VALUE) {
+                        topBarState.heightOffset = 0f
+                    }
+                }
+                when (direction) {
+                    Int.MAX_VALUE -> listState.scrollToItem(listState.layoutInfo.totalItemsCount - 1)
+                    Int.MIN_VALUE -> listState.scrollToItem(0)
+                    else -> {
+                        val layout = listState.layoutInfo
+                        val viewport = layout.viewportEndOffset - layout.viewportStartOffset -
+                            layout.beforeContentPadding - layout.afterContentPadding
+                        if (viewport > 0) {
+                            listState.scrollBy(viewport * pageTurnPercent / 100f * direction)
+                        }
+                    }
+                }
+                if (topBarState != null &&
+                    direction < 0 &&
+                    listState.firstVisibleItemIndex == 0 &&
+                    listState.firstVisibleItemScrollOffset == 0
+                ) {
+                    topBarState.heightOffset = 0f
+                }
+            } finally {
+                guideState.isScrolling = false
+            }
+        }
+    }
+}
+
+class PageTurnGuideState {
+    var lastDirection by mutableIntStateOf(0)
+    var isScrolling by mutableStateOf(false)
+}
+
+/**
+ * 在可见区域绘制水平虚线标记翻页边界。
+ * [lastDirection] 控制只显示与最近翻页方向相关的那条线：
+ * 下翻(1)后只显示上线（标记重叠区起点），上翻(-1)后只显示下线；
+ * 0 表示尚未翻页，不绘制任何线。
+ */
+@Composable
+fun PageTurnGuideOverlay(
+    pageTurnPercent: Int,
+    modifier: Modifier = Modifier,
+    topInsetPx: Float = 0f,
+    bottomInsetPx: Float = 0f,
+    lastDirection: Int = 0,
+) {
+    if (lastDirection == 0) return
+    val guideColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f)
+    val density = LocalDensity.current
+    Canvas(modifier = modifier.fillMaxSize()) {
+        val effectiveHeight = size.height - topInsetPx - bottomInsetPx
+        if (effectiveHeight <= 0f) return@Canvas
+        val overlapFraction = 1f - pageTurnPercent / 100f
+        val dash = PathEffect.dashPathEffect(floatArrayOf(10f, 8f), 0f)
+        val arrowSize = with(density) { 10.dp.toPx() }
+
+        fun drawGuideLineWithArrows(y: Float) {
+            drawLine(
+                color = guideColor,
+                start = Offset(0f, y),
+                end = Offset(size.width, y),
+                strokeWidth = 2f,
+                pathEffect = dash,
+            )
+            // 左端向内箭头 (>)
+            drawLine(guideColor, Offset(0f, y - arrowSize), Offset(arrowSize, y), strokeWidth = 2f)
+            drawLine(guideColor, Offset(0f, y + arrowSize), Offset(arrowSize, y), strokeWidth = 2f)
+            // 右端向内箭头 (<)
+            drawLine(guideColor, Offset(size.width, y - arrowSize), Offset(size.width - arrowSize, y), strokeWidth = 2f)
+            drawLine(guideColor, Offset(size.width, y + arrowSize), Offset(size.width - arrowSize, y), strokeWidth = 2f)
+        }
+        if (lastDirection > 0) {
+            drawGuideLineWithArrows(topInsetPx + overlapFraction * effectiveHeight)
+        }
+        if (lastDirection < 0) {
+            drawGuideLineWithArrows(topInsetPx + (pageTurnPercent / 100f) * effectiveHeight)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/DraggablePageTurnButtons.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/DraggablePageTurnButtons.kt
@@ -304,8 +304,17 @@ fun PageTurnLazyListEffect(
                     }
                 }
                 when (direction) {
-                    Int.MAX_VALUE -> listState.scrollToItem(listState.layoutInfo.totalItemsCount - 1)
-                    Int.MIN_VALUE -> listState.scrollToItem(0)
+                    Int.MAX_VALUE -> {
+                        val lastIndex = listState.layoutInfo.totalItemsCount - 1
+                        if (lastIndex >= 0) {
+                            listState.scrollToItem(lastIndex)
+                        }
+                    }
+                    Int.MIN_VALUE -> {
+                        if (listState.layoutInfo.totalItemsCount > 0) {
+                            listState.scrollToItem(0)
+                        }
+                    }
                     else -> {
                         val layout = listState.layoutInfo
                         val viewport = layout.viewportEndOffset - layout.viewportStartOffset -

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/DraggableRefreshButton.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/DraggableRefreshButton.kt
@@ -25,7 +25,9 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -87,9 +89,17 @@ fun DraggableRefreshButton(
     )
     val hapticFeedback = LocalHapticFeedback.current
 
+    val opacityFraction = fabOpacityPercent.intValue / 100f
     FloatingActionButton(
         onClick = onClick,
         shape = CircleShape,
+        containerColor = FloatingActionButtonDefaults.containerColor.copy(alpha = opacityFraction),
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = opacityFraction),
+        elevation = if (opacityFraction < 1f) {
+            FloatingActionButtonDefaults.elevation(0.dp, 0.dp, 0.dp, 0.dp)
+        } else {
+            FloatingActionButtonDefaults.elevation()
+        },
         modifier = modifier
             .offset { IntOffset(animatedOffsetX.roundToInt(), animatedOffsetY.roundToInt()) }
             .pointerInput(Unit) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
@@ -85,6 +85,8 @@ import com.github.zly2006.zhihu.shared.platform.UserMessageDuration
 import com.github.zly2006.zhihu.shared.platform.rememberIsLiteVariant
 import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
+import com.github.zly2006.zhihu.ui.subscreens.PREF_FONT_SIZE
+import com.github.zly2006.zhihu.ui.subscreens.PREF_LINE_HEIGHT
 import com.github.zly2006.zhihu.util.parseHtmlTextWithTheme
 import kotlinx.coroutines.launch
 import kotlin.math.abs
@@ -482,6 +484,9 @@ private fun FeedCardContent(
     duo3CardLargeTitle: Boolean,
     showSourceLabel: Boolean,
 ) {
+    val settings = rememberSettingsStore()
+    val fontSizePercent = remember { settings.getInt(PREF_FONT_SIZE, 100) }
+    val lineHeightPercent = remember { settings.getInt(PREF_LINE_HEIGHT, 160) }
     val navigator = LocalNavigator.current
     if (duo3CardLayout) {
         // ── 新排版（duo3）────────────────────────────────────────────────────
@@ -509,7 +514,10 @@ private fun FeedCardContent(
             Row {
                 Text(
                     text = parseHtmlTextWithTheme(item.summary ?: ""),
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontSize = 14.sp * fontSizePercent / 100,
+                        lineHeight = 14.sp * fontSizePercent / 100 * lineHeightPercent / 100,
+                    ),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 4,
                     overflow = TextOverflow.Ellipsis,
@@ -633,7 +641,8 @@ private fun FeedCardContent(
             Column(modifier = Modifier.weight(2f)) {
                 Text(
                     text = parseHtmlTextWithTheme(item.summary ?: ""),
-                    fontSize = 14.sp,
+                    fontSize = 14.sp * fontSizePercent / 100,
+                    lineHeight = 14.sp * fontSizePercent / 100 * lineHeightPercent / 100,
                     maxLines = 3,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.padding(top = if (item.isFiltered) 0.dp else 3.dp),

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/PaginatedList.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/PaginatedList.kt
@@ -21,6 +21,7 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -41,6 +42,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
+import com.github.zly2006.zhihu.ui.subscreens.DEFAULT_PAGE_TURN_PERCENT
+import com.github.zly2006.zhihu.ui.subscreens.PREF_PAGE_TURN_PERCENT
+import com.github.zly2006.zhihu.ui.subscreens.PREF_SHOW_PAGE_TURN_GUIDE
 import kotlinx.coroutines.delay
 
 val ProgressIndicatorFooter: @Composable (LazyListState) -> Unit = { state ->
@@ -123,6 +128,16 @@ fun <T> PaginatedList(
     topContent: LazyListScope.() -> Unit = {},
     itemContent: @Composable LazyItemScope.(T) -> Unit,
 ) {
+    val settings = rememberSettingsStore()
+    val pageTurnPercent = remember { settings.getInt(PREF_PAGE_TURN_PERCENT, DEFAULT_PAGE_TURN_PERCENT) }
+    val showPageTurnGuide = remember { settings.getBoolean(PREF_SHOW_PAGE_TURN_GUIDE, false) }
+    val guideState = remember { PageTurnGuideState() }
+    PageTurnLazyListEffect(listState, pageTurnPercent, guideState)
+
+    if (showPageTurnGuide && guideState.lastDirection != 0 && listState.isScrollInProgress && !guideState.isScrolling) {
+        guideState.lastDirection = 0
+    }
+
     val shouldLoadMore by remember {
         derivedStateOf {
             val layoutInfo = listState.layoutInfo
@@ -144,40 +159,51 @@ fun <T> PaginatedList(
         }
     }
 
-    LazyColumn(
-        state = listState,
-        modifier = modifier,
-        contentPadding = contentPadding,
-    ) {
-        topContent(this)
+    Box(modifier = modifier) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = contentPadding,
+        ) {
+            topContent(this)
 
-        if (key != null) {
-            val itemKeys = uniquePaginatedListKeys(items, key)
-            itemsIndexed(items, key = { index, _ -> itemKeys[index] }) { _, item ->
-                PaginatedListItem(item, itemContent)
+            if (key != null) {
+                val itemKeys = uniquePaginatedListKeys(items, key)
+                itemsIndexed(items, key = { index, _ -> itemKeys[index] }) { _, item ->
+                    PaginatedListItem(item, itemContent)
+                }
+            } else {
+                items(items) { item ->
+                    PaginatedListItem(item, itemContent)
+                }
             }
-        } else {
-            items(items) { item ->
-                PaginatedListItem(item, itemContent)
+
+            item {
+                if (isEnd()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = "已经到底啦",
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                } else {
+                    footer?.invoke(listState)
+                }
             }
         }
 
-        item {
-            if (isEnd()) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = "已经到底啦",
-                        textAlign = TextAlign.Center,
-                    )
-                }
-            } else {
-                footer?.invoke(listState)
-            }
+        if (showPageTurnGuide) {
+            PageTurnGuideOverlay(
+                pageTurnPercent,
+                topInsetPx = listState.layoutInfo.beforeContentPadding.toFloat(),
+                bottomInsetPx = listState.layoutInfo.afterContentPadding.toFloat(),
+                lastDirection = guideState.lastDirection,
+            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/PaginatedList.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/PaginatedList.kt
@@ -21,7 +21,6 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -159,10 +158,10 @@ fun <T> PaginatedList(
         }
     }
 
-    Box(modifier = modifier) {
+    Box {
         LazyColumn(
             state = listState,
-            modifier = Modifier.fillMaxSize(),
+            modifier = modifier,
             contentPadding = contentPadding,
         ) {
             topContent(this)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
@@ -76,6 +76,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
@@ -105,11 +107,13 @@ import com.github.zly2006.zhihu.ui.components.ColorPickerDialog
 import com.github.zly2006.zhihu.ui.components.DEFAULT_ANSWER_SWITCH_SENSITIVITY
 import com.github.zly2006.zhihu.ui.components.MAX_ANSWER_SWITCH_SENSITIVITY
 import com.github.zly2006.zhihu.ui.components.MIN_ANSWER_SWITCH_SENSITIVITY
+import com.github.zly2006.zhihu.ui.components.PageTurnScrollEffect
 import com.github.zly2006.zhihu.ui.components.SettingItem
 import com.github.zly2006.zhihu.ui.components.SettingItemGroup
 import com.github.zly2006.zhihu.ui.components.SettingItemOverall
 import com.github.zly2006.zhihu.ui.components.SettingItemWithSwitch
 import com.github.zly2006.zhihu.ui.components.normalizedAnswerSwitchSensitivity
+import com.github.zly2006.zhihu.ui.components.pageTurnFabVisible
 import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
 import kotlin.time.Duration.Companion.milliseconds
@@ -118,6 +122,11 @@ const val DUO3_CARD_LARGE_TITLE_PREFERENCE_KEY = "duo3_card_large_title"
 const val PREF_FONT_SIZE = "contentFontSize"
 const val PREF_LINE_HEIGHT = "contentLineHeight"
 const val PREF_BLOCK_SPACING = "contentBlockSpacing"
+const val PREF_PAGE_TURN_PERCENT = "pageTurnPercent"
+const val DEFAULT_PAGE_TURN_PERCENT = 90
+const val PREF_VOLUME_KEY_PAGE_TURN = "volumeKeyPageTurn"
+const val PREF_SHOW_PAGE_TURN_FAB = "showPageTurnFab"
+const val PREF_SHOW_PAGE_TURN_GUIDE = "showPageTurnGuide"
 const val APPEARANCE_SETTINGS_SCROLL_TAG = "appearanceSettings.scroll"
 const val APPEARANCE_SETTINGS_START_DESTINATION_TAG = "appearanceSettings.startDestination"
 const val APPEARANCE_SETTINGS_ANSWER_DOUBLE_TAP_TAG = "appearanceSettings.answerDoubleTap"
@@ -345,9 +354,16 @@ fun AppearanceSettingsScreen(
             )
         },
     ) { innerPadding ->
+        val density = LocalDensity.current
+        var rawViewportHeight by remember { mutableIntStateOf(0) }
+        val topPx = with(density) { innerPadding.calculateTopPadding().toPx().toInt() }
+        val bottomPx = with(density) { innerPadding.calculateBottomPadding().toPx().toInt() }
+        val viewportHeight = (rawViewportHeight - topPx - bottomPx).coerceAtLeast(0)
+        PageTurnScrollEffect(scrollState, viewportHeight, scrollBehavior.state)
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .onSizeChanged { rawViewportHeight = it.height }
                 .verticalScroll(scrollState)
                 .testTag(APPEARANCE_SETTINGS_SCROLL_TAG)
                 .padding(innerPadding)
@@ -590,6 +606,68 @@ fun AppearanceSettingsScreen(
                             steps = 29,
                             modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
                         )
+                    },
+                )
+            }
+
+            // ── 翻页 ───────────────────────────────────────────────────────────
+            SettingItemGroup(
+                title = "翻页",
+            ) {
+                var pageTurnPercent by remember {
+                    mutableIntStateOf(settings.getInt(PREF_PAGE_TURN_PERCENT, DEFAULT_PAGE_TURN_PERCENT))
+                }
+                SettingItem(
+                    title = { Text("翻页百分比") },
+                    description = { Text("每次翻页滚动的屏幕比例 ($pageTurnPercent%)，降低可避免悬浮栏遮挡内容。") },
+                    bottomAction = {
+                        Slider(
+                            value = pageTurnPercent.toFloat(),
+                            onValueChange = {
+                                val pct = (it / 5).roundToInt() * 5
+                                pageTurnPercent = pct
+                                settings.putInt(PREF_PAGE_TURN_PERCENT, pct)
+                            },
+                            valueRange = 30f..100f,
+                            steps = 13,
+                            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                        )
+                    },
+                )
+
+                val volumeKeyPageTurn = remember {
+                    mutableStateOf(settings.getBoolean(PREF_VOLUME_KEY_PAGE_TURN, false))
+                }
+                SettingItemWithSwitch(
+                    title = { Text("使用音量键翻页") },
+                    description = { Text("按音量键时翻页而非调节音量，适合墨水屏设备。") },
+                    checked = volumeKeyPageTurn.value,
+                    onCheckedChange = {
+                        volumeKeyPageTurn.value = it
+                        settings.putBoolean(PREF_VOLUME_KEY_PAGE_TURN, it)
+                    },
+                )
+
+                SettingItemWithSwitch(
+                    title = { Text("显示翻页悬浮按钮") },
+                    description = { Text("在页面上显示可拖动的上下翻页按钮。") },
+                    checked = pageTurnFabVisible.value,
+                    onCheckedChange = {
+                        pageTurnFabVisible.value = it
+                        settings.putBoolean(PREF_SHOW_PAGE_TURN_FAB, it)
+                    },
+                )
+
+                val showPageTurnGuide = remember {
+                    mutableStateOf(settings.getBoolean(PREF_SHOW_PAGE_TURN_GUIDE, false))
+                }
+                SettingItemWithSwitch(
+                    title = { Text("显示翻页范围标记") },
+                    description = { Text("用两条虚线标记翻页边界，帮助定位翻页后的阅读位置。") },
+                    checked = showPageTurnGuide.value,
+                    onCheckedChange = {
+                        showPageTurnGuide.value = it
+                        settings.putBoolean(PREF_SHOW_PAGE_TURN_GUIDE, it)
                     },
                 )
             }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
@@ -638,6 +638,14 @@ fun AppearanceSettingsScreen(
             // ── 翻页 ───────────────────────────────────────────────────────────
             SettingItemGroup(
                 title = "翻页",
+                header = {
+                    Text(
+                        "适合墨水屏电纸书等无触屏滑动体验的设备。",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                    )
+                },
             ) {
                 var pageTurnPercent by remember {
                     mutableIntStateOf(settings.getInt(PREF_PAGE_TURN_PERCENT, DEFAULT_PAGE_TURN_PERCENT))
@@ -665,7 +673,7 @@ fun AppearanceSettingsScreen(
                 }
                 SettingItemWithSwitch(
                     title = { Text("使用音量键翻页") },
-                    description = { Text("按音量键时翻页而非调节音量，适合墨水屏设备。") },
+                    description = { Text("按音量键时翻页而非调节音量。") },
                     checked = volumeKeyPageTurn.value,
                     onCheckedChange = {
                         volumeKeyPageTurn.value = it

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
@@ -112,6 +112,7 @@ import com.github.zly2006.zhihu.ui.components.SettingItem
 import com.github.zly2006.zhihu.ui.components.SettingItemGroup
 import com.github.zly2006.zhihu.ui.components.SettingItemOverall
 import com.github.zly2006.zhihu.ui.components.SettingItemWithSwitch
+import com.github.zly2006.zhihu.ui.components.fabOpacityPercent
 import com.github.zly2006.zhihu.ui.components.normalizedAnswerSwitchSensitivity
 import com.github.zly2006.zhihu.ui.components.pageTurnFabVisible
 import kotlinx.coroutines.delay
@@ -127,6 +128,8 @@ const val DEFAULT_PAGE_TURN_PERCENT = 90
 const val PREF_VOLUME_KEY_PAGE_TURN = "volumeKeyPageTurn"
 const val PREF_SHOW_PAGE_TURN_FAB = "showPageTurnFab"
 const val PREF_SHOW_PAGE_TURN_GUIDE = "showPageTurnGuide"
+const val PREF_FAB_OPACITY = "fabOpacity"
+const val DEFAULT_FAB_OPACITY = 100
 const val APPEARANCE_SETTINGS_SCROLL_TAG = "appearanceSettings.scroll"
 const val APPEARANCE_SETTINGS_START_DESTINATION_TAG = "appearanceSettings.startDestination"
 const val APPEARANCE_SETTINGS_ANSWER_DOUBLE_TAP_TAG = "appearanceSettings.answerDoubleTap"
@@ -543,6 +546,28 @@ fun AppearanceSettingsScreen(
                         },
                     )
                 }
+
+                var fabOpacity by remember {
+                    mutableIntStateOf(settings.getInt(PREF_FAB_OPACITY, DEFAULT_FAB_OPACITY))
+                }
+                SettingItem(
+                    title = { Text("悬浮按钮透明度") },
+                    description = { Text("控制所有悬浮按钮的透明度 ($fabOpacity%)。") },
+                    bottomAction = {
+                        Slider(
+                            value = fabOpacity.toFloat(),
+                            onValueChange = {
+                                val v = (it / 5).roundToInt() * 5
+                                fabOpacity = v
+                                fabOpacityPercent.intValue = v
+                                settings.putInt(PREF_FAB_OPACITY, v)
+                            },
+                            valueRange = 10f..100f,
+                            steps = 17,
+                            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                        )
+                    },
+                )
             }
             // ── 阅读 ────────────────────────────────────────────────────────────
             SettingItemGroup(
@@ -689,7 +714,7 @@ fun AppearanceSettingsScreen(
                 )
 
                 SettingItemWithSwitch(
-                    title = { Text("显示刷新 FAB 按钮") },
+                    title = { Text("显示刷新悬浮按钮") },
                     description = { Text("在页面上显示可拖动的刷新按钮。") },
                     checked = showRefreshFab.value,
                     onCheckedChange = {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/ContentFilterSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/ContentFilterSettingsScreen.kt
@@ -53,12 +53,15 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.github.zly2006.zhihu.navigation.Account
@@ -69,6 +72,7 @@ import com.github.zly2006.zhihu.shared.filter.rememberContentFilterMaintenance
 import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
 import com.github.zly2006.zhihu.shared.util.Log
+import com.github.zly2006.zhihu.ui.components.PageTurnScrollEffect
 import com.github.zly2006.zhihu.ui.components.SettingItem
 import com.github.zly2006.zhihu.ui.components.SettingItemGroup
 import com.github.zly2006.zhihu.ui.components.SettingItemWithSwitch
@@ -132,9 +136,16 @@ fun ContentFilterSettingsScreen(
             )
         },
     ) { innerPadding ->
+        val density = LocalDensity.current
+        var rawViewportHeight by remember { mutableIntStateOf(0) }
+        val topPx = with(density) { innerPadding.calculateTopPadding().toPx().toInt() }
+        val bottomPx = with(density) { innerPadding.calculateBottomPadding().toPx().toInt() }
+        val viewportHeight = (rawViewportHeight - topPx - bottomPx).coerceAtLeast(0)
+        PageTurnScrollEffect(scrollState, viewportHeight, scrollBehavior.state)
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .onSizeChanged { rawViewportHeight = it.height }
                 .verticalScroll(scrollState)
                 .testTag("contentFilterSettings:scroll")
                 .padding(innerPadding)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/DeveloperSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/DeveloperSettingsScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
@@ -58,6 +59,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
@@ -70,6 +73,7 @@ import com.github.zly2006.zhihu.shared.platform.rememberPlainTextClipboard
 import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
 import com.github.zly2006.zhihu.ui.TtsState
+import com.github.zly2006.zhihu.ui.components.PageTurnScrollEffect
 import com.github.zly2006.zhihu.ui.components.SettingItemOverall
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -138,10 +142,18 @@ fun DeveloperSettingsScreen() {
             )
         },
     ) { innerPadding ->
+        val scrollState = rememberScrollState()
+        val density = LocalDensity.current
+        var rawViewportHeight by remember { mutableIntStateOf(0) }
+        val topPx = with(density) { innerPadding.calculateTopPadding().toPx().toInt() }
+        val bottomPx = with(density) { innerPadding.calculateBottomPadding().toPx().toInt() }
+        val viewportHeight = (rawViewportHeight - topPx - bottomPx).coerceAtLeast(0)
+        PageTurnScrollEffect(scrollState, viewportHeight, scrollBehavior.state)
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState())
+                .onSizeChanged { rawViewportHeight = it.height }
+                .verticalScroll(scrollState)
                 .padding(innerPadding)
                 .padding(16.dp),
         ) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/OpenSourceLicensesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/OpenSourceLicensesScreen.kt
@@ -20,6 +20,8 @@ package com.github.zly2006.zhihu.ui.subscreens
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.DataObject
@@ -34,11 +36,14 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import com.github.zly2006.zhihu.navigation.LocalNavigator
+import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
+import com.github.zly2006.zhihu.ui.components.PageTurnLazyListEffect
 import com.github.zly2006.zhihu.ui.components.SettingItem
 import com.github.zly2006.zhihu.ui.components.SettingItemGroup
 import com.mikepenz.aboutlibraries.Libs
@@ -107,6 +112,7 @@ val fullVariantManualLibraries = listOf(
 @Composable
 fun OpenSourceLicensesContent(
     modifier: Modifier = Modifier,
+    lazyListState: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues,
     manualLibraries: List<ManualLicenseEntry>,
     onOpenUrl: (String) -> Unit,
@@ -114,6 +120,7 @@ fun OpenSourceLicensesContent(
     LibrariesContainer(
         libraries = rememberOpenSourceLicensesLibraries(),
         modifier = modifier,
+        lazyListState = lazyListState,
         contentPadding = contentPadding,
         header = {
             if (manualLibraries.isNotEmpty()) {
@@ -174,7 +181,12 @@ fun OpenSourceLicensesScreen() {
             )
         },
     ) { innerPadding ->
+        val listState = rememberLazyListState()
+        val settings = rememberSettingsStore()
+        val pageTurnPercent = remember { settings.getInt(PREF_PAGE_TURN_PERCENT, DEFAULT_PAGE_TURN_PERCENT) }
+        PageTurnLazyListEffect(listState, pageTurnPercent, topBarState = scrollBehavior.state)
         OpenSourceLicensesContent(
+            lazyListState = listState,
             contentPadding = PaddingValues(16.dp),
             manualLibraries = manualLibraries,
             onOpenUrl = uriHandler::openUri,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SystemAndUpdateSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SystemAndUpdateSettingsScreen.kt
@@ -65,6 +65,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
@@ -78,6 +80,7 @@ import com.github.zly2006.zhihu.shared.aigc.AIGC_MARKING_ENABLED_PREFERENCE_KEY
 import com.github.zly2006.zhihu.shared.platform.rememberExternalUrlOpener
 import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.util.ContinuousUsageReminderPolicy
+import com.github.zly2006.zhihu.ui.components.PageTurnScrollEffect
 import com.github.zly2006.zhihu.ui.components.SettingItem
 import com.github.zly2006.zhihu.ui.components.SettingItemGroup
 import com.github.zly2006.zhihu.ui.components.SettingItemWithSwitch
@@ -134,9 +137,16 @@ fun SystemAndUpdateSettingsScreen() {
         },
     ) { innerPadding ->
         val scrollState = rememberScrollState()
+        val density = LocalDensity.current
+        var rawViewportHeight by remember { mutableIntStateOf(0) }
+        val topPx = with(density) { innerPadding.calculateTopPadding().toPx().toInt() }
+        val bottomPx = with(density) { innerPadding.calculateBottomPadding().toPx().toInt() }
+        val viewportHeight = (rawViewportHeight - topPx - bottomPx).coerceAtLeast(0)
+        PageTurnScrollEffect(scrollState, viewportHeight, scrollBehavior.state)
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .onSizeChanged { rawViewportHeight = it.height }
                 .verticalScroll(scrollState)
                 .padding(innerPadding)
                 .padding(vertical = 16.dp),


### PR DESCRIPTION
## 必填：AI 使用与验证材料

请如实勾选：

- [ ] 未使用 AI 编写、改写或批量生成代码
- [x] 使用了 AI 编写、改写或批量生成代码

如果使用了 AI，本 PR 必须附上以下验证材料，否则不会进入 review：

- [x] 已上传测试截图
- [x] 已上传测试录屏

截图和录屏应来自实际运行结果，不能使用设计图、旧截图或仅靠文字说明代替。

## 变更说明

===

我在墨水屏阅读器 文石P6+ 上用这个知乎++，很好用，但是有些地方不太顺手。为此，在 Cursor claude-4.6-opus-high-thinking 的帮助下，我增加了如下功能：

1. 主页摘要和评论正文接入内容字体大小百分比控制
     在墨水屏上，字体看起来很小。知乎++设置页面里有个字号大小的设定，但是只能控制回答正文内容。这个改动让它能同时控制主页列表里的摘要和正文点开的评论的字体大小；

2. 增加了音量翻页键和悬浮按钮翻页功能
     新增"外观与阅读体验"翻页设置组：
     - 音量键翻页开关
     - 显示翻页悬浮按钮开关（可拖动定位）
     - 翻页百分比（每次翻页滚动的屏幕比例）
     - 显示翻页引导线开关

     支持的交互：
     - 短按音量键/悬浮按钮翻一页，长按跳转顶部或底部
     - 翻页引导线在触摸滑动时自动隐藏
     - 正文、评论、设置等页面均可翻页
     - 当评论翻到底时，增加了标记“— · —”

3. 增加了悬浮按钮透明度设置

===

我不太懂 Android 开发和 Kotlin 语言，这些主要都是由 Cursor 写的，但是我有仔细测试打磨过，用下来没有什么问题。

为了方便作者审阅代码，我让 AI 给复杂的翻页功能的代码改动生成了一份架构文档 [docs/page-turn-architecture.md](https://github.com/silverzhaojr/zhihu-plus-plus/blob/48b5d1700e8cd9532fba2572b233571635f3fbcf/docs/page-turn-architecture.md)。

每个功能都是单独的提交，如果作者同意合并的话，希望不要将它们压缩成一个，而是保留三个独立的提交，这样方便以后回溯审阅相关代码改动。

## 测试与验证

见截图和录屏。

1. 新增设置项：
<img width="412" height="824" alt="a01" src="https://github.com/user-attachments/assets/ffafdd13-ac1a-4c53-aaa8-c1478b435f69" />
<img width="412" height="824" alt="a02" src="https://github.com/user-attachments/assets/23f1ac7c-4b68-4c70-9100-79e30f7fb575" />

2. 摘要、正文、评论文字同步变大：
<img width="412" height="824" alt="a03" src="https://github.com/user-attachments/assets/f299979a-1524-4636-8179-e76ab3fa2538" />
<img width="412" height="824" alt="a04" src="https://github.com/user-attachments/assets/7a8827cb-eb86-4137-b81d-98863e75d898" />
<img width="412" height="824" alt="a05" src="https://github.com/user-attachments/assets/ba82ff09-7469-4c2e-a669-37a1f0641d11" />
<img width="412" height="824" alt="a06" src="https://github.com/user-attachments/assets/1d6d4536-b296-4548-88ff-943225ae62f8" />

3. 录屏：
<video src="https://github.com/user-attachments/assets/333d848c-5153-4ffb-bfdb-0ebb535258ca" controls="controls" width="100%"></video>
