### PR TITLE
fix: 修复 Markdown 长回答滚动状态闪烁

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTouchInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.github.zly2006.zhihu.markdown.RenderImage
 import com.github.zly2006.zhihu.markdown.RenderMarkdownText
 import com.github.zly2006.zhihu.navigation.AnswerNavigator
 import com.github.zly2006.zhihu.navigation.Article
@@ -59,6 +60,7 @@ import com.github.zly2006.zhihu.ui.TtsState
 import com.github.zly2006.zhihu.ui.rememberArticleTtsState
 import com.github.zly2006.zhihu.viewmodel.ArticleViewModel
 import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
+import com.hrm.markdown.renderer.MarkdownImageData
 import io.ktor.client.HttpClient
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -244,6 +246,33 @@ class ArticleScreenInstrumentedTest {
             "Initial estimated scroll range should stay within 25% of the fully materialized range; " +
                 "estimated=$initialMaxScroll materialized=$materializedMaxScroll",
             estimateRatio in 0.75f..1.25f,
+        )
+    }
+
+    @Test
+    fun markdownImageReservesItsApiAspectRatioBeforeNetworkLoad() {
+        composeRule.setScreenContent {
+            RenderImage(
+                data = MarkdownImageData(
+                    url = "https://invalid.invalid/not-loaded.jpg",
+                    altText = "未加载的比例图片",
+                    width = 1200,
+                    height = 880,
+                ),
+                modifier = androidx.compose.ui.Modifier,
+            )
+        }
+
+        val imageBounds = composeRule
+            .onNodeWithContentDescription("未加载的比例图片")
+            .fetchSemanticsNode()
+            .boundsInRoot
+        assertTrue("Image width must be reserved before loading", imageBounds.width > 0f)
+        assertTrue("Image height must be reserved before loading", imageBounds.height > 0f)
+        assertEquals(
+            1200.0 / 880.0,
+            imageBounds.width.toDouble() / imageBounds.height.toDouble(),
+            0.02,
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
@@ -388,6 +388,10 @@ private fun createBlockImage(element: Element): MarkdownNode? {
     return Figure(
         imageUrl = src,
         caption = caption,
+        imageWidth = element.attr("data-rawwidth").toIntOrNull()
+            ?: element.attr("width").toIntOrNull(),
+        imageHeight = element.attr("data-rawheight").toIntOrNull()
+            ?: element.attr("height").toIntOrNull(),
     )
 }
 
@@ -398,8 +402,10 @@ private fun createFigureBlock(element: Element): MarkdownNode? {
         return Figure(
             imageUrl = src,
             caption = caption,
-            imageWidth = image.attr("width").toIntOrNull(),
-            imageHeight = image.attr("height").toIntOrNull(),
+            imageWidth = image.attr("data-rawwidth").toIntOrNull()
+                ?: image.attr("width").toIntOrNull(),
+            imageHeight = image.attr("data-rawheight").toIntOrNull()
+                ?: image.attr("height").toIntOrNull(),
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/RenderMarkdown.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/RenderMarkdown.kt
@@ -98,6 +98,14 @@ fun RenderImage(
     val previewUrls = remember(imageUrls, data.url) {
         imageUrls.ifEmpty { listOf(data.url) }
     }
+    val imageWidth = data.width
+    val imageHeight = data.height
+    val imageAspectRatio =
+        if (imageWidth != null && imageHeight != null && imageWidth > 0 && imageHeight > 0) {
+            imageWidth.toFloat() / imageHeight
+        } else {
+            null
+        }
 
     fun openGallery() {
         val initialIndex = previewUrls.indexOf(data.url).takeIf { it >= 0 } ?: 0
@@ -113,7 +121,13 @@ fun RenderImage(
             contentDescription = data.altText,
             modifier = modifier
                 .fillMaxWidth(0.8f)
-                .pointerInput(Unit) {
+                .then(
+                    if (imageAspectRatio != null) {
+                        Modifier.aspectRatio(imageAspectRatio)
+                    } else {
+                        Modifier
+                    },
+                ).pointerInput(Unit) {
                     detectTapGestures(
                         onTap = {
                             openGallery()

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/markdown/MdAstImageDimensionsTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/markdown/MdAstImageDimensionsTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.markdown
+
+import com.hrm.markdown.parser.ast.Figure
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class MdAstImageDimensionsTest {
+    @Test
+    fun standaloneZhihuImagePreservesItsRawDimensions() {
+        val document = htmlToMdAst(
+            """
+            <img
+                src="https://picx.zhimg.com/example.jpg"
+                data-rawwidth="1200"
+                data-rawheight="880"
+                width="1200"
+            />
+            """.trimIndent(),
+        )
+
+        val figure = assertIs<Figure>(document.children.single())
+        assertEquals(1200, figure.imageWidth)
+        assertEquals(880, figure.imageHeight)
+    }
+}


### PR DESCRIPTION
## 问题

在图片较多的长回答中，滚动到部分内容边界后，即使手势已经停止，页面滚动范围仍会反复变化，导致阅读进度条和页面出现明显闪烁。

已在回答 [有哪些关于湖南的冷知识？](https://www.zhihu.com/question/52318001/answer/2057260147966316638) 上稳定复现。

## 根因

知乎图片响应携带 `data-rawwidth` / `data-rawheight`，但 HTML 转 Markdown AST 时，独立图片节点没有保留这些尺寸。延迟渲染因此先使用估算高度，图片块进入渲染区后又在网络加载前变为 0 高度。边界块随布局变化反复物化和回收，最终让同一 `ScrollState.value` 下的 `maxValue` 持续跳动。

## 修复

- HTML 转 AST 时保留知乎图片的原始宽高，并兼容标准 `width` / `height` 属性。
- 图片具备合法尺寸时，在网络加载完成前按原始宽高比预留布局空间。
- 增加 AST 尺寸保留的 JVM 回归测试。
- 增加图片加载前宽高比占位的 Android Compose 回归测试。

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `./gradlew :shared:jvmTest --tests 'com.github.zly2006.zhihu.markdown.MdAstImageDimensionsTest' assembleLiteDebugAndroidTest`
- 可见本地 `Pixel_6_Pro` AVD 定向运行 `ArticleScreenInstrumentedTest#markdownImageReservesItsApiAspectRatioBeforeNetworkLoad`
- 在上述真实回答中连续执行相同的 18 次滚动手势：
  - 修复前，停止手势且 `scroll value` 不变时，`maxValue` 最大摆动 2357 px
  - 修复后，非初始加载阶段最大摆动降为 83 px
  - 诊断中的 0 高图片块由 4 次降为 0

所有临时诊断日志均已移除，`git diff --check` 通过。