### PR TITLE
fix: 修复连续无花括号 LaTeX 上下标渲染

### DIFF
--- a/.agents/skills/release-latex-fork/SKILL.md
+++ b/.agents/skills/release-latex-fork/SKILL.md
@@ -45,6 +45,13 @@ Optional proxy for Sonatype and repo1 access:
 ## Guardrails
 
 - Publish under `io.github.zly2006`, never `io.github.huarangmeng`.
+- Do not delegate passive Maven Central publication waits unless the available
+  subagent interface can explicitly select the user-approved low-cost model and
+  reasoning level. If model selection is unavailable, state that limitation and
+  keep polling in the primary agent; never assume the inherited/default model is
+  cheap. This still applies when the user previously asked to delegate waiting:
+  disclose the unavailable cost control before spawning instead of silently
+  accepting an unknown-cost worker.
 - `Original version` means the upstream `huarangmeng/latex` tag. `Fork version`
   means the `0.0.1-alphaN` version published by zly2006.
 - Never use destructive git commands on a dirty tree.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -190,7 +190,7 @@ dependencies {
 
     implementation(project(":markdown-parser"))
     implementation(project(":markdown-renderer"))
-    implementation("io.github.zly2006:latex-renderer-android:0.0.1-alpha1")
+    implementation("io.github.zly2006:latex-renderer-android:0.0.1-alpha2")
 
     implementation("io.coil-kt.coil3:coil-compose:$coil")
     implementation("io.coil-kt.coil3:coil-network-ktor3-android:$coil")

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/CollectionContentScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/CollectionContentScreenInstrumentedTest.kt
@@ -34,7 +34,6 @@ import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
 import com.github.zly2006.zhihu.shared.data.toFeedDisplayItemNavDestinationJson
 import com.github.zly2006.zhihu.test.MainActivityComposeRule
 import com.github.zly2006.zhihu.test.RecordingNavigator
-import com.github.zly2006.zhihu.test.performHorizontalSwipeCycle
 import com.github.zly2006.zhihu.test.performVerticalSwipeCycle
 import com.github.zly2006.zhihu.test.pressSystemBack
 import com.github.zly2006.zhihu.test.resetAppPreferences
@@ -145,8 +144,8 @@ class CollectionContentScreenInstrumentedTest {
     fun listClickNavigatesAndSwipeCyclesKeepTheSeededListStable() {
         /*
          * Expected behavior:
-         * 1. A larger locally seeded list should remain scrollable and safe under vertical and
-         *    horizontal swipe cycles, without triggering network pagination.
+         * 1. A larger locally seeded list should remain scrollable and safe under vertical swipe
+         *    cycles, without triggering network pagination.
          * 2. After those gestures, the toolbar and seeded list rows should still be interactive,
          *    proving that the page layout and semantics tree remain intact.
          * 3. Clicking a seeded row should navigate to that row's destination exactly once.
@@ -155,7 +154,6 @@ class CollectionContentScreenInstrumentedTest {
 
         composeRule.onNodeWithTag(LIST_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(LIST_TAG).performVerticalSwipeCycle()
-        composeRule.onNodeWithTag(LIST_TAG).performHorizontalSwipeCycle()
         composeRule.waitForIdle()
 
         composeRule.onNodeWithText(SEEDED_COLLECTION_TITLE).assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/HistoryScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/HistoryScreenInstrumentedTest.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.zly2006.zhihu.test.MainActivityComposeRule
-import com.github.zly2006.zhihu.test.performHorizontalSwipeCycle
 import com.github.zly2006.zhihu.test.performVerticalSwipeCycle
 import com.github.zly2006.zhihu.test.setScreenContent
 import com.github.zly2006.zhihu.ui.LegacyLocalHistoryScreen
@@ -86,11 +85,6 @@ class HistoryScreenInstrumentedTest {
             )
         }
 
-        // A horizontal swipe is effectively a no-op for this screen, but it should still be safe:
-        // the gesture must not crash the list, duplicate the footer, or mutate the empty history
-        // backing store just because the user brushed sideways on the surface.
-        historyList.performHorizontalSwipeCycle()
-        composeRule.waitForIdle()
         composeRule.onNodeWithText(END_OF_LIST_TEXT).assertIsDisplayed()
         composeRule.onAllNodes(hasText(END_OF_LIST_TEXT)).assertCountEquals(1)
         composeRule.runOnIdle {

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/HotListScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/HotListScreenInstrumentedTest.kt
@@ -32,7 +32,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
 import com.github.zly2006.zhihu.test.MainActivityComposeRule
 import com.github.zly2006.zhihu.test.RecordingNavigator
-import com.github.zly2006.zhihu.test.performHorizontalSwipeCycle
 import com.github.zly2006.zhihu.test.performVerticalSwipeCycle
 import com.github.zly2006.zhihu.test.resetAppPreferences
 import com.github.zly2006.zhihu.test.setScreenContent
@@ -93,7 +92,6 @@ class HotListScreenInstrumentedTest {
         composeRule.onNodeWithText(seedTitle(9)).assertIsDisplayed()
 
         composeRule.onNodeWithTag(HOT_LIST_LIST_TAG).performVerticalSwipeCycle()
-        composeRule.onNodeWithTag(HOT_LIST_LIST_TAG).performHorizontalSwipeCycle()
         composeRule.onNodeWithText(seedTitle(9)).assertIsDisplayed()
 
         composeRule.runOnIdle {

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/LatexEscapedCharactersInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/LatexEscapedCharactersInstrumentedTest.kt
@@ -84,7 +84,7 @@ class LatexEscapedCharactersInstrumentedTest {
                         style = MaterialTheme.typography.headlineSmall,
                     )
                     Text(
-                        text = "io.github.zly2006 · 0.0.1-alpha1",
+                        text = "io.github.zly2006 · 0.0.1-alpha2",
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         style = MaterialTheme.typography.bodyMedium,
                     )
@@ -116,8 +116,74 @@ class LatexEscapedCharactersInstrumentedTest {
             }
         }
 
+        captureScreenshot(
+            tag = "latex_compatibility_screenshot",
+            filename = "latex-escaped-characters.png",
+        )
+    }
+
+    @Test
+    fun rendersAdjacentUnbracedScriptsAsSeparateTerms() {
+        val latex = "a_ib_jx^{i+j}"
+
+        composeRule.setScreenContent {
+            Surface(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag("latex_unbraced_scripts_screenshot"),
+                color = MaterialTheme.colorScheme.background,
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(28.dp),
+                    verticalArrangement = Arrangement.spacedBy(20.dp),
+                ) {
+                    Text(
+                        text = "无花括号上下标回归验证",
+                        style = MaterialTheme.typography.headlineSmall,
+                    )
+                    Text(
+                        text = "io.github.zly2006 · 0.0.1-alpha2",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(text = "输入", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        text = latex,
+                        fontFamily = FontFamily.Monospace,
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        text = "a、b、x 应为三个独立底数",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                            .padding(horizontal = 24.dp, vertical = 32.dp),
+                    ) {
+                        Latex(
+                            latex = latex,
+                            modifier = Modifier.fillMaxWidth(),
+                            config = LatexConfig(fontSize = 40.sp),
+                        )
+                    }
+                }
+            }
+        }
+
+        captureScreenshot(
+            tag = "latex_unbraced_scripts_screenshot",
+            filename = "latex-unbraced-scripts.png",
+        )
+    }
+
+    private fun captureScreenshot(tag: String, filename: String) {
         val screenshotNode = composeRule
-            .onNodeWithTag("latex_compatibility_screenshot")
+            .onNodeWithTag(tag)
             .assertIsDisplayed()
         composeRule.waitForIdle()
 
@@ -125,7 +191,7 @@ class LatexEscapedCharactersInstrumentedTest {
             .getInstrumentation()
             .targetContext
             .getExternalFilesDir(null)
-        val screenshot = File(outputDir, "latex-escaped-characters.png")
+        val screenshot = File(outputDir, filename)
         val bitmap = screenshotNode.captureToImage().asAndroidBitmap()
         FileOutputStream(screenshot).use { stream ->
             bitmap.compress(

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/NotificationSettingsScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/NotificationSettingsScreenInstrumentedTest.kt
@@ -157,7 +157,7 @@ class NotificationSettingsScreenInstrumentedTest {
             ToggleCase(
                 title = "打开通知自动已读",
                 group = ToggleGroup.AutoMarkAsRead,
-                defaultValue = false,
+                defaultValue = true,
                 labelOccurrenceCount = 1,
                 labelOccurrenceIndex = 0,
             ),

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/OnlineHistoryScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/OnlineHistoryScreenInstrumentedTest.kt
@@ -29,7 +29,6 @@ import com.github.zly2006.zhihu.navigation.History
 import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
 import com.github.zly2006.zhihu.test.MainActivityComposeRule
 import com.github.zly2006.zhihu.test.RecordingNavigator
-import com.github.zly2006.zhihu.test.performHorizontalSwipeCycle
 import com.github.zly2006.zhihu.test.performVerticalSwipeCycle
 import com.github.zly2006.zhihu.test.pressSystemBack
 import com.github.zly2006.zhihu.test.resetAppPreferences
@@ -134,9 +133,8 @@ class OnlineHistoryScreenInstrumentedTest {
 
         composeRule.onNodeWithTag(LIST_TAG).assertExists()
         composeRule.onNodeWithTag(LIST_TAG).performVerticalSwipeCycle()
-        composeRule.onNodeWithTag(LIST_TAG).performHorizontalSwipeCycle()
 
-        // After both gesture cycles, the toolbar should remain interactive, the overflow menu
+        // After the gesture cycle, the toolbar should remain interactive, the overflow menu
         // should still open normally, and dismissing the confirmation dialog with system back
         // should restore the untouched list state instead of navigating away or corrupting UI.
         composeRule.onNodeWithText("历史记录").assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/QuestionScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/QuestionScreenInstrumentedTest.kt
@@ -41,7 +41,6 @@ import com.github.zly2006.zhihu.test.MainActivityComposeRule
 import com.github.zly2006.zhihu.test.RecordingNavigator
 import com.github.zly2006.zhihu.test.ZhihuMockApi
 import com.github.zly2006.zhihu.test.mockRootComments
-import com.github.zly2006.zhihu.test.performHorizontalSwipeCycle
 import com.github.zly2006.zhihu.test.performVerticalSwipeCycle
 import com.github.zly2006.zhihu.test.resetAppPreferences
 import com.github.zly2006.zhihu.test.seedViewModel
@@ -175,8 +174,8 @@ class QuestionScreenInstrumentedTest {
          * Expected behavior:
          * 1. A locally seeded answer list should render in the paginated list immediately, without
          *    waiting for QuestionFeedViewModel to fetch real answers.
-         * 2. Scrolling to a deep row should keep list semantics intact, and vertical plus horizontal
-         *    swipe cycles must not break the list or remove the visible seeded item.
+         * 2. Scrolling to a deep row and running vertical swipe cycles must keep list semantics intact
+         *    without removing the visible seeded item.
          * 3. Reaching the lower part of the list should trigger the seeded ViewModel load-more path
          *    at least once, proving pagination can be exercised offline.
          * 4. Clicking a seeded row must navigate to its deterministic destination exactly once.
@@ -194,7 +193,6 @@ class QuestionScreenInstrumentedTest {
             .performScrollToNode(hasTestTag("question_feed_item_offline-question-item-18"))
         composeRule.onNodeWithTag("question_feed_item_offline-question-item-18").assertIsDisplayed()
         composeRule.onNodeWithTag(QUESTION_SCREEN_LIST_TAG).performVerticalSwipeCycle()
-        composeRule.onNodeWithTag(QUESTION_SCREEN_LIST_TAG).performHorizontalSwipeCycle()
         composeRule
             .onNodeWithTag(QUESTION_SCREEN_LIST_TAG)
             .performScrollToNode(hasTestTag("question_feed_item_offline-question-item-18"))

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/SearchScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/SearchScreenInstrumentedTest.kt
@@ -36,7 +36,6 @@ import com.github.zly2006.zhihu.navigation.Account
 import com.github.zly2006.zhihu.navigation.Search
 import com.github.zly2006.zhihu.test.InstrumentedTestEnvironment
 import com.github.zly2006.zhihu.test.ZhihuMockApi
-import com.github.zly2006.zhihu.test.performHorizontalSwipeCycle
 import com.github.zly2006.zhihu.test.performVerticalSwipeCycle
 import com.github.zly2006.zhihu.test.resetAppPreferences
 import com.github.zly2006.zhihu.test.setScreenContent
@@ -252,7 +251,7 @@ class SearchScreenInstrumentedTest {
         //    call through the authenticated fetch path.
         // 2. Pressing refresh performs a second mocked HTTP request and keeps the rendered list stable.
         // 3. Opening the overflow menu exposes the settings action and navigates to the expected destination.
-        // 4. Vertical and horizontal swipe cycles leave the mocked content intact instead of breaking layout state.
+        // 4. Vertical swipe cycles leave the mocked content intact instead of breaking layout state.
         ZhihuMockApi.mockJson(
             method = HttpMethod.Get,
             url = "https://www.zhihu.com/api/v4/search/hot_search",
@@ -303,9 +302,8 @@ class SearchScreenInstrumentedTest {
             recordingNavigator.destinations,
         )
 
-        // Swipe cycles should not disturb the injected offline list or create any extra navigation side effects.
+        // Vertical swipes should not disturb the injected offline list or create extra navigation side effects.
         composeRule.onNodeWithTag("search_hot_list").performVerticalSwipeCycle()
-        composeRule.onNodeWithTag("search_hot_list").performHorizontalSwipeCycle()
         composeRule.waitForIdle()
         composeRule.onNodeWithText("mock alpha").assertIsDisplayed()
         composeRule.onNodeWithText("mock gamma").assertIsDisplayed()

--- a/docs/ai-ui-design-guide.md
+++ b/docs/ai-ui-design-guide.md
@@ -120,7 +120,6 @@ URL 解析集中在 `resolveContent()`。支持知乎问题、回答、文章、
 | `allowTelemetry` | 遥测统计 | 匿名使用统计 | 不影响核心功能 |
 | `continuousUsageReminderIntervalMinutes` | 防沉迷提醒 | 连续使用提醒间隔 | 0 表示关闭 |
 | `developer` | 开发者模式 | 账号页显示开发者选项 | 账号页点击版本 5 次开启 |
-| `enableSwipeReaction` | 开发者选项: 滑动反馈 | Feed 卡片左右滑动触发喜欢/不喜欢 | 由 `FeedCard` 读取，需要调用方提供喜欢/不喜欢回调 |
 | `enableScrollEndHaptic` | 开发者选项: 滚动到底震动 | 滚动边界反馈行为开关 | 改前查具体 overScroll 使用点 |
 | `showDebugOverlay` | 开发者选项: 调试悬浮窗 | 调试 Feed 详情显示 | 如果 `rg` 只命中设置页，先补运行时读取点 |
 | `zse96_key` | 开发者签名请求 | 调试签名相关请求 | 只在开发者页处理 |
@@ -151,7 +150,7 @@ URL 解析集中在 `resolveContent()`。支持知乎问题、回答、文章、
 3. 新设置项: 记录 preference key、默认值、读取点、是否实时生效、是否需要重启、对应 test tag 和从账号页跳转高亮的 `settingKey`。
 4. 新按钮: 优先复用 Material 3 组件和现有图标库，补稳定 test tag，描述点击后影响的状态或导航目标。
 5. 新正文/卡片渲染逻辑: 同时确认 Compose Markdown、WebView、共享组件、平台 adapter、lite/full variant 差异。
-6. 新手势: 明确方向、阈值、和现有回答切换/底栏自动隐藏/图片查看/Feed 滑动反馈的冲突关系。
+6. 新手势: 明确方向、阈值，以及和现有回答切换、底栏自动隐藏、图片查看的冲突关系。
 
 ## 验证入口
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -119,7 +119,7 @@ kotlin {
             implementation("io.ktor:ktor-serialization-kotlinx-json:3.5.0")
             implementation("com.materialkolor:material-kolor:4.1.1")
             implementation("com.fleeksoft.ksoup:ksoup:0.2.6")
-            implementation("io.github.zly2006:latex-renderer:0.0.1-alpha1")
+            implementation("io.github.zly2006:latex-renderer:0.0.1-alpha2")
             implementation(project(":markdown-parser"))
             implementation(project(":markdown-renderer"))
             implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/FollowScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/FollowScreen.kt
@@ -536,12 +536,6 @@ fun FollowDynamicScreen(
                     item = item,
                     modifier = Modifier.testTag("follow_dynamic_item_${item.stableKey}"),
                     showSourceLabel = true,
-                    onLike = {
-                        userMessages.showShortMessage("收到喜欢，功能正在优化")
-                    },
-                    onDislike = {
-                        userMessages.showShortMessage("收到反馈，功能正在优化")
-                    },
                     onBlockUser = { feedItem ->
                         feedBlockActions.handleBlockUser(viewModel, feedItem) { authorInfo ->
                             userToBlock = authorInfo

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
@@ -616,22 +616,6 @@ fun HomeScreen(
                             is Feed.AnswerTarget -> target.thumbnail
                             else -> null
                         },
-                        onLike = {
-                            if (localHomeViewModel != null && it.localContentId != null) {
-                                localHomeViewModel.onLocalItemFeedback(it, 1.0)
-                                userMessages.showShortMessage("已记录喜欢，本地推荐会逐步学习")
-                            } else {
-                                userMessages.showShortMessage("收到喜欢，功能正在优化")
-                            }
-                        },
-                        onDislike = {
-                            if (localHomeViewModel != null && it.localContentId != null) {
-                                localHomeViewModel.onLocalItemFeedback(it, -1.0)
-                                userMessages.showShortMessage("已降低这类本地推荐的优先级")
-                            } else {
-                                userMessages.showShortMessage("收到反馈，功能正在优化")
-                            }
-                        },
                         onBlockUser = { feedItem ->
                             feedBlockActions.handleBlockUser(viewModel, feedItem) { authorInfo ->
                                 userToBlock = authorInfo

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
@@ -18,13 +18,7 @@
 package com.github.zly2006.zhihu.ui.components
 
 import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -32,7 +26,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
@@ -40,9 +33,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.ThumbDown
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
@@ -54,20 +45,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.scale
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -88,19 +72,15 @@ import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
 import com.github.zly2006.zhihu.ui.subscreens.PREF_FONT_SIZE
 import com.github.zly2006.zhihu.ui.subscreens.PREF_LINE_HEIGHT
 import com.github.zly2006.zhihu.util.parseEmphasizedHtmlTextWithTheme
-import kotlinx.coroutines.launch
-import kotlin.math.abs
-import kotlin.math.max
-import kotlin.math.min
 
 /**
  * 信息流卡片的 Material 3 实现。
  *
- * 卡片负责展示标题、摘要、作者、徽章、缩略图和更多菜单，并根据设置支持卡片/分割线两种外观、Duo3 排版、缩略图开关和滑动反馈。
- * 默认点击会解析 [FeedDisplayItem] 的导航目标并进入详情页；外部也可以注入喜欢/不喜欢、屏蔽用户、按关键词屏蔽和屏蔽主题等动作。
+ * 卡片负责展示标题、摘要、作者、徽章、缩略图和更多菜单，并根据设置支持卡片/分割线两种外观、Duo3 排版和缩略图开关。
+ * 默认点击会解析 [FeedDisplayItem] 的导航目标并进入详情页；外部也可以注入屏蔽用户、按关键词屏蔽和屏蔽主题等动作。
  *
  * 修改这个组件时要同步复核 `showFeedThumbnail`、`feedCardStyle`、`duo3_card_appearance`、
- * `duo3_card_layout`、`duo3_card_large_title` 和 `enableSwipeReaction` 对各信息流入口的影响。
+ * `duo3_card_layout` 和 `duo3_card_large_title` 对各信息流入口的影响。
  */
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
@@ -110,8 +90,6 @@ fun FeedCard(
     maxHeight: Dp = 240.dp,
     thumbnailUrl: String? = null,
     horizontalPadding: Dp = 16.dp,
-    onLike: ((FeedDisplayItem) -> Unit)? = null,
-    onDislike: ((FeedDisplayItem) -> Unit)? = null,
     onBlockUser: ((FeedDisplayItem) -> Unit)? = null,
     onBlockByKeywords: ((FeedDisplayItem) -> Unit)? = null,
     onBlockTopic: ((topicId: String, topicName: String) -> Unit)? = null,
@@ -121,23 +99,12 @@ fun FeedCard(
      */
     onClick: (FeedDisplayItem.() -> Unit)? = null,
 ) {
-    val density = LocalDensity.current
     val navigator = LocalNavigator.current
     val uriHandler = LocalUriHandler.current
     val userMessages = rememberUserMessageSink()
     val settings = rememberSettingsStore()
     val isLiteVariant = rememberIsLiteVariant()
-    var offsetX by remember { mutableFloatStateOf(0f) }
-    var currentY by remember { mutableFloatStateOf(0f) } // 当前手指Y位置
-    var startY by remember { mutableFloatStateOf(0f) } // 开始滑动时的Y位置
-    var isDragging by remember { mutableStateOf(false) }
     var showMenu by remember { mutableStateOf(false) }
-    val coroutineScope = rememberCoroutineScope()
-    val enableSwipeReaction = remember {
-        settings.getBoolean("enableSwipeReaction", false)
-    } &&
-        onLike != null &&
-        onDislike != null
     val showFeedThumbnail = remember {
         settings.getBoolean("showFeedThumbnail", true)
     }
@@ -159,31 +126,6 @@ fun FeedCard(
         }
     }
 
-    // 动画偏移量
-    val animatedOffsetX by animateFloatAsState(
-        targetValue = if (isDragging) offsetX else 0f,
-        animationSpec = spring(
-            dampingRatio = Spring.DampingRatioMediumBouncy,
-            stiffness = Spring.StiffnessMediumLow,
-        ),
-        label = "offsetAnimation",
-    )
-
-    // 操作区域的透明度动画
-    val actionAlpha by animateFloatAsState(
-        targetValue = if (abs(animatedOffsetX) > 50f) (abs(animatedOffsetX) - 50f) / 100f else 0f,
-        animationSpec = tween(150),
-        label = "actionAlpha",
-    )
-
-    // 根据横向滑动距离和纵向位置确定当前操作类型
-    val currentAction = when {
-        abs(animatedOffsetX) < 75f -> "none" // 横向滑动不够，无操作
-        currentY - startY < -30f -> "like" // 手指向上，喜欢
-        currentY - startY > 30f -> "dislike" // 手指向下，不喜欢
-        else -> "neutral" // 中间位置，待定
-    }
-
     if (feedCardStyle == "divider") {
         Column(
             modifier = modifier
@@ -194,10 +136,7 @@ fun FeedCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable { onClick(item) }
-                    .pointerInput(Unit) {
-                        // Divider rows have no swipe action, but must not turn horizontal drags into clicks.
-                        detectHorizontalDragGestures { _, _ -> }
-                    }.padding(horizontal = horizontalPadding, vertical = 12.dp),
+                    .padding(horizontal = horizontalPadding, vertical = 12.dp),
             ) {
                 FeedCardContent(
                     item = item,
@@ -233,52 +172,12 @@ fun FeedCard(
                 shape = if (duo3CardAppearance) RoundedCornerShape(24.dp) else CardDefaults.shape,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .alpha(1 - min(actionAlpha, 0.5f))
-                    .offset(x = with(density) { animatedOffsetX.toDp() })
                     .let { if (duo3CardAppearance) it.clip(RoundedCornerShape(24.dp)) else it }
-                    .clickable {
-                        if (!isDragging && abs(animatedOffsetX) < 10f) {
-                            onClick(item)
-                        }
-                    }.let {
-                        if (enableSwipeReaction) {
-                            it.pointerInput(Unit) {
-                                detectHorizontalDragGestures(
-                                    onDragStart = { offset ->
-                                        isDragging = true
-                                        startY = offset.y
-                                        currentY = offset.y
-                                    },
-                                    onDragEnd = {
-                                        isDragging = false
-                                        when {
-                                            abs(offsetX) >= 75f && currentY - startY < -30f && onLike != null -> {
-                                                onLike(item)
-                                            }
-                                            abs(offsetX) >= 75f && currentY - startY > 30f && onDislike != null -> {
-                                                onDislike(item)
-                                            }
-                                        }
-                                        coroutineScope.launch {
-                                            offsetX = 0f
-                                            currentY = 0f
-                                            startY = 0f
-                                        }
-                                    },
-                                ) { change, dragAmount ->
-                                    currentY = change.position.y
-                                    val newOffset = offsetX + dragAmount
-                                    offsetX = max(newOffset, -250f).coerceAtMost(0f)
-                                }
-                            }
-                        } else {
-                            it
-                        }
-                    },
+                    .clickable { onClick(item) },
                 elevation = if (duo3CardAppearance) {
                     CardDefaults.cardElevation()
                 } else {
-                    CardDefaults.cardElevation(defaultElevation = if (isDragging) 8.dp else 2.dp)
+                    CardDefaults.cardElevation(defaultElevation = 2.dp)
                 },
             ) {
                 Column(
@@ -301,80 +200,6 @@ fun FeedCard(
                         duo3CardLargeTitle = duo3CardLargeTitle,
                         showSourceLabel = showSourceLabel,
                     )
-                }
-            }
-
-            if (actionAlpha > 0f && enableSwipeReaction) {
-                Box(
-                    modifier = Modifier
-                        .matchParentSize()
-                        .background(
-                            color = when (currentAction) {
-                                "like" -> Color(0xFF4CAF50).copy(alpha = actionAlpha * 0.2f)
-                                "dislike" -> Color(0xFFFF5722).copy(alpha = actionAlpha * 0.2f)
-                                "neutral" -> Color(0xFF9E9E9E).copy(alpha = actionAlpha * 0.1f)
-                                else -> Color.Transparent
-                            },
-                            shape = RoundedCornerShape(12.dp),
-                        ),
-                    contentAlignment = when (currentAction) {
-                        "like" -> Alignment.TopStart
-                        "dislike" -> Alignment.BottomStart
-                        else -> Alignment.CenterStart
-                    },
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp),
-                    ) {
-                        when (currentAction) {
-                            "like" -> {
-                                Icon(
-                                    imageVector = Icons.Default.Favorite,
-                                    contentDescription = "喜欢",
-                                    tint = Color(0xFF4CAF50),
-                                    modifier = Modifier
-                                        .size(32.dp)
-                                        .scale(1f + actionAlpha * 0.3f),
-                                )
-                                Spacer(modifier = Modifier.width(12.dp))
-                                Text(
-                                    text = "向上滑动 - 喜欢",
-                                    color = Color(0xFF4CAF50),
-                                    fontWeight = FontWeight.Bold,
-                                    fontSize = 14.sp,
-                                    modifier = Modifier.scale(1f + actionAlpha * 0.2f),
-                                )
-                            }
-                            "dislike" -> {
-                                Icon(
-                                    imageVector = Icons.Default.ThumbDown,
-                                    contentDescription = "不喜欢",
-                                    tint = Color(0xFFFF5722),
-                                    modifier = Modifier
-                                        .size(32.dp)
-                                        .scale(1f + actionAlpha * 0.3f),
-                                )
-                                Spacer(modifier = Modifier.width(12.dp))
-                                Text(
-                                    text = "向下滑动 - 不喜欢",
-                                    color = Color(0xFFFF5722),
-                                    fontWeight = FontWeight.Bold,
-                                    fontSize = 14.sp,
-                                    modifier = Modifier.scale(1f + actionAlpha * 0.2f),
-                                )
-                            }
-                            "neutral" -> {
-                                Text(
-                                    text = "上下滑动选择",
-                                    color = Color(0xFF9E9E9E),
-                                    fontWeight = FontWeight.Bold,
-                                    fontSize = 14.sp,
-                                    modifier = Modifier.scale(1f + actionAlpha * 0.2f),
-                                )
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
@@ -194,7 +194,10 @@ fun FeedCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable { onClick(item) }
-                    .padding(horizontal = horizontalPadding, vertical = 12.dp),
+                    .pointerInput(Unit) {
+                        // Divider rows have no swipe action, but must not turn horizontal drags into clicks.
+                        detectHorizontalDragGestures { _, _ -> }
+                    }.padding(horizontal = horizontalPadding, vertical = 12.dp),
             ) {
                 FeedCardContent(
                     item = item,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/local/LocalHomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/local/LocalHomeFeedViewModel.kt
@@ -28,7 +28,6 @@ import com.github.zly2006.zhihu.viewmodel.feed.HomeFeedInteractionViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class LocalHomeFeedViewModel :
     BaseFeedViewModel(),
@@ -76,27 +75,6 @@ class LocalHomeFeedViewModel :
         }
     }
 
-    fun onLocalItemFeedback(item: FeedDisplayItem, feedback: Double) {
-        val contentId = item.localContentId ?: return
-        val reason = item.localReason?.let { runCatching { CrawlingReason.valueOf(it) }.getOrNull() } ?: return
-        if (!::recommendationEngine.isInitialized) {
-            return
-        }
-        viewModelScope.launch(Dispatchers.Default) {
-            recommendationEngine.recordRecommendationFeedback(
-                feedId = item.localFeedId,
-                contentId = contentId,
-                reason = reason,
-                feedback = feedback,
-            )
-            if (feedback < 0) {
-                withContext(Dispatchers.Main) {
-                    displayItems.remove(item)
-                }
-            }
-        }
-    }
-
     private suspend fun ensureEngine(environment: LocalRecommendationEnvironment): LocalRecommendationEngine {
         if (!::recommendationEngine.isInitialized) {
             recommendationEngine = environment.localRecommendationEngine()
@@ -110,14 +88,14 @@ class LocalHomeFeedViewModel :
         val fallbackItems = listOf(
             FeedDisplayItem(
                 title = "本地推荐正在建立候选池",
-                summary = "系统会先抓取关注动态、热门内容和相关话题，再根据你的点击与反馈逐步调整排序。",
+                summary = "系统会先抓取关注动态、热门内容和相关话题，再根据你的点击逐步调整排序。",
                 details = "本地推荐 · 冷启动",
                 feed = null,
                 isFiltered = false,
             ),
             FeedDisplayItem(
                 title = "你的行为只在本地学习",
-                summary = "点开、喜欢、不喜欢都会影响后续排序，但这些学习信号不会作为推荐特征上传到服务器。",
+                summary = "点开内容会影响后续排序，但这些学习信号不会作为推荐特征上传到服务器。",
                 details = "本地推荐 · 隐私优先",
                 feed = null,
                 isFiltered = false,

--- a/third_party/markdown/markdown-renderer/build.gradle.kts
+++ b/third_party/markdown/markdown-renderer/build.gradle.kts
@@ -47,9 +47,9 @@ kotlin {
             implementation("org.jetbrains.compose.ui:ui:1.11.1")
             implementation("org.jetbrains.compose.components:components-resources:1.11.1")
 
-            implementation("io.github.zly2006:latex-base:0.0.1-alpha1")
-            implementation("io.github.zly2006:latex-parser:0.0.1-alpha1")
-            implementation("io.github.zly2006:latex-renderer:0.0.1-alpha1")
+            implementation("io.github.zly2006:latex-base:0.0.1-alpha2")
+            implementation("io.github.zly2006:latex-parser:0.0.1-alpha2")
+            implementation("io.github.zly2006:latex-renderer:0.0.1-alpha2")
             implementation("io.github.huarangmeng:codehighlight-parser:1.1.1")
             implementation("io.github.huarangmeng:codehighlight-render:1.1.1")
 


### PR DESCRIPTION
Resolves #532

## 问题

用户反馈公式 `a_ib_jx^{i+j}` 渲染异常。原因是 fork 解析无花括号上下标时一次消费了整段文本，导致相邻底数和上下标被错误合并。

反馈链接：https://www.zhihu.com/question/2510240856/answer/18989697232

## 修复

- 在 LaTeX fork 中让无花括号上下标只消费一个 Unicode 字符，并保留源码范围。
- 发布 `io.github.zly2006` LaTeX fork `0.0.1-alpha2`，同步升级应用、shared 和内置 Markdown renderer 的依赖版本。
- 新增 Android instrument 回归用例，直接渲染 `a_ib_jx^{i+j}`，验证 `a_i`、`b_j`、`x^{i+j}` 是三个独立项。
- 删除已弃用的 FeedCard swipe action，包括手势状态、动画反馈、喜欢/不喜欢回调、本地 feed 反馈入口和相关横滑测试步骤。
- 同步通知设置 instrument test 到当前“自动已读”默认开启的产品契约。
- 更新 fork 发布 skill：无法明确指定低成本模型和思考强度时，不再把 Maven Central 被动等待交给 subagent。

Fork 修复提交：https://github.com/zly2006/latex/commit/27760b3

Fork 发布合并：https://github.com/zly2006/latex/commit/7ce475f

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `./gradlew :app:assembleLiteDebugAndroidTest`
- Android 15 远端 AVD：`LatexEscapedCharactersInstrumentedTest#rendersAdjacentUnbracedScriptsAsSeparateTerms` 通过
- Android 15 远端 AVD：CI 失败的收藏列表、通知设置、问题回答列表 3 个定向 instrument 用例在同一会话中全部通过
- 实际 Lite Debug APK 可正常启动并完成 `ui-test dump`；备份登录态已被服务端判定过期，因此未把空 feed 当作视觉验证结论

## 实际效果截图

截图来自实际运行的 Lite Debug APK，在 Android 15 远端 AVD 上由上述 instrument test 渲染并保存。图中 `a_i`、`b_j`、`x^{i+j}` 已成为三个独立项。

![连续无花括号 LaTeX 上下标渲染结果](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-563/latex-unbraced-scripts.png)
