### PR TITLE
fix: 关注页（FollowPage）左右滑动动画重构

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -46,6 +45,7 @@ import com.github.zly2006.zhihu.shared.filter.ContentOpenFrom
 import com.github.zly2006.zhihu.test.MainActivityComposeRule
 import com.github.zly2006.zhihu.test.resetAppPreferences
 import com.github.zly2006.zhihu.test.setZhihuMainContent
+import com.github.zly2006.zhihu.ui.FOLLOW_SCREEN_PAGER_TAG
 import com.github.zly2006.zhihu.ui.PREFERENCE_NAME
 import com.github.zly2006.zhihu.ui.subscreens.BOTTOM_BAR_ITEMS_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.subscreens.START_DESTINATION_PREFERENCE_KEY
@@ -136,59 +136,54 @@ class ZhihuMainNavigationInstrumentedTest {
     }
 
     @Test
-    fun flattenedMainPager_swipesThroughFollowPagesWithoutLosingBottomTabSelection() {
-        // Follow is represented by two adjacent main-pager pages but a single bottom-bar item.
-        // Swiping between "推荐" and "动态" must keep the Follow item selected; swiping past the
-        // second Follow page should move to the next configured bottom destination.
+    fun followInnerPager_swipesBetweenTabsWithoutLosingBottomTabSelection() {
+        // Follow is now a single main-tab page that owns its own inner pager. Swiping inside the
+        // follow pager must switch between "推荐" and "动态" while keeping the bottom-bar Follow
+        // item selected, and leaving Follow should still require switching the main tab itself.
         composeRule.launchZhihuMain(startDestination = Home.name)
         composeRule.onNodeWithTag("nav_tab_follow").performClick()
 
         composeRule.waitUntilTabSelected("nav_tab_follow")
-        composeRule
-            .onNodeWithText("推荐")
-            .assertExists()
-            .assertIsDisplayed()
-            .assertIsSelected()
-        composeRule
-            .onNodeWithText("动态")
-            .assertExists()
-            .assertIsDisplayed()
-            .assertIsNotSelected()
+        composeRule.waitUntilTabSelected("follow_screen_tab_0")
+        composeRule.onNodeWithTag("follow_screen_tab_0").assertIsSelected()
+        composeRule.onNodeWithTag("follow_screen_tab_1").assertIsNotSelected()
+        composeRule.onNodeWithText("推荐").assertExists().assertIsDisplayed()
+        composeRule.onNodeWithText("动态").assertExists().assertIsDisplayed()
 
-        composeRule.onRoot().performTouchInput { swipeLeft() }
+        composeRule.onNodeWithTag(FOLLOW_SCREEN_PAGER_TAG).performTouchInput { swipeLeft() }
 
-        composeRule.waitUntilTextSelected("动态")
-        composeRule.onNodeWithText("动态").assertIsSelected()
-        composeRule.onNodeWithText("推荐").assertIsNotSelected()
+        composeRule.waitUntilTabSelected("follow_screen_tab_1")
+        composeRule.onNodeWithTag("follow_screen_tab_1").assertIsSelected()
+        composeRule.onNodeWithTag("follow_screen_tab_0").assertIsNotSelected()
         composeRule.onNodeWithTag("nav_tab_follow").assertIsSelected()
 
-        composeRule.onRoot().performTouchInput { swipeLeft() }
-
-        composeRule.waitUntilTabSelected("nav_tab_daily")
+        composeRule.onNodeWithTag("nav_tab_daily").performClick()
         composeRule.onNodeWithTag("nav_tab_daily").assertIsSelected()
         composeRule.onNodeWithTag("nav_tab_follow").assertIsNotSelected()
 
-        composeRule.onRoot().performTouchInput { swipeRight() }
+        composeRule.onNodeWithTag("nav_tab_follow").performClick()
 
-        composeRule.waitUntilTextSelected("动态")
-        composeRule.onNodeWithText("动态").assertIsSelected()
-        composeRule.onNodeWithText("推荐").assertIsNotSelected()
+        composeRule.waitUntilTabSelected("nav_tab_follow")
+        composeRule.waitUntilTabSelected("follow_screen_tab_1")
+        composeRule.onNodeWithTag("follow_screen_tab_1").assertIsSelected()
+        composeRule.onNodeWithTag("follow_screen_tab_0").assertIsNotSelected()
         composeRule.onNodeWithTag("nav_tab_follow").assertIsSelected()
 
-        composeRule.onRoot().performTouchInput { swipeRight() }
+        composeRule.onNodeWithTag(FOLLOW_SCREEN_PAGER_TAG).performTouchInput { swipeRight() }
 
-        composeRule.waitUntilTextSelected("推荐")
-        composeRule.onNodeWithText("推荐").assertIsSelected()
-        composeRule.onNodeWithText("动态").assertIsNotSelected()
+        composeRule.waitUntilTabSelected("follow_screen_tab_0")
+        composeRule.onNodeWithTag("follow_screen_tab_0").assertIsSelected()
+        composeRule.onNodeWithTag("follow_screen_tab_1").assertIsNotSelected()
         composeRule.onNodeWithTag("nav_tab_follow").assertIsSelected()
         composeRule.onNodeWithTag("nav_tab_home").assertIsNotSelected()
     }
 
     @Test
     fun startDestinationAndHiddenBottomTabsRemainCompatibleWithFlattenedPager() {
-        // The main shell now stores all configured bottom tabs inside one pager. This keeps the
-        // preference contract intact: startup opens the configured visible tab, hidden tabs stay
-        // hidden, and legacy top-level NavDestination requests cannot navigate to missing routes.
+        // The flattened main pager now treats Follow as a single main tab with an internal pager.
+        // Startup still opens the configured visible tab, hidden tabs stay hidden, and entering
+        // Follow from the main pager lands on the Follow page while its inner pager starts from
+        // the default recommendation tab.
         composeRule.launchZhihuMain(
             startDestination = Daily.name,
             bottomBarItems = linkedSetOf(Follow.name, Daily.name, Account.name),
@@ -204,15 +199,16 @@ class ZhihuMainNavigationInstrumentedTest {
 
         composeRule.onRoot().performTouchInput { swipeRight() }
 
-        composeRule.waitUntilTextSelected("动态")
+        composeRule.waitUntilTabSelected("follow_screen_tab_0")
         composeRule.onNodeWithTag("nav_tab_follow").assertIsSelected()
-        composeRule.onNodeWithText("动态").assertIsSelected()
+        composeRule.onNodeWithTag("follow_screen_tab_0").assertIsSelected()
+        composeRule.onNodeWithTag("follow_screen_tab_1").assertIsNotSelected()
 
-        composeRule.onRoot().performTouchInput { swipeRight() }
+        composeRule.onNodeWithTag(FOLLOW_SCREEN_PAGER_TAG).performTouchInput { swipeLeft() }
 
-        composeRule.waitUntilTextSelected("推荐")
+        composeRule.waitUntilTabSelected("follow_screen_tab_1")
         composeRule.onNodeWithTag("nav_tab_follow").assertIsSelected()
-        composeRule.onNodeWithText("推荐").assertIsSelected()
+        composeRule.onNodeWithTag("follow_screen_tab_1").assertIsSelected()
 
         composeRule.activity.runOnUiThread {
             composeRule.activity.navigate(MainTabs, popup = true)
@@ -228,6 +224,7 @@ class ZhihuMainNavigationInstrumentedTest {
 
         composeRule.waitUntilTabSelected("nav_tab_follow")
         composeRule.onNodeWithTag("nav_tab_follow").assertIsSelected()
+        composeRule.waitUntilTabSelected("follow_screen_tab_1")
     }
 
     @Test
@@ -264,14 +261,6 @@ class ZhihuMainNavigationInstrumentedTest {
     private fun MainActivityComposeRule.waitUntilTabSelected(tag: String) {
         waitUntil(timeoutMillis = 5_000) {
             onAllNodes(hasTestTag(tag).and(isSelectedMatcher()))
-                .fetchSemanticsNodes()
-                .isNotEmpty()
-        }
-    }
-
-    private fun MainActivityComposeRule.waitUntilTextSelected(text: String) {
-        waitUntil(timeoutMillis = 5_000) {
-            onAllNodes(hasText(text).and(isSelectedMatcher()))
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/FollowScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/FollowScreen.kt
@@ -21,18 +21,22 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
@@ -45,6 +49,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -58,7 +63,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -158,22 +162,20 @@ private fun FollowScreenContent(
 ) {
     val viewModel = viewModel { FollowScreenData() }
     val titles = listOf("推荐", "动态")
-    val pagerState = rememberPagerState(pageCount = { titles.size })
+    val pagerState = rememberPagerState(
+        initialPage = viewModel.selectedTabIndex,
+        pageCount = { titles.size },
+    )
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(pagerState.currentPage) {
         viewModel.selectedTabIndex = pagerState.currentPage
     }
 
-    LaunchedEffect(viewModel.selectedTabIndex) {
-        if (pagerState.currentPage != viewModel.selectedTabIndex) {
-            pagerState.animateScrollToPage(viewModel.selectedTabIndex)
-        }
-    }
-
     Column(modifier = Modifier.padding(bottom = innerPadding.calculateBottomPadding())) {
         FollowTabRow(
-            selectedTabIndex = viewModel.selectedTabIndex,
+            pagerState = pagerState,
+            selectedTabIndex = pagerState.currentPage,
             onTabSelected = { index ->
                 viewModel.selectedTabIndex = index
                 coroutineScope.launch {
@@ -212,54 +214,57 @@ private fun FollowScreenContent(
 }
 
 @Composable
-fun FollowTopLevelPage(
-    selectedTabIndex: Int,
-    onTabSelected: (Int) -> Unit,
-    scrollToTopTrigger: Int,
-    innerPadding: PaddingValues,
-    isActive: Boolean,
-) {
-    Column(
-        modifier = Modifier
-            .padding(bottom = innerPadding.calculateBottomPadding())
-            .then(if (isActive) Modifier else Modifier.clearAndSetSemantics {}),
-    ) {
-        FollowTabRow(
-            selectedTabIndex = selectedTabIndex,
-            onTabSelected = onTabSelected,
-            modifier = Modifier.padding(top = innerPadding.calculateTopPadding()),
-        )
-        when (selectedTabIndex) {
-            0 -> FollowRecommendScreen(
-                scrollToTopTrigger = scrollToTopTrigger,
-                isActive = isActive,
-            )
-            1 -> FollowDynamicScreen(
-                scrollToTopTrigger = scrollToTopTrigger,
-                isActive = isActive,
-            )
-        }
-    }
-}
-
-@Composable
 private fun FollowTabRow(
+    pagerState: PagerState? = null,
     selectedTabIndex: Int,
     onTabSelected: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val titles = listOf("推荐", "动态")
-    PrimaryTabRow(
-        selectedTabIndex = selectedTabIndex,
-        modifier = modifier.testTag(FOLLOW_SCREEN_TAB_ROW_TAG),
-    ) {
+    val tabs: @Composable () -> Unit = {
         titles.forEachIndexed { index, title ->
             Tab(
                 modifier = Modifier.testTag("follow_screen_tab_$index"),
                 selected = selectedTabIndex == index,
                 onClick = { onTabSelected(index) },
-                text = { Text(text = title, maxLines = 2, overflow = TextOverflow.Ellipsis) },
+                text = {
+                    Text(
+                        text = title,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.fillMaxWidth(),
+                        textAlign = TextAlign.Center,
+                    )
+                },
             )
+        }
+    }
+
+    if (pagerState != null) {
+        BoxWithConstraints(modifier) {
+            val tabWidth = maxWidth / titles.size
+            PrimaryTabRow(
+                selectedTabIndex = selectedTabIndex,
+                modifier = Modifier.testTag(FOLLOW_SCREEN_TAB_ROW_TAG),
+                indicator = {
+                    val page = (pagerState.currentPage + pagerState.currentPageOffsetFraction)
+                        .coerceIn(0f, (titles.size - 1).toFloat())
+                    TabRowDefaults.PrimaryIndicator(
+                        modifier = Modifier
+                            .offset(x = tabWidth * page)
+                            .width(tabWidth),
+                    )
+                },
+            ) {
+                tabs()
+            }
+        }
+    } else {
+        PrimaryTabRow(
+            selectedTabIndex = selectedTabIndex,
+            modifier = modifier.testTag(FOLLOW_SCREEN_TAB_ROW_TAG),
+        ) {
+            tabs()
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -63,7 +63,6 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -132,9 +131,7 @@ private sealed class MainTabPage(
 ) {
     data object HomePage : MainTabPage(Home, "home")
 
-    data object FollowRecommendPage : MainTabPage(Follow, "follow_recommend")
-
-    data object FollowDynamicPage : MainTabPage(Follow, "follow_dynamic")
+    data object FollowPage : MainTabPage(Follow, "follow")
 
     data object HotListPage : MainTabPage(HotList, "hotlist")
 
@@ -248,7 +245,7 @@ fun ZhihuMain(
         bottomBarItems.flatMap { item ->
             when (item.first) {
                 Home -> listOf(MainTabPage.HomePage)
-                Follow -> listOf(MainTabPage.FollowRecommendPage, MainTabPage.FollowDynamicPage)
+                Follow -> listOf(MainTabPage.FollowPage)
                 HotList -> listOf(MainTabPage.HotListPage)
                 Daily -> listOf(MainTabPage.DailyPage)
                 OnlineHistory -> listOf(MainTabPage.OnlineHistoryPage)
@@ -267,7 +264,6 @@ fun ZhihuMain(
             it.bottomDestination::class == startDestination::class
         }.takeIf { it >= 0 } ?: 0
 
-    var lastFollowPageKey by rememberSaveable { mutableStateOf(MainTabPage.FollowRecommendPage.key) }
     val mainPagerState = rememberPagerState(
         initialPage = pageIndexForDestination(startDestination),
         pageCount = { mainTabPages.size },
@@ -277,26 +273,14 @@ fun ZhihuMain(
     fun currentMainTabPage(): MainTabPage? = mainTabPages.getOrNull(mainPagerState.currentPage)
     var currentMainTabDestination by remember { mutableStateOf(startDestination) }
 
-    fun pageIndexForBottomDestination(destination: TopLevelDestination): Int {
-        if (destination == Follow) {
-            val rememberedFollowPage = mainTabPages.indexOfFirst { it.key == lastFollowPageKey }
-            if (rememberedFollowPage >= 0) return rememberedFollowPage
-        }
-        return pageIndexForDestination(destination)
-    }
-
     fun navigateTopLevel(destination: TopLevelDestination) {
-        val targetPage = pageIndexForBottomDestination(destination)
+        val targetPage = pageIndexForDestination(destination)
         coroutineScope.launch {
             mainPagerState.animateScrollToPage(targetPage)
         }
     }
 
     LaunchedEffect(mainPagerState.currentPage, mainTabPages) {
-        when (val page = currentMainTabPage()) {
-            MainTabPage.FollowRecommendPage, MainTabPage.FollowDynamicPage -> lastFollowPageKey = page.key
-            else -> {}
-        }
         currentMainTabPage()?.bottomDestination?.let { destination ->
             currentMainTabDestination = destination
             navigationState.setCurrentMainTabOpenFrom(destination.openFrom)
@@ -308,7 +292,7 @@ fun ZhihuMain(
         mainTabNavigationTarget?.let { destination ->
             // 平台适配层会把旧的顶层 route 请求映射到 MainTabs。这里消费该请求，
             // 让 deeplink 等调用方仍能选中 Home/Follow 等 tab，而不是把旧 route 压入返回栈。
-            mainPagerState.scrollToPage(pageIndexForBottomDestination(destination))
+            mainPagerState.scrollToPage(pageIndexForDestination(destination))
             navigationState.consumeMainTabNavigationTarget(destination)
         }
     }
@@ -444,19 +428,6 @@ fun ZhihuMain(
                         pages = mainTabPages,
                         scrollToTopTrigger = scrollToTopTrigger,
                         innerPadding = innerPadding,
-                        onFollowTabSelected = { followTabIndex ->
-                            val page = if (followTabIndex == 0) {
-                                MainTabPage.FollowRecommendPage
-                            } else {
-                                MainTabPage.FollowDynamicPage
-                            }
-                            val index = mainTabPages.indexOfFirst { it.key == page.key }
-                            if (index >= 0) {
-                                coroutineScope.launch {
-                                    mainPagerState.animateScrollToPage(index)
-                                }
-                            }
-                        },
                     )
                 }
                 composable<Question> { navEntry ->
@@ -565,7 +536,6 @@ fun ZhihuMain(
 /**
  * 渲染可配置底部导航主壳内的页面。
  *
- * pager 的页数可以多于底部栏项，因为 [Follow] 会拆成“推荐”和“动态”两个页面。这样横向滑动仍然自然，而底部栏仍只展示一个“关注”入口。
  * 每个页面都接收主壳给出的 [innerPadding]，保证系统栏、底部栏和子页面之间的留白一致。
  */
 @OptIn(ExperimentalFoundationApi::class)
@@ -575,7 +545,6 @@ private fun MainTabsPager(
     pages: List<MainTabPage>,
     scrollToTopTrigger: Int,
     innerPadding: PaddingValues,
-    onFollowTabSelected: (Int) -> Unit,
 ) {
     HorizontalPager(
         state = pagerState,
@@ -587,19 +556,9 @@ private fun MainTabsPager(
                 scrollToTopTrigger = scrollToTopTrigger,
                 innerPadding = innerPadding,
             )
-            MainTabPage.FollowRecommendPage -> FollowTopLevelPage(
-                selectedTabIndex = 0,
-                onTabSelected = onFollowTabSelected,
+            MainTabPage.FollowPage -> FollowScreen(
                 scrollToTopTrigger = scrollToTopTrigger,
                 innerPadding = innerPadding,
-                isActive = pagerState.currentPage == pageIndex,
-            )
-            MainTabPage.FollowDynamicPage -> FollowTopLevelPage(
-                selectedTabIndex = 1,
-                onTabSelected = onFollowTabSelected,
-                scrollToTopTrigger = scrollToTopTrigger,
-                innerPadding = innerPadding,
-                isActive = pagerState.currentPage == pageIndex,
             )
             MainTabPage.HotListPage -> HotListScreen(
                 innerPadding = innerPadding,


### PR DESCRIPTION
## 必填：AI 使用与验证材料

请如实勾选：

- [ ] 未使用 AI 编写、改写或批量生成代码
- [x] 使用了 AI 编写、改写或批量生成代码

如果使用了 AI，本 PR 必须附上以下验证材料，否则不会进入 review：

- [ ] 已上传测试截图
- [x] 已上传测试录屏

截图和录屏应来自实际运行结果，不能使用设计图、旧截图或仅靠文字说明代替。

## 变更说明

- 主页：把 FollowRecommendPage/FollowDynamicPage 合并为 FollowPage
- Follow 页内部指示器： FollowTabRow 在传入 pagerState 时，用 currentPage + currentPageOffsetFraction 驱动横线平滑位移

## 测试与验证

原来在页面中左右滑动，顶部TabRow会跟随一起滑动：

https://github.com/user-attachments/assets/27e14cc5-f7f1-4cf3-aba6-6e45cb1ca57d

现在将 TabRow 固定，不跟着页面一起滑动，只有下面的指示横线跟手移动。

https://github.com/user-attachments/assets/2cae6398-7b78-4ea2-8837-beb74736936d
