### PR TITLE
fix: 修复身份切换后状态栏变灰

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/SystemBarsInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/SystemBarsInstrumentedTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu
+
+import android.app.Activity
+import android.app.Application
+import android.graphics.Bitmap
+import android.os.Bundle
+import android.os.SystemClock
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.zly2006.zhihu.shared.theme.ThemeMode
+import com.github.zly2006.zhihu.test.resetAppPreferences
+import com.github.zly2006.zhihu.theme.AndroidThemeSettings
+import com.github.zly2006.zhihu.theme.ZhihuTheme
+import com.github.zly2006.zhihu.ui.subscreens.IdentityManagementRuntime
+import com.github.zly2006.zhihu.ui.subscreens.rememberIdentityManagementRuntime
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.FileOutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import androidx.compose.ui.graphics.Color as ComposeColor
+
+@RunWith(AndroidJUnit4::class)
+class SystemBarsInstrumentedTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Before
+    fun setUp() {
+        composeRule.resetAppPreferences()
+        AndroidThemeSettings.setThemeMode(composeRule.activity, ThemeMode.DARK)
+    }
+
+    @Test
+    fun identityChangeRestartKeepsDarkThemeStatusBarEdgeToEdge() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val originalActivity = composeRule.activity
+        val runtime = AtomicReference<IdentityManagementRuntime>()
+        instrumentation.runOnMainSync {
+            originalActivity.setContent {
+                ZhihuTheme {
+                    val identityRuntime = rememberIdentityManagementRuntime()
+                    runtime.set(identityRuntime)
+                    SolidThemeSurface()
+                }
+            }
+        }
+        composeRule.waitForIdle()
+        assertNotNull("Identity management runtime was not composed", runtime.get())
+        assertStatusBarColor(originalActivity, "before identity restart")
+
+        val relaunchedActivity = AtomicReference<MainActivity>()
+        val resumedLatch = CountDownLatch(1)
+        val callbacks = object : Application.ActivityLifecycleCallbacks {
+            override fun onActivityResumed(activity: Activity) {
+                if (activity is MainActivity && activity !== originalActivity) {
+                    relaunchedActivity.set(activity)
+                    resumedLatch.countDown()
+                }
+            }
+
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+
+            override fun onActivityStarted(activity: Activity) = Unit
+
+            override fun onActivityPaused(activity: Activity) = Unit
+
+            override fun onActivityStopped(activity: Activity) = Unit
+
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+
+            override fun onActivityDestroyed(activity: Activity) = Unit
+        }
+        originalActivity.application.registerActivityLifecycleCallbacks(callbacks)
+        try {
+            instrumentation.runOnMainSync {
+                runtime.get().reloadApplication()
+            }
+            assertTrue(
+                "Identity restart did not launch a fresh MainActivity",
+                resumedLatch.await(10, TimeUnit.SECONDS),
+            )
+        } finally {
+            originalActivity.application.unregisterActivityLifecycleCallbacks(callbacks)
+        }
+
+        val activity = checkNotNull(relaunchedActivity.get())
+        instrumentation.runOnMainSync {
+            activity.setContent {
+                ZhihuTheme {
+                    SolidThemeSurface()
+                }
+            }
+        }
+        instrumentation.waitForIdleSync()
+
+        val deadline = SystemClock.uptimeMillis() + 5_000
+        while (
+            sampleStatusBarColor(activity) != SOLID_SURFACE_COLOR &&
+            SystemClock.uptimeMillis() < deadline
+        ) {
+            instrumentation.waitForIdleSync()
+        }
+        assertStatusBarColor(activity, "after identity restart")
+
+        val screenshot = instrumentation.uiAutomation.takeScreenshot()
+        FileOutputStream(activity.cacheDir.resolve("system-bars-after-identity-restart.png")).use {
+            screenshot.compress(Bitmap.CompressFormat.PNG, 100, it)
+        }
+    }
+
+    private fun assertStatusBarColor(
+        activity: MainActivity,
+        stage: String,
+    ) {
+        val statusBarColor = sampleStatusBarColor(activity)
+        assertTrue(
+            "$stage: expected status bar ${SOLID_SURFACE_COLOR.toUInt().toString(16)}, " +
+                "but was ${statusBarColor.toUInt().toString(16)}",
+            statusBarColor == SOLID_SURFACE_COLOR,
+        )
+    }
+
+    private fun sampleStatusBarColor(activity: MainActivity): Int {
+        val screenshot = InstrumentationRegistry.getInstrumentation().uiAutomation.takeScreenshot()
+        val statusBarHeight = ViewCompat
+            .getRootWindowInsets(activity.window.decorView)
+            ?.getInsets(WindowInsetsCompat.Type.statusBars())
+            ?.top
+            ?: error("Status bar insets unavailable")
+        val x = screenshot.width / 2
+        return screenshot.getPixel(x, statusBarHeight / 2)
+    }
+}
+
+@Composable
+private fun SolidThemeSurface() {
+    Box(
+        Modifier
+            .fillMaxSize()
+            .background(ComposeColor(SOLID_SURFACE_COLOR)),
+    )
+}
+
+private const val SOLID_SURFACE_COLOR = 0xFF121212.toInt()

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/IdentityManagementRuntime.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/IdentityManagementRuntime.android.kt
@@ -20,6 +20,7 @@ package com.github.zly2006.zhihu.ui.subscreens
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.content.Intent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -141,7 +142,15 @@ actual fun rememberIdentityManagementRuntime(): IdentityManagementRuntime {
                 }
             },
             reloadApplication = {
-                context.findActivity()?.recreate()
+                context.findActivity()?.let { activity ->
+                    // Activity.recreate() restores a fitted decor view and leaves a gray status bar.
+                    // A fresh task also guarantees that no screen or cache from the previous identity survives.
+                    val launchIntent = activity.packageManager
+                        .getLaunchIntentForPackage(activity.packageName)
+                        ?: error("无法获取应用启动入口")
+                    launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    activity.startActivity(launchIntent)
+                }
             },
         )
     }


### PR DESCRIPTION
## 改动

- 身份切换后不再使用 `Activity.recreate()`，改为清空任务栈并从应用启动入口重新启动
- 让新 Activity 走与冷启动一致的 edge-to-edge 初始化路径，同时清除旧身份残留的页面和缓存
- 新增真实 Activity 重启的状态栏像素回归测试

## 根因

`Activity.recreate()` 会恢复旧窗口的 decor/insets 状态。深色模式下，身份切换完成后新建的 Activity 因此回到 fitted system bars，状态栏实际像素从页面背景的 `#121212` 变成灰色 `#303030`。仅重新调用 edge-to-edge 配置不能稳定消除这段恢复状态。

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew assembleLiteDebugAndroidTest`
- `./gradlew ktlintFormat`
- 远端 API 35 AVD 定向运行 `SystemBarsInstrumentedTest`：`OK (1 test)`
- 红绿对照：`b88c53a8` 上同一测试以 `#303030` 失败；修复后状态栏像素为 `#121212` 并通过
- 已拉取并目视检查修复后的状态栏截图