### PR TITLE
fix: 保持子评论返回位置

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/CommentScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/CommentScreenInstrumentedTest.kt
@@ -17,8 +17,12 @@
 
 package com.github.zly2006.zhihu
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
@@ -39,10 +43,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.ArticleType
 import com.github.zly2006.zhihu.navigation.CommentHolder
+import com.github.zly2006.zhihu.navigation.LocalNavigator
 import com.github.zly2006.zhihu.navigation.NavDestination
+import com.github.zly2006.zhihu.navigation.Navigator
 import com.github.zly2006.zhihu.navigation.Person
 import com.github.zly2006.zhihu.shared.comment.CommentSortOrder
 import com.github.zly2006.zhihu.shared.data.DataHolder
+import com.github.zly2006.zhihu.shared.data.ZhihuJson
 import com.github.zly2006.zhihu.shared.viewmodel.CommentItem
 import com.github.zly2006.zhihu.test.InstrumentedTestEnvironment
 import com.github.zly2006.zhihu.test.MainActivityComposeRule
@@ -68,6 +75,7 @@ import com.github.zly2006.zhihu.ui.COMMENT_SORT_TIME_TAG
 import com.github.zly2006.zhihu.ui.CommentImageMenuAction
 import com.github.zly2006.zhihu.ui.CommentScreen
 import com.github.zly2006.zhihu.ui.CommentScreenTestOverrides
+import com.github.zly2006.zhihu.ui.components.CommentScreenComponent
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
 import com.github.zly2006.zhihu.viewmodel.comment.BaseCommentViewModel
@@ -76,6 +84,7 @@ import com.github.zly2006.zhihu.viewmodel.filter.getContentFilterDatabase
 import com.github.zly2006.zhihu.viewmodel.paginationEnvironment
 import io.ktor.http.HttpMethod
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonArray
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -190,6 +199,94 @@ class CommentScreenInstrumentedTest {
             ),
             navigator.destinations,
         )
+    }
+
+    @Test
+    fun childCommentTargetAndScrollSurviveExternalNavigation() {
+        /*
+         * Expected behavior:
+         * 1. Opening a root comment's reply sheet and scrolling deep into its child replies records
+         *    both the active root comment and the child list position in the host back-stack state.
+         * 2. Navigating to a child comment author's profile removes the comment host from composition.
+         * 3. Returning to the saved host must reopen the same reply sheet at the same child reply,
+         *    instead of falling back to the root comment list or resetting the child list to the top.
+         */
+        val rootComment = seedRootComment(index = 99, childCommentCount = 24)
+        val childComments = seedChildComments(count = 24)
+        ZhihuMockApi.mockJsonPrefix(
+            method = HttpMethod.Get,
+            urlPrefix = "https://www.zhihu.com/api/v4/comment_v5/answers/9001/root_comment",
+            body =
+                """
+                {
+                  "data": ${ZhihuJson.json.encodeToString(listOf(rootComment))},
+                  "paging": {"is_end": true, "is_start": true, "totals": 1, "next": ""}
+                }
+                """.trimIndent(),
+        )
+        ZhihuMockApi.mockJsonPrefix(
+            method = HttpMethod.Get,
+            urlPrefix = "https://www.zhihu.com/api/v4/comment_v5/comment/root-99/child_comment",
+            body =
+                """
+                {
+                  "data": ${ZhihuJson.json.encodeToString(childComments)},
+                  "paging": {"is_end": true, "is_start": true, "totals": 24, "next": ""}
+                }
+                """.trimIndent(),
+        )
+
+        val showCommentHost = mutableStateOf(true)
+        composeRule.setScreenContent {
+            val stateHolder = rememberSaveableStateHolder()
+            val navigator = remember {
+                Navigator(
+                    onNavigate = { showCommentHost.value = false },
+                    onNavigateBack = {},
+                )
+            }
+            if (showCommentHost.value) {
+                stateHolder.SaveableStateProvider("comment-host") {
+                    CompositionLocalProvider(LocalNavigator provides navigator) {
+                        CommentScreenComponent(
+                            showComments = true,
+                            onDismiss = {},
+                            content = ROOT_ARTICLE,
+                        )
+                    }
+                }
+            } else {
+                androidx.compose.material3.Text(
+                    text = "外部页面",
+                    modifier = Modifier.testTag("external_page"),
+                )
+            }
+        }
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag("comment_child_button_root-99").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag("comment_child_button_root-99").performClick()
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(COMMENT_SCREEN_LIST_TAG).fetchSemanticsNodes().size == 2
+        }
+        composeRule
+            .onAllNodesWithTag(COMMENT_SCREEN_LIST_TAG)[1]
+            .performScrollToNode(hasTestTag("comment_row_child-20"))
+        composeRule.onNodeWithTag("comment_row_child-20").assertIsDisplayed()
+        composeRule.onNodeWithTag("comment_author_child-20").performClick()
+        composeRule.onNodeWithTag("external_page").assertIsDisplayed()
+
+        composeRule.runOnIdle { showCommentHost.value = true }
+        composeRule.waitUntil(timeoutMillis = 10_000) {
+            composeRule.onAllNodesWithTag(COMMENT_SCREEN_LIST_TAG).fetchSemanticsNodes().size == 2
+        }
+        composeRule.waitUntil(timeoutMillis = 10_000) {
+            runCatching {
+                composeRule.onNodeWithTag("comment_row_child-20").assertIsDisplayed()
+            }.isSuccess
+        }
+        composeRule.onNodeWithTag("comment_row_child-20").assertIsDisplayed()
     }
 
     @Test

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CommentScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CommentScreen.kt
@@ -441,6 +441,23 @@ fun CommentScreen(
             RootCommentViewModel(resolvedContent)
         }
     }
+    val restoredListPosition = remember(resolvedContent) {
+        listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
+    }
+    var restoredListPositionApplied by remember(resolvedContent) {
+        mutableStateOf(restoredListPosition.first == 0 && restoredListPosition.second == 0)
+    }
+    LaunchedEffect(viewModel.allData.size) {
+        if (!restoredListPositionApplied && viewModel.allData.isNotEmpty()) {
+            // 子评论 ViewModel 异步重建且列表仍为空时，恢复的 LazyListState 会先被压回顶部；
+            // 等回复数据到达后必须重新应用原位置。
+            listState.scrollToItem(
+                restoredListPosition.first.coerceAtMost(viewModel.allData.size),
+                restoredListPosition.second,
+            )
+            restoredListPositionApplied = true
+        }
+    }
     val rootContent = when (resolvedContent) {
         is CommentHolder -> resolvedContent.article
         else -> resolvedContent

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CommentScreenComponent.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CommentScreenComponent.kt
@@ -27,10 +27,11 @@ import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -44,9 +45,13 @@ import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.navigation.Pin
 import com.github.zly2006.zhihu.navigation.Question
 import com.github.zly2006.zhihu.navigation.SegmentCommentHolder
+import com.github.zly2006.zhihu.shared.data.DataHolder
+import com.github.zly2006.zhihu.shared.data.ZhihuJson
 import com.github.zly2006.zhihu.shared.viewmodel.CommentItem
 import com.github.zly2006.zhihu.theme.Typography
 import com.github.zly2006.zhihu.ui.CommentScreen
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
 
 /**
  * 最好不要在 if 或者其他条件语句中使用，这会导致本组件内部状态丢失。
@@ -58,8 +63,10 @@ fun CommentScreenComponent(
     onDismiss: () -> Unit,
     content: NavDestination,
 ) {
-    var activeChildComment by remember { mutableStateOf<CommentItem?>(null) }
     val contentStateKey = commentContentStateKey(content)
+    var activeChildComment by rememberSaveable(contentStateKey, saver = activeChildCommentSaver) {
+        mutableStateOf<CommentItem?>(null)
+    }
     var commentDrafts by rememberSaveable(contentStateKey) {
         mutableStateOf<Map<String, String>>(emptyMap())
     }
@@ -75,6 +82,15 @@ fun CommentScreenComponent(
     val childSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val childTarget = activeChildComment?.clickTarget
     val childDraftKey = childTarget?.let(::commentContentStateKey)
+    var childListResetToken by rememberSaveable(contentStateKey) { mutableIntStateOf(0) }
+    val childListState = rememberSaveable(
+        contentStateKey,
+        childDraftKey,
+        childListResetToken,
+        saver = LazyListState.Saver,
+    ) {
+        LazyListState()
+    }
 
     @Composable
     fun DragHandleTitle(text: String) {
@@ -96,6 +112,7 @@ fun CommentScreenComponent(
     fun dismissRootComments() {
         activeChildComment = null
         rootListResetToken += 1
+        childListResetToken += 1
         onDismiss()
     }
 
@@ -121,7 +138,11 @@ fun CommentScreenComponent(
         ) {
             CommentScreen(
                 content = { content },
-                onChildCommentClick = { activeChildComment = it },
+                onChildCommentClick = { commentItem ->
+                    if (commentItem.clickTarget != null) {
+                        activeChildComment = commentItem
+                    }
+                },
                 commentInput = commentDrafts[contentStateKey].orEmpty(),
                 onCommentInputChange = { updateCommentDraft(contentStateKey, it) },
                 listState = rootListState,
@@ -131,7 +152,10 @@ fun CommentScreenComponent(
 
     if (showComments && activeChildComment != null && childTarget != null && childDraftKey != null) {
         MyModalBottomSheet(
-            onDismissRequest = { activeChildComment = null },
+            onDismissRequest = {
+                activeChildComment = null
+                childListResetToken += 1
+            },
             sheetState = childSheetState,
             containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
             properties = ModalBottomSheetProperties(
@@ -147,10 +171,40 @@ fun CommentScreenComponent(
                 onChildCommentClick = { },
                 commentInput = commentDrafts[childDraftKey].orEmpty(),
                 onCommentInputChange = { updateCommentDraft(childDraftKey, it) },
+                listState = childListState,
             )
         }
     }
 }
+
+private val activeChildCommentSaver = Saver<MutableState<CommentItem?>, List<String>>(
+    save = { state ->
+        val commentItem = state.value
+        val target = commentItem?.clickTarget
+        if (commentItem == null || target == null) {
+            emptyList()
+        } else {
+            listOf(
+                ZhihuJson.json.encodeToString(commentItem.item),
+                ZhihuJson.json.encodeToString(target),
+            )
+        }
+    },
+    restore = { saved ->
+        mutableStateOf(
+            if (saved.size != 2) {
+                null
+            } else {
+                runCatching {
+                    CommentItem(
+                        item = ZhihuJson.json.decodeFromString<DataHolder.Comment>(saved[0]),
+                        clickTarget = ZhihuJson.json.decodeFromString<CommentHolder>(saved[1]),
+                    )
+                }.getOrNull()
+            },
+        )
+    },
+)
 
 private fun commentContentStateKey(content: NavDestination): String = when (content) {
     is Article -> "article:${content.type}:${content.id}"


### PR DESCRIPTION
## 修改内容

- 将当前子评论目标和父评论快照保存到返回栈可恢复状态
- 保存子评论列表滚动位置，并在异步回复数据加载后重新应用
- 主动关闭评论区时清理子评论状态，外部导航返回时恢复原上下文
- 增加覆盖“进入子评论、深滚动、跳转用户页、返回原位”的回归测试

## 根因

总评论弹层开关和根评论列表位置已经使用 `rememberSaveable`，但当前子评论目标仍由普通 `remember` 持有。跳转到其他页面后评论宿主离开组合，返回时子评论目标丢失，只能恢复总评论列表。子评论 ViewModel 异步重建时还会把提前恢复的列表状态压回顶部，因此需要在回复数据到达后重新应用保存的位置。

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew assembleLiteDebugAndroidTest`
- `./gradlew ktlintFormat`
- Pixel AVD 定向运行 `CommentScreenInstrumentedTest`：6/6 通过
- 用户已完成实际验证

Fixes #572