### PR TITLE
feat: 支持 AppView 链接解析

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
@@ -353,12 +353,28 @@ fun resolveContent(url: Url): NavDestination? {
             } else if (segments.size == 2 && segments[0] == "pin") {
                 val pinId = segments[1].toLongOrNull() ?: return null
                 return Pin(id = pinId)
+            } else if (segments.size == 3 && segments[0] == "appview") {
+                val contentId = segments[2].toLongOrNull() ?: return null
+                return when (segments[1]) {
+                    "pin" -> Pin(id = contentId)
+                    "answer" -> Article(type = ArticleType.Answer, id = contentId)
+                    "p" -> Article(type = ArticleType.Article, id = contentId)
+                    else -> null
+                }
             } else if (segments.size == 1 &&
                 segments[0] == "search"
             ) {
                 val query = url.parameters["q"] ?: ""
                 return Search(query)
             }
+            /*
+             * 尚未支持的 destination，等待后续补充对应的 NavDestination：
+             * - https://www.zhihu.com/appview/roundtable -> https://www.zhihu.com/roundtable
+             * - https://www.zhihu.com/appview/special -> https://www.zhihu.com/special/all
+             * - https://www.zhihu.com/column/{columnToken}
+             * - https://daily.zhihu.com/story/{storyId}
+             * - https://www.zhihu.com/special/{specialId}
+             */
             Log.w("NavDestination", "Cannot resolve content from url: $url")
         } else if (url.host == "zhuanlan.zhihu.com") {
             if (segments.size == 2 &&

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/navigation/NavDestinationTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/navigation/NavDestinationTest.kt
@@ -46,4 +46,30 @@ class NavDestinationTest {
         assertEquals(ArticleType.Answer, article.type)
         assertEquals(42L, article.id)
     }
+
+    @Test
+    fun resolvesZhihuAppViewPinUrlFromCommonCode() {
+        val destination = resolveContent("https://www.zhihu.com/appview/pin/2059710318939301395")
+
+        val pin = assertIs<Pin>(destination)
+        assertEquals(2059710318939301395L, pin.id)
+    }
+
+    @Test
+    fun resolvesZhihuAppViewAnswerUrlFromCommonCode() {
+        val destination = resolveContent("https://www.zhihu.com/appview/answer/2040633177593619876")
+
+        val article = assertIs<Article>(destination)
+        assertEquals(ArticleType.Answer, article.type)
+        assertEquals(2040633177593619876L, article.id)
+    }
+
+    @Test
+    fun resolvesZhihuAppViewArticleUrlFromCommonCode() {
+        val destination = resolveContent("https://www.zhihu.com/appview/p/1981671287999981270")
+
+        val article = assertIs<Article>(destination)
+        assertEquals(ArticleType.Article, article.type)
+        assertEquals(1981671287999981270L, article.id)
+    }
 }


### PR DESCRIPTION
## 改动内容

- 支持将想法 AppView 链接解析为现有 `Pin` destination
- 支持将回答和文章 AppView 链接解析为现有 `Article` destination
- 用一个块注释集中列出当前缺少 destination 的圆桌、专题、专栏和日报等页面，等待后续支持
- 补充三类 AppView 链接的公共导航解析回归测试

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `./gradlew :shared:jvmTest --tests com.github.zly2006.zhihu.navigation.NavDestinationTest`
- 独立代码 review：APPROVE，无 findings

Resolves #536