### PR TITLE
fix: 给知乎擦屁股之兼容不规范的异常嵌套列表

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
@@ -358,13 +358,20 @@ private fun createListBlock(
                 precedingListItem = listItem
             }
 
-            "ul", "ol" -> precedingListItem?.appendChild(
-                createListBlock(
+            "ul", "ol" -> {
+                val nestedList = createListBlock(
                     childElement,
                     ordered = childElement.tagName().equals("ol", ignoreCase = true),
                     noNativeBlock = noNativeBlock,
-                ),
-            )
+                )
+                if (precedingListItem != null) {
+                    precedingListItem.appendChild(nestedList)
+                } else {
+                    val nestedItems = nestedList.children.toList()
+                    nestedList.clearChildren()
+                    appendChildren(nestedItems)
+                }
+            }
         }
     }
 }

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/markdown/MdAstTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/markdown/MdAstTest.kt
@@ -197,6 +197,30 @@ class MdAstTest {
     }
 
     @Test
+    fun nested_list_without_preceding_item_should_keep_its_items() {
+        val document = htmlToMdAst(
+            """
+            <h3>1.2 国际带宽分配</h3>
+            <ul><ul>
+              <li>电信的国际带宽总量最大，约为7.7T</li>
+              <li>带宽分配较为均衡，各省都有一定的国际带宽</li>
+            </ul></ul>
+            """.trimIndent(),
+        )
+        val list = document.children.filterIsInstance<ListBlock>().single()
+        val items = list.children.filterIsInstance<ListItem>()
+
+        assertEquals(2, items.size)
+        assertEquals(
+            listOf(
+                "电信的国际带宽总量最大，约为7.7T",
+                "带宽分配较为均衡，各省都有一定的国际带宽",
+            ),
+            items.map { it.plainText() },
+        )
+    }
+
+    @Test
     fun preview_image_urls_should_keep_document_order_and_drop_duplicates() {
         val document = htmlToMdAst(
             """


### PR DESCRIPTION
## 修改内容

- 修复知乎文章 HTML 中无前置列表项的异常嵌套列表解析，保留内层列表项正文
- 添加来自问题文章结构的 JVM 单元测试，覆盖 `<ul><ul><li>…</li></ul></ul>`
- 保持已有正常嵌套列表行为不变

## 根因

问题文章从“1.2 国际带宽分配”起返回双层 `ul`。解析器原本只会把嵌套列表挂到前一个 `li`，外层列表没有直接 `li` 时会丢弃整个内层列表，导致标题存在但列表正文不显示。

## 验证

- `./gradlew :shared:jvmTest --tests 'com.github.zly2006.zhihu.markdown.MdAstTest'`
- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`

Resolves #565
