### PR TITLE
feat: 支持分享 Markdown 正文

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
@@ -640,6 +640,17 @@ fun ArticleActionsMenu(
         Spacer(modifier = Modifier.height(12.dp))
 
         MenuActionButton(
+            icon = Icons.Filled.Share,
+            text = "分享 Markdown 正文",
+            onClick = {
+                onDismissRequest()
+                shareRuntime.directShare(article, viewModel.convertToMarkdown())
+            },
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        MenuActionButton(
             icon = Icons.AutoMirrored.Filled.Comment,
             text = "总结本文",
             onClick = {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ArticleScreen.kt
@@ -513,6 +513,7 @@ fun ArticleActionsMenu(
     val openArticleInBrowser = rememberArticleBrowserOpener()
     val shareRuntime = rememberShareDialogRuntime()
     val coroutineScope = rememberCoroutineScope()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     @Composable
     fun MenuActionButton(
@@ -640,17 +641,6 @@ fun ArticleActionsMenu(
         Spacer(modifier = Modifier.height(12.dp))
 
         MenuActionButton(
-            icon = Icons.Filled.Share,
-            text = "分享 Markdown 正文",
-            onClick = {
-                onDismissRequest()
-                shareRuntime.directShare(article, viewModel.convertToMarkdown())
-            },
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        MenuActionButton(
             icon = Icons.AutoMirrored.Filled.Comment,
             text = "总结本文",
             onClick = {
@@ -712,6 +702,17 @@ fun ArticleActionsMenu(
         Spacer(modifier = Modifier.height(12.dp))
 
         MenuActionButton(
+            icon = Icons.Filled.Share,
+            text = "分享 Markdown 正文",
+            onClick = {
+                onDismissRequest()
+                shareRuntime.directShare(article, viewModel.convertToMarkdown())
+            },
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        MenuActionButton(
             icon = Icons.Outlined.DesktopWindows,
             text = "在电脑中打开（我计划使用浏览器插件实现，还在写，点击后请手动前往收藏夹打开）",
             onClick = {
@@ -727,7 +728,10 @@ fun ArticleActionsMenu(
     }
 
     if (showMenu) {
-        MyModalBottomSheet(onDismissRequest) {
+        MyModalBottomSheet(
+            onDismissRequest = onDismissRequest,
+            sheetState = sheetState,
+        ) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()


### PR DESCRIPTION
## 改动

- 在文章一级菜单中新增「分享 Markdown 正文」，放在「导出文章」下方。
- 复用现有 `convertToMarkdown()` 生成逻辑，并通过已有标准文本分享运行时调起 Android 系统分享面板。
- 文章操作菜单跳过半展开状态，打开后直接完整展开。
- 不新增网络请求、状态、模型、设置项或测试。

## 验证

- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process assembleLiteDebug`
- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process ktlintFormat`
- 此前已在本地 Pixel_6_Pro API 31 AVD 安装 Lite Debug APK，确认 Markdown 正文可进入 Android 系统分享面板，分享内容以 Markdown 标题、作者信息和分隔线开头。

系统分享截图来自本 PR 前一提交的实际 Lite Debug APK；本次后续提交只调整菜单项位置和弹层展开方式，未改变 Markdown 生成或系统分享链路。按要求未重新进行设备截图验证。AVD 的账号 ticket 已过期，因此页面背景使用了应用的内容加载失败兜底，不将该截图视为完整正文渲染验证。

![Markdown 正文进入 Android 系统分享面板](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-589/android-system-share-markdown.png)

Resolves #524
