### PR TITLE
feat: 底栏默认material风格并取消设置选项

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ZhihuMainNavigationInstrumentedTest.kt
@@ -251,7 +251,6 @@ class ZhihuMainNavigationInstrumentedTest {
             putString(START_DESTINATION_PREFERENCE_KEY, startDestination)
             putStringSet(BOTTOM_BAR_ITEMS_PREFERENCE_KEY, bottomBarItems)
             putBoolean("duo3_home_account", false)
-            putBoolean("duo3_nav_style", false)
             putBoolean("bottomBarTapScrollToTop", false)
             putBoolean("autoHideBottomBar", false)
         }

--- a/app/src/main/java/com/github/zly2006/zhihu/ui/ZhihuMainAndroidState.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/ui/ZhihuMainAndroidState.kt
@@ -44,7 +44,7 @@ import com.github.zly2006.zhihu.ui.subscreens.resolveValidStartDestinationKey
 /**
  * 读取 Android SharedPreferences 中会影响主壳的设置快照。
  *
- * 这些设置决定底部栏项目、启动页、Duo3 底栏样式和自动隐藏行为。设置页退出后会重新读取这份快照，
+ * 这些设置决定底部栏项目、启动页和自动隐藏行为。设置页退出后会重新读取这份快照，
  * 因此新增主壳设置时要同步这里和 Desktop 的读取逻辑。
  */
 @Composable
@@ -72,7 +72,6 @@ fun rememberAndroidZhihuMainPreferenceState(): ZhihuMainPreferenceState {
         )
         ZhihuMainPreferenceSnapshot(
             duo3HomeAccount = duo3HomeAccount,
-            duo3NavStyle = settings.getBoolean("duo3_nav_style", false),
             tapToScrollToTopEnabled = settings.getBoolean("bottomBarTapScrollToTop", true),
             autoHideBottomBar = settings.getBoolean("autoHideBottomBar", false),
             selectedBottomBarItemKeys = orderedSelectedKeys,

--- a/docs/ai-ui-design-guide.md
+++ b/docs/ai-ui-design-guide.md
@@ -127,14 +127,13 @@ URL 解析集中在 `resolveContent()`。支持知乎问题、回答、文章、
 
 ## 123Duo3 UI/UX 开关
 
-`duo3_all` 是批量开关。开启时会写入 `duo3_home_account`、`duo3_nav_style`、`duo3_card_appearance`、`duo3_card_layout`、`duo3_article_bar`、`duo3_article_actions`，并关闭 `showRefreshFab` 和 `buttonSkipAnswer`。
+`duo3_all` 是批量开关。开启时会写入 `duo3_home_account`、`duo3_card_appearance`、`duo3_card_layout`、`duo3_article_bar`、`duo3_article_actions`，并关闭 `showRefreshFab` 和 `buttonSkipAnswer`。底部导航栏统一使用 Material 样式，不再提供单独开关。
 
 各子开关影响:
 
 | key | 影响 |
 | --- | --- |
 | `duo3_home_account` | 主页头像承接账号入口，底栏账号项规则变化，账号页可能显示历史快捷方式 |
-| `duo3_nav_style` | 底栏高度、标签显示、图标和选中样式变化 |
 | `duo3_card_appearance` | Feed 卡片圆角、背景和阴影变化 |
 | `duo3_card_layout` | Feed 卡片作者、图片、摘要行数和字体排版变化 |
 | `duo3_card_large_title` | `duo3_card_layout` 开启后控制标题字号 |

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
@@ -436,7 +436,6 @@ enum class TtsState(
  */
 data class ZhihuMainPreferenceSnapshot(
     val duo3HomeAccount: Boolean,
-    val duo3NavStyle: Boolean,
     val tapToScrollToTopEnabled: Boolean,
     val autoHideBottomBar: Boolean,
     val selectedBottomBarItemKeys: List<String>,
@@ -455,7 +454,6 @@ class ZhihuMainPreferenceState(
     private var snapshot by mutableStateOf(readSnapshot())
 
     val duo3HomeAccount: Boolean get() = snapshot.duo3HomeAccount
-    val duo3NavStyle: Boolean get() = snapshot.duo3NavStyle
     val tapToScrollToTopEnabled: Boolean get() = snapshot.tapToScrollToTopEnabled
     val autoHideBottomBar: Boolean get() = snapshot.autoHideBottomBar
     val selectedBottomBarItemKeys: List<String> get() = snapshot.selectedBottomBarItemKeys

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -46,10 +46,8 @@ import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.ManageAccounts
 import androidx.compose.material.icons.filled.Newspaper
-import androidx.compose.material.icons.filled.PersonAddAlt1
 import androidx.compose.material.icons.filled.Whatshot
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -69,16 +67,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavDestination.Companion.hierarchy
@@ -188,7 +183,6 @@ fun ZhihuMain(
 ) {
     val bottomPadding = ScaffoldDefaults.contentWindowInsets.asPaddingValues().calculateBottomPadding()
     val duo3HomeAccount = preferenceState.duo3HomeAccount
-    val duo3NavStyle = preferenceState.duo3NavStyle
     val tapToScrollToTopEnabled = preferenceState.tapToScrollToTopEnabled
     val autoHideBottomBar = preferenceState.autoHideBottomBar
     val selectedBottomBarItemKeys = preferenceState.selectedBottomBarItemKeys
@@ -224,7 +218,7 @@ fun ZhihuMain(
 
     val allBottomBarItems = listOf(
         Triple(Home, "主页", Icons.Filled.Home),
-        Triple(Follow, "关注", if (duo3NavStyle) Icons.Filled.Group else Icons.Filled.PersonAddAlt1),
+        Triple(Follow, "关注", Icons.Filled.Group),
         Triple(HotList, "热榜", Icons.Filled.Whatshot),
         Triple(Daily, "日报", Icons.Filled.Newspaper),
         Triple(OnlineHistory, "历史", Icons.Filled.History),
@@ -326,7 +320,7 @@ fun ZhihuMain(
                     NavigationBar(
                         containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                         modifier = Modifier.height(
-                            (if (duo3NavStyle) 64.dp else 56.dp) + bottomPadding,
+                            64.dp + bottomPadding,
                         ),
                     ) {
                         @Composable
@@ -345,41 +339,22 @@ fun ZhihuMain(
                                         scrollToTopTrigger++
                                     }
                                 },
-                                label = {
-                                    if (duo3NavStyle) {
-                                        Text(label)
-                                    } else {
-                                        Text(
-                                            label,
-                                            style = TextStyle(
-                                                fontSize = 9.sp,
-                                                color = LocalContentColor.current.copy(alpha = 0.6f),
-                                            ),
-                                        )
-                                    }
-                                },
-                                alwaysShowLabel = duo3NavStyle,
-                                colors = if (duo3NavStyle) {
-                                    if (!isDarkTheme) {
-                                        NavigationBarItemDefaults.colors().copy(
-                                            selectedIndicatorColor =
-                                                MaterialTheme.colorScheme.secondaryContainer
-                                                    .copy(alpha = 0.92f)
-                                                    .compositeOver(MaterialTheme.colorScheme.secondary),
-                                        )
-                                    } else {
-                                        NavigationBarItemDefaults.colors()
-                                    }
-                                } else {
-                                    NavigationBarItemDefaults.colors(
-                                        selectedIconColor = Color(0xff66ccff),
-                                        indicatorColor = Color.Transparent,
+                                label = { Text(label) },
+                                alwaysShowLabel = true,
+                                colors = if (!isDarkTheme) {
+                                    NavigationBarItemDefaults.colors().copy(
+                                        selectedIndicatorColor =
+                                            MaterialTheme.colorScheme.secondaryContainer
+                                                .copy(alpha = 0.92f)
+                                                .compositeOver(MaterialTheme.colorScheme.secondary),
                                     )
+                                } else {
+                                    NavigationBarItemDefaults.colors()
                                 },
                                 icon = {
                                     Icon(icon, contentDescription = label)
                                 },
-                                modifier = (if (duo3NavStyle) Modifier.padding(top = 4.dp) else Modifier).testTag(tag),
+                                modifier = Modifier.padding(top = 4.dp).testTag(tag),
                             )
                         }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
@@ -1315,7 +1315,6 @@ fun AppearanceSettingsScreen(
 
             // 先声明所有子开关状态，以便主开关可以批量操作
             val duo3All = remember { mutableStateOf(settings.getBoolean("duo3_all", false)) }
-            val duo3NavStyle = remember { mutableStateOf(settings.getBoolean("duo3_nav_style", false)) }
             val duo3CardAppearance = remember { mutableStateOf(settings.getBoolean("duo3_card_appearance", false)) }
             val duo3CardLayout = remember { mutableStateOf(settings.getBoolean("duo3_card_layout", false)) }
             val duo3CardLargeTitle = remember {
@@ -1326,7 +1325,6 @@ fun AppearanceSettingsScreen(
 
             fun enableAllSubs() {
                 settings.putBoolean("duo3_home_account", true)
-                settings.putBoolean("duo3_nav_style", true)
                 settings.putBoolean("duo3_card_appearance", true)
                 settings.putBoolean("duo3_card_layout", true)
                 settings.putBoolean("duo3_article_bar", true)
@@ -1334,7 +1332,6 @@ fun AppearanceSettingsScreen(
                 settings.putBoolean("showRefreshFab", false)
                 settings.putBoolean("buttonSkipAnswer", false)
                 duo3HomeAccount.value = true
-                duo3NavStyle.value = true
                 duo3CardAppearance.value = true
                 duo3CardLayout.value = true
                 duo3ArticleBar.value = true
@@ -1352,13 +1349,11 @@ fun AppearanceSettingsScreen(
 
             fun disableAllSubs() {
                 settings.putBoolean("duo3_home_account", false)
-                settings.putBoolean("duo3_nav_style", false)
                 settings.putBoolean("duo3_card_appearance", false)
                 settings.putBoolean("duo3_card_layout", false)
                 settings.putBoolean("duo3_article_bar", false)
                 settings.putBoolean("duo3_article_actions", false)
                 duo3HomeAccount.value = false
-                duo3NavStyle.value = false
                 duo3CardAppearance.value = false
                 duo3CardLayout.value = false
                 duo3ArticleBar.value = false
@@ -1420,16 +1415,6 @@ fun AppearanceSettingsScreen(
                             selectedBottomBarItemKeys.value
                         }
                         persistBottomBarSelection(updatedSelection, it)
-                    },
-                )
-
-                SettingItemWithSwitch(
-                    title = { Text("底部导航栏：改为 Material 样式") },
-                    description = { Text("移除自定义样式；更改「关注」按钮图标。") },
-                    checked = duo3NavStyle.value,
-                    onCheckedChange = {
-                        duo3NavStyle.value = it
-                        settings.putBoolean("duo3_nav_style", it)
                     },
                 )
 

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/DesktopZhihuMain.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/DesktopZhihuMain.kt
@@ -262,7 +262,6 @@ private fun rememberDesktopZhihuMainPreferenceState(): ZhihuMainPreferenceState 
         )
         ZhihuMainPreferenceSnapshot(
             duo3HomeAccount = duo3HomeAccount,
-            duo3NavStyle = settings.getBoolean("duo3_nav_style", false),
             tapToScrollToTopEnabled = settings.getBoolean("bottomBarTapScrollToTop", true),
             autoHideBottomBar = settings.getBoolean("autoHideBottomBar", false),
             selectedBottomBarItemKeys = orderedSelectedKeys,


### PR DESCRIPTION
## 改动内容

- 底部导航栏统一使用 Material 样式，并固定使用对应高度、标签、图标和选中态
- 移除 `duo3_nav_style` 设置项、偏好读取和 `duo3_all` 对该键的批量写入
- 同步精简 Android、Desktop 主壳设置快照与项目 UI 指南

## 原因与影响

底栏 Material 样式已经成为默认产品行为，不再需要保留旧样式分支和用户开关。升级后历史偏好值不会继续影响底栏外观，Android 与 Desktop 行为保持一致。

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `./gradlew :shared:compileKotlinJvm`
- `git diff --check`