### PR TITLE
fix: 让feed的html tag解析只支持em标签

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/NotificationScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/NotificationScreen.kt
@@ -81,7 +81,6 @@ import com.github.zly2006.zhihu.shared.util.formatRelativeTime
 import com.github.zly2006.zhihu.ui.components.DraggableRefreshButton
 import com.github.zly2006.zhihu.ui.components.PaginatedList
 import com.github.zly2006.zhihu.ui.components.ProgressIndicatorFooter
-import com.github.zly2006.zhihu.util.parseHtmlTextWithTheme
 import com.github.zly2006.zhihu.viewmodel.MobileNotificationCategory
 import com.github.zly2006.zhihu.viewmodel.NotificationEnvironment
 import com.github.zly2006.zhihu.viewmodel.NotificationViewModel
@@ -365,7 +364,7 @@ fun NotificationItemView(
                         modifier = Modifier.weight(1f),
                     ) {
                         Text(
-                            text = parseHtmlTextWithTheme(notification.displayTitle()),
+                            text = notification.displayTitle(),
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.SemiBold,
                             maxLines = 2,
@@ -374,7 +373,7 @@ fun NotificationItemView(
                         notification.displaySubtitle().takeIf { it.isNotBlank() }?.let { subtitle ->
                             Spacer(modifier = Modifier.height(3.dp))
                             Text(
-                                text = parseHtmlTextWithTheme(subtitle),
+                                text = subtitle,
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 maxLines = 1,
@@ -384,7 +383,7 @@ fun NotificationItemView(
                         notification.displayText().takeIf { it.isNotBlank() }?.let { content ->
                             Spacer(modifier = Modifier.height(4.dp))
                             Text(
-                                text = parseHtmlTextWithTheme(content),
+                                text = content,
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 maxLines = 3,
@@ -413,7 +412,7 @@ fun NotificationItemView(
                         modifier = Modifier.padding(12.dp),
                     ) {
                         Text(
-                            text = parseHtmlTextWithTheme(sourceText),
+                            text = sourceText,
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             maxLines = 3,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
@@ -87,7 +87,7 @@ import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
 import com.github.zly2006.zhihu.ui.subscreens.PREF_FONT_SIZE
 import com.github.zly2006.zhihu.ui.subscreens.PREF_LINE_HEIGHT
-import com.github.zly2006.zhihu.util.parseHtmlTextWithTheme
+import com.github.zly2006.zhihu.util.parseEmphasizedHtmlTextWithTheme
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.max
@@ -496,7 +496,7 @@ private fun FeedCardContent(
         if (!item.title.isEmpty()) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = parseHtmlTextWithTheme(item.title),
+                    text = parseEmphasizedHtmlTextWithTheme(item.title),
                     style = if (duo3CardLargeTitle) {
                         MaterialTheme.typography.titleLarge
                     } else {
@@ -513,7 +513,7 @@ private fun FeedCardContent(
         Column {
             Row {
                 Text(
-                    text = parseHtmlTextWithTheme(item.summary ?: ""),
+                    text = parseEmphasizedHtmlTextWithTheme(item.summary ?: ""),
                     style = MaterialTheme.typography.bodyMedium.copy(
                         fontSize = 14.sp * fontSizePercent / 100,
                         lineHeight = 14.sp * fontSizePercent / 100 * lineHeightPercent / 100,
@@ -598,7 +598,7 @@ private fun FeedCardContent(
         if (!item.title.isEmpty() && !item.isFiltered) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = parseHtmlTextWithTheme(item.title),
+                    text = parseEmphasizedHtmlTextWithTheme(item.title),
                     fontSize = 16.sp,
                     fontWeight = FontWeight.Bold,
                     maxLines = 2,
@@ -640,7 +640,7 @@ private fun FeedCardContent(
         Row {
             Column(modifier = Modifier.weight(2f)) {
                 Text(
-                    text = parseHtmlTextWithTheme(item.summary ?: ""),
+                    text = parseEmphasizedHtmlTextWithTheme(item.summary ?: ""),
                     fontSize = 14.sp * fontSizePercent / 100,
                     lineHeight = 14.sp * fontSizePercent / 100 * lineHeightPercent / 100,
                     maxLines = 3,
@@ -682,7 +682,7 @@ private fun FeedCardContent(
 private fun FeedCardSourceLabel(sourceLabel: String?) {
     val label = sourceLabel?.takeIf { it.isNotBlank() } ?: return
     Text(
-        text = parseHtmlTextWithTheme(label),
+        text = label,
         style = MaterialTheme.typography.labelMedium,
         color = MaterialTheme.colorScheme.primary,
         maxLines = 1,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/util/HtmlText.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/util/HtmlText.kt
@@ -23,74 +23,48 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import com.fleeksoft.ksoup.Ksoup
-import com.fleeksoft.ksoup.nodes.Element
-import com.fleeksoft.ksoup.nodes.Node
-import com.fleeksoft.ksoup.nodes.TextNode
 
-/**
- * Parse HTML text and convert it to AnnotatedString with styling.
- * Currently supports <em> tags which are styled with the provided emphasis color.
- *
- * @param html The HTML string to parse
- * @param emphasisColor The color to use for emphasized text (content within <em> tags)
- * @return AnnotatedString with styled text
- */
-fun parseHtmlText(
+fun parseEmphasizedHtmlText(
     html: String,
     emphasisColor: Color,
 ): AnnotatedString {
-    // Parse HTML fragment using Ksoup (more efficient than full document parsing)
-    val document = Ksoup.parseBodyFragment(html)
-    val body = document.body()
-
+    // Assume that the input contains only text and valid, non-nested <em> tags.
     return buildAnnotatedString {
-        processNode(this, body, emphasisColor)
-    }
-}
-
-/**
- * Recursively process nodes and append text with styling
- */
-private fun processNode(
-    builder: AnnotatedString.Builder,
-    node: Node,
-    emphasisColor: Color,
-) {
-    when (node) {
-        is TextNode -> {
-            // Append plain text
-            builder.append(node.text())
-        }
-        is Element -> {
-            when (node.tagName().lowercase()) {
-                "em" -> {
-                    // Push emphasis style
-                    val startIndex = builder.length
-                    node.childNodes().forEach { childNode ->
-                        processNode(builder, childNode, emphasisColor)
-                    }
-                    val endIndex = builder.length
-                    // Apply emphasis color to the text within <em> tags
-                    if (startIndex < endIndex) {
-                        builder.addStyle(
-                            style = SpanStyle(color = emphasisColor),
-                            start = startIndex,
-                            end = endIndex,
-                        )
-                    }
+        var cursor = 0
+        var emphasisStart: Int? = null
+        while (cursor < html.length) {
+            when {
+                html.startsWith("<em>", cursor) -> {
+                    emphasisStart = length
+                    cursor += 4
                 }
-                "body" -> {
-                    // Process body children without adding any styling
-                    node.childNodes().forEach { childNode ->
-                        processNode(builder, childNode, emphasisColor)
+                html.startsWith("</em>", cursor) -> {
+                    emphasisStart?.let { start ->
+                        if (start < length) {
+                            addStyle(SpanStyle(color = emphasisColor), start, length)
+                        }
                     }
+                    emphasisStart = null
+                    cursor += 5
+                }
+                html[cursor] == '&' -> {
+                    val entityEnd = html.indexOf(';', cursor + 1)
+                    val entity = entityEnd.takeIf { it != -1 }?.let { html.substring(cursor + 1, it) }
+                    val decoded =
+                        when (entity) {
+                            "lt" -> '<'
+                            "gt" -> '>'
+                            "quot" -> '"'
+                            "#39" -> '\''
+                            "amp" -> '&'
+                            else -> null
+                        }
+                    append(decoded ?: '&')
+                    cursor = if (decoded == null) cursor + 1 else entityEnd + 1
                 }
                 else -> {
-                    // For other tags, just process children (ignore the tag itself)
-                    node.childNodes().forEach { childNode ->
-                        processNode(builder, childNode, emphasisColor)
-                    }
+                    append(html[cursor])
+                    cursor++
                 }
             }
         }
@@ -105,7 +79,7 @@ private fun processNode(
  * @return AnnotatedString with styled text using theme colors
  */
 @Composable
-fun parseHtmlTextWithTheme(html: String): AnnotatedString {
+fun parseEmphasizedHtmlTextWithTheme(html: String): AnnotatedString {
     val emphasisColor = MaterialTheme.colorScheme.primary
-    return parseHtmlText(html, emphasisColor)
+    return parseEmphasizedHtmlText(html, emphasisColor)
 }

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/util/HtmlTextDetailedTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/util/HtmlTextDetailedTest.kt
@@ -35,7 +35,7 @@ class HtmlTextDetailedTest {
     fun testEmTagParsing() {
         val html = "This is a <em>test</em> string"
         val emphasisColor = Color.Blue
-        val annotatedString = parseHtmlText(html, emphasisColor)
+        val annotatedString = parseEmphasizedHtmlText(html, emphasisColor)
 
         // Verify the text content is correct
         assertEquals("This is a test string", annotatedString.text)
@@ -58,7 +58,7 @@ class HtmlTextDetailedTest {
     fun testMultipleEmTags() {
         val html = "Search <em>keyword1</em> and <em>keyword2</em>"
         val emphasisColor = Color.Red
-        val annotatedString = parseHtmlText(html, emphasisColor)
+        val annotatedString = parseEmphasizedHtmlText(html, emphasisColor)
 
         // Verify the text content is correct
         assertEquals("Search keyword1 and keyword2", annotatedString.text)
@@ -74,7 +74,7 @@ class HtmlTextDetailedTest {
     fun testPlainText() {
         val html = "This is plain text"
         val emphasisColor = Color.Green
-        val annotatedString = parseHtmlText(html, emphasisColor)
+        val annotatedString = parseEmphasizedHtmlText(html, emphasisColor)
 
         // Verify the text content is correct
         assertEquals("This is plain text", annotatedString.text)
@@ -90,7 +90,7 @@ class HtmlTextDetailedTest {
     fun testNestedHtml() {
         val html = "Test <em>emphasis</em> text"
         val emphasisColor = Color.Yellow
-        val annotatedString = parseHtmlText(html, emphasisColor)
+        val annotatedString = parseEmphasizedHtmlText(html, emphasisColor)
 
         // Verify the text is parsed correctly
         assertEquals("Test emphasis text", annotatedString.text)
@@ -105,7 +105,7 @@ class HtmlTextDetailedTest {
         // Real format from Zhihu search API
         val html = "为什么互联网给我一种想<em>搜</em>的东西什么都搜不到，屁用没有的信息一大堆的无力感？"
         val emphasisColor = Color.Cyan
-        val annotatedString = parseHtmlText(html, emphasisColor)
+        val annotatedString = parseEmphasizedHtmlText(html, emphasisColor)
 
         // Verify the text content
         assertTrue(annotatedString.text.contains("搜"), "Should contain the search keyword")
@@ -121,7 +121,7 @@ class HtmlTextDetailedTest {
     fun testEmptyString() {
         val html = ""
         val emphasisColor = Color.Magenta
-        val annotatedString = parseHtmlText(html, emphasisColor)
+        val annotatedString = parseEmphasizedHtmlText(html, emphasisColor)
 
         // Verify empty result
         assertEquals("", annotatedString.text, "Should have empty text")
@@ -135,9 +135,9 @@ class HtmlTextDetailedTest {
     fun testHtmlEntities() {
         val html = "Test &lt;em&gt;<em>keyword</em>&lt;/em&gt;"
         val emphasisColor = Color.Black
-        val annotatedString = parseHtmlText(html, emphasisColor)
+        val annotatedString = parseEmphasizedHtmlText(html, emphasisColor)
 
-        // Jsoup automatically decodes HTML entities
+        // HTML entities in text nodes are decoded
         assertTrue(annotatedString.text.contains("<em>"), "Should decode HTML entities")
         assertTrue(annotatedString.spanStyles.isNotEmpty(), "Should have emphasized text")
     }

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/util/HtmlTextTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/util/HtmlTextTest.kt
@@ -33,4 +33,17 @@ class HtmlTextTest {
         assertEquals(4, span.end)
         assertEquals(Color.Red, span.item.color)
     }
+
+    @Test
+    fun parseEmphasizedHtmlTextKeepsAngleBracketText() {
+        listOf(
+            "为什么Deepseek在输入<think 后会匹配到疑似其他对话?",
+            "vector<bool>",
+        ).forEach { source ->
+            val text = parseEmphasizedHtmlText(source, Color.Red)
+
+            assertEquals(source, text.text)
+            assertEquals(0, text.spanStyles.size)
+        }
+    }
 }

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/util/HtmlTextTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/util/HtmlTextTest.kt
@@ -23,8 +23,8 @@ import kotlin.test.assertEquals
 
 class HtmlTextTest {
     @Test
-    fun parseHtmlTextKeepsEmphasisSpan() {
-        val text = parseHtmlText("普通<em>高亮</em>文本", Color.Red)
+    fun parseEmphasizedHtmlTextKeepsEmphasisSpan() {
+        val text = parseEmphasizedHtmlText("普通<em>高亮</em>文本", Color.Red)
 
         assertEquals("普通高亮文本", text.text)
         assertEquals(1, text.spanStyles.size)


### PR DESCRIPTION
<img width="1682" height="1372" alt="image" src="https://github.com/user-attachments/assets/8cda5360-d016-45ff-ad89-2e195cb86c41" />
家人们谁懂啊，知乎自己都各种转义错误