### PR TITLE
fix: 给知乎擦屁股之修复列表嵌套解析

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
@@ -338,21 +338,34 @@ private fun createListBlock(
     ordered = ordered,
     startNumber = element.attr("start").toIntOrNull() ?: 1,
 ).apply {
-    element.select("> li").forEach { listItemElement ->
-        appendChild(
-            ListItem().apply {
-                val children = listItemElement.childNodes().convertNodesToBlocks(noNativeBlock)
-                if (children.isEmpty()) {
-                    appendChild(
-                        Paragraph().apply {
-                            appendChildren(extractInlineChildren(listItemElement))
-                        },
-                    )
-                } else {
-                    appendChildren(children)
+    var precedingListItem: ListItem? = null
+    element.children().forEach { childElement ->
+        when (childElement.tagName().lowercase()) {
+            "li" -> {
+                val listItem = ListItem().apply {
+                    val children = childElement.childNodes().convertNodesToBlocks(noNativeBlock)
+                    if (children.isEmpty()) {
+                        appendChild(
+                            Paragraph().apply {
+                                appendChildren(extractInlineChildren(childElement))
+                            },
+                        )
+                    } else {
+                        appendChildren(children)
+                    }
                 }
-            },
-        )
+                appendChild(listItem)
+                precedingListItem = listItem
+            }
+
+            "ul", "ol" -> precedingListItem?.appendChild(
+                createListBlock(
+                    childElement,
+                    ordered = childElement.tagName().equals("ol", ignoreCase = true),
+                    noNativeBlock = noNativeBlock,
+                ),
+            )
+        }
     }
 }
 

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/markdown/MdAstTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/markdown/MdAstTest.kt
@@ -20,6 +20,8 @@ package com.github.zly2006.zhihu.markdown
 import com.hrm.markdown.parser.ast.ContainerNode
 import com.hrm.markdown.parser.ast.Figure
 import com.hrm.markdown.parser.ast.InlineMath
+import com.hrm.markdown.parser.ast.ListBlock
+import com.hrm.markdown.parser.ast.ListItem
 import com.hrm.markdown.parser.ast.MathBlock
 import com.hrm.markdown.parser.ast.NativeBlock
 import com.hrm.markdown.parser.ast.Node
@@ -142,6 +144,54 @@ class MdAstTest {
             document.plainText(),
         )
         assertEquals(4, document.allNodes().count { it is StrongEmphasis })
+    }
+
+    @Test
+    fun sibling_ordered_lists_should_nest_under_the_preceding_list_item() {
+        val document = htmlToMdAst(
+            """
+            <ol>
+              <li>继续跳票。</li>
+              <li>在较短时间内推出，但是</li>
+              <ol>
+                <li>分词器和灰测表现不一致</li>
+                <ol>
+                  <li>正式版性能约等于 Fable。</li>
+                  <li>正式版性能远不及 Fable。</li>
+                </ol>
+                <li>分词器和灰测表现一致</li>
+                <ol>
+                  <li>正式版的性能接近 Fable。</li>
+                  <li>正式版的表现远不及 Fable。</li>
+                </ol>
+              </ol>
+            </ol>
+            """.trimIndent(),
+        )
+
+        val outerList = document.children.single() as ListBlock
+        val outerItems = outerList.children.filterIsInstance<ListItem>()
+        val secondLevelList = outerItems[1].children.filterIsInstance<ListBlock>().single()
+        val secondLevelItems = secondLevelList.children.filterIsInstance<ListItem>()
+
+        assertEquals(2, outerItems.size)
+        assertEquals(2, secondLevelItems.size)
+        assertEquals(
+            2,
+            secondLevelItems[0]
+                .children
+                .filterIsInstance<ListBlock>()
+                .single()
+                .children.size,
+        )
+        assertEquals(
+            2,
+            secondLevelItems[1]
+                .children
+                .filterIsInstance<ListBlock>()
+                .single()
+                .children.size,
+        )
     }
 
     @Test


### PR DESCRIPTION
## 修改内容

- 修复知乎 HTML 中子列表与列表项同级时，`htmlToMdAst` 静默丢弃嵌套列表的问题
- 按节点顺序将紧随列表项的 `ol` / `ul` 挂载到前一个列表项
- 增加三级嵌套有序列表回归测试

Resolves #554 

## 根因

知乎返回的部分列表 HTML 不符合标准嵌套结构：子 `ol` 不是放在对应 `li` 内，而是作为父 `ol` 的直接子节点。原实现只选择直接 `li`，导致这些子列表没有进入 Markdown AST。

## 验证

- `:shared:jvmTest --tests com.github.zly2006.zhihu.markdown.MdAstTest`
- `assembleLiteDebug`
- `ktlintFormat`