### PR TITLE
fix: 弹出搜索页动画+搜索框自动聚焦

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/SearchScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/SearchScreenInstrumentedTest.kt
@@ -20,6 +20,7 @@ package com.github.zly2006.zhihu
 import android.content.Context
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
@@ -70,7 +71,7 @@ class SearchScreenInstrumentedTest {
     fun searchBoxEditingClearImeAndBackAreDeterministic() {
         // This test disables hot-search entirely so the screen stays offline and deterministic.
         // Expected behavior:
-        // 1. The search field starts empty and shows its placeholder.
+        // 1. The search field starts empty, is focused immediately, and shows its placeholder.
         // 2. Text input and replacement update the editable value exactly.
         // 3. Triggering the IME search action navigates with the final query instead of touching the network.
         // 4. The clear button resets the field back to the placeholder state.
@@ -89,6 +90,7 @@ class SearchScreenInstrumentedTest {
 
         val searchInput = composeRule.onNodeWithTag("search_input")
         searchInput.assertIsDisplayed()
+        searchInput.assertIsFocused()
         composeRule.onNodeWithText("搜索内容").assertIsDisplayed()
 
         // Typing should produce an exact editable value and reveal the explicit clear affordance.
@@ -148,6 +150,7 @@ class SearchScreenInstrumentedTest {
         composeRule.onAllNodesWithTag("search_hot_list").assertCountEquals(0)
 
         val searchInput = composeRule.onNodeWithTag("search_input")
+        searchInput.assertIsFocused()
         searchInput.performTextInput("限定关键词")
         searchInput.performImeAction()
         composeRule.waitForIdle()
@@ -163,6 +166,25 @@ class SearchScreenInstrumentedTest {
             recordingNavigator.destinations,
         )
         assertEquals("""["全局历史"]""", preferences.getString("searchHistoryQueries", null))
+    }
+
+    @Test
+    fun prefilledSearchDoesNotStealFocusFromResultsState() {
+        composeRule.activity
+            .getSharedPreferences(PREFERENCE_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean("showSearchHotSearch", false)
+            .commit()
+
+        composeRule.setScreenContent {
+            SearchScreen(
+                search = Search(query = "已有关键词"),
+                testHotSearchQueries = emptyList(),
+            )
+        }
+
+        composeRule.onNodeWithTag("search_input").assertIsDisplayed().assertTextEquals("已有关键词")
+        composeRule.onAllNodesWithText("搜索内容").assertCountEquals(0)
     }
 
     @Test

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
@@ -64,6 +64,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
@@ -90,6 +93,7 @@ import com.github.zly2006.zhihu.viewmodel.feed.SearchViewModel
 import com.github.zly2006.zhihu.viewmodel.feed.ZHIHU_HOT_SEARCH_URL
 import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonArray
@@ -136,12 +140,15 @@ fun SearchScreen(
     val settings = rememberSettingsStore()
     val viewModel = viewModel { SearchViewModel(search.query, search.restrictedMemberHashId) }
     val paginationEnvironment = rememberPaginationEnvironment(allowGuestAccess = false)
+    val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
+    val searchInputFocusRequester = remember { FocusRequester() }
     var searchText by remember { mutableStateOf(search.query) }
     val coroutineScope = rememberCoroutineScope()
     val isMemberSearch = search.isRestrictedToMember
     val memberSearchName = search.restrictedMemberName.ifBlank { "TA" }
     val searchPlaceholder = if (isMemberSearch) "搜索 $memberSearchName 的创作" else "搜索内容"
+    val shouldAutoFocusSearchInput = search.query.isBlank()
 
     val showHotSearch = remember { mutableStateOf(!isMemberSearch && settings.getBoolean("showSearchHotSearch", true)) }
     val hotSearchItems = remember(testHotSearchQueries) {
@@ -165,6 +172,8 @@ fun SearchScreen(
     fun submitSearch(query: String) {
         val trimmedQuery = query.trim()
         if (trimmedQuery.isEmpty()) return
+        focusManager.clearFocus(force = true)
+        keyboardController?.hide()
         if (showSearchHistory.value) {
             searchHistoryItems.remove(trimmedQuery)
             searchHistoryItems.add(0, trimmedQuery)
@@ -243,6 +252,15 @@ fun SearchScreen(
         }
     }
 
+    LaunchedEffect(shouldAutoFocusSearchInput) {
+        if (shouldAutoFocusSearchInput) {
+            // 等待导航切换后的第一帧，让搜索框以“进入即输入”的状态出现，而不是先切页再补抢焦点。
+            yield()
+            searchInputFocusRequester.requestFocus()
+            keyboardController?.show()
+        }
+    }
+
     LaunchedEffect(viewModel.errorMessage) {
         viewModel.errorMessage?.let {
             userMessages.showMessage(it, UserMessageDuration.Long)
@@ -283,6 +301,7 @@ fun SearchScreen(
                                     onValueChange = { searchText = it },
                                     modifier = Modifier
                                         .weight(1f)
+                                        .focusRequester(searchInputFocusRequester)
                                         .testTag("search_input"),
                                     textStyle = MaterialTheme.typography.bodyLarge.copy(
                                         color = MaterialTheme.colorScheme.onSurface,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -22,7 +22,10 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
@@ -499,7 +502,32 @@ fun ZhihuMain(
                 composable<Account> {
                     AccountSettingScreen(innerPadding)
                 }
-                composable<Search> { navEntry ->
+                composable<Search>(
+                    enterTransition = {
+                        if (initialState.destination.hasRoute<Search>()) {
+                            EnterTransition.None
+                        } else {
+                            fadeIn(animationSpec = tween(durationMillis = 240)) +
+                                slideInVertically(animationSpec = tween(durationMillis = 280)) { it / 16 } +
+                                scaleIn(
+                                    animationSpec = tween(durationMillis = 280),
+                                    initialScale = 0.985f,
+                                )
+                        }
+                    },
+                    popExitTransition = {
+                        if (targetState.destination.hasRoute<Search>()) {
+                            ExitTransition.None
+                        } else {
+                            fadeOut(animationSpec = tween(durationMillis = 180)) +
+                                slideOutVertically(animationSpec = tween(durationMillis = 220)) { it / 20 } +
+                                scaleOut(
+                                    animationSpec = tween(durationMillis = 220),
+                                    targetScale = 0.985f,
+                                )
+                        }
+                    },
+                ) { navEntry ->
                     val search: Search = navEntry.toRoute()
                     SearchScreen(search)
                 }


### PR DESCRIPTION
## 必填：AI 使用与验证材料

请如实勾选：

- [ ] 未使用 AI 编写、改写或批量生成代码
- [x] 使用了 AI 编写、改写或批量生成代码

如果使用了 AI，本 PR 必须附上以下验证材料，否则不会进入 review：

- [ ] 已上传测试截图
- [x] 已上传测试录屏

截图和录屏应来自实际运行结果，不能使用设计图、旧截图或仅靠文字说明代替。

## 变更说明

主页搜索框是假的→需要点一次进入搜索页→再点一次输入框，不优雅

## 测试与验证

- 假的主页搜索框→点一次进入搜索页→自动聚焦键盘
- 搜索页上浮动画
- 提供test

https://github.com/user-attachments/assets/86041f29-9cf2-4bb8-aa86-23e0cdb930de

