### PR TITLE
fix: 修复划线评论区无法发布评论

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/RenderMarkdown.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/RenderMarkdown.kt
@@ -369,7 +369,7 @@ private fun RenderMarkdownDocument(
     CommentScreenComponent(
         showComments = segmentCommentTarget != null,
         onDismiss = { segmentCommentTarget = null },
-        content = segmentCommentTarget ?: SegmentCommentHolder("dummy", "dummy", "dummy"),
+        content = segmentCommentTarget ?: SegmentCommentHolder("dummy", "dummy", "dummy", "", "", 0, 0),
     )
     segmentActionSheetState?.let { state ->
         SegmentActionSheet(state)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/navigation/NavDestination.kt
@@ -223,6 +223,10 @@ data class SegmentCommentHolder(
     val contentId: String,
     val contentType: String,
     val segmentId: String,
+    val segmentContent: String,
+    val paragraphId: String,
+    val startOffset: Int,
+    val endOffset: Int,
 ) : NavDestination
 
 @Serializable

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/SegmentHighlight.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/SegmentHighlight.kt
@@ -318,5 +318,9 @@ private fun SegmentHighlightSpan.toSegmentCommentHolder(): SegmentCommentHolder?
         contentId = contentId,
         contentType = contentType,
         segmentId = segmentId,
+        segmentContent = text,
+        paragraphId = paragraphId ?: return null,
+        startOffset = startOffset ?: return null,
+        endOffset = endOffset ?: return null,
     )
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/RootCommentViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/RootCommentViewModel.kt
@@ -37,6 +37,7 @@ import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -62,7 +63,7 @@ class RootCommentViewModel(
                 }
 
                 is SegmentCommentHolder -> {
-                    "https://www.zhihu.com/api/v4/comment_v5/${normalizedContentType}s/$contentId/segment/comment?segment_id=$segmentId"
+                    "https://www.zhihu.com/api/v4/comment_v5/${normalizedContentType}s/$contentId/segment/comment"
                 }
 
                 else -> ""
@@ -127,14 +128,7 @@ class RootCommentViewModel(
 
         viewModelScope.launch {
             try {
-                // Escape HTML special characters to prevent HTML injection
-                val escapedText = commentText.escapeCommentHtml()
-
-                // Use buildJsonObject to properly escape JSON special characters
-                val requestBody = buildJsonObject {
-                    put("content", "<p>$escapedText</p>")
-                    replyToCommentId?.let { put("reply_comment_id", it) }
-                }
+                val requestBody = content.buildSubmitCommentBody(commentText, replyToCommentId)
 
                 val response = environment.postSigned(content.submitCommentUrl) {
                     contentType(ContentType.Application.Json)
@@ -152,6 +146,46 @@ class RootCommentViewModel(
             } catch (e: Exception) {
                 errorMessage = "评论发送异常: ${e.message}"
             }
+        }
+    }
+}
+
+internal fun NavDestination.buildSubmitCommentBody(
+    commentText: String,
+    replyToCommentId: String?,
+): JsonObject {
+    val escapedText = commentText.escapeCommentHtml()
+    return buildJsonObject {
+        put("content", "<p>$escapedText</p>")
+        replyToCommentId?.let { put("reply_comment_id", it) }
+        if (this@buildSubmitCommentBody is SegmentCommentHolder) {
+            put("unfriendly_check", "strict")
+            put("selected_settings", buildJsonArray { })
+            put(
+                "segment",
+                buildJsonObject {
+                    put("content", segmentContent)
+                    put(
+                        "position",
+                        buildJsonObject {
+                            put(
+                                "start",
+                                buildJsonObject {
+                                    put("offset", startOffset)
+                                    put("paragraph_id", paragraphId)
+                                },
+                            )
+                            put(
+                                "end",
+                                buildJsonObject {
+                                    put("offset", endOffset)
+                                    put("paragraph_id", paragraphId)
+                                },
+                            )
+                        },
+                    )
+                },
+            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/RootCommentViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/comment/RootCommentViewModel.kt
@@ -37,7 +37,6 @@ import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -159,8 +158,7 @@ internal fun NavDestination.buildSubmitCommentBody(
         put("content", "<p>$escapedText</p>")
         replyToCommentId?.let { put("reply_comment_id", it) }
         if (this@buildSubmitCommentBody is SegmentCommentHolder) {
-            put("unfriendly_check", "strict")
-            put("selected_settings", buildJsonArray { })
+            // `unfriendly_check` 和 `selected_settings` 均为可选字段，发布段评时无需提交。
             put(
                 "segment",
                 buildJsonObject {

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/viewmodel/comment/RootCommentViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/viewmodel/comment/RootCommentViewModelTest.kt
@@ -19,7 +19,6 @@ package com.github.zly2006.zhihu.viewmodel.comment
 
 import com.github.zly2006.zhihu.navigation.SegmentCommentHolder
 import com.github.zly2006.zhihu.viewmodel.comment.RootCommentViewModel.Companion.submitCommentUrl
-import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
@@ -49,8 +48,8 @@ class RootCommentViewModelTest {
         val position = segment["position"]!!.jsonObject
 
         assertEquals("<p>，</p>", body["content"]!!.jsonPrimitive.content)
-        assertEquals("strict", body["unfriendly_check"]!!.jsonPrimitive.content)
-        assertEquals(0, body["selected_settings"]!!.jsonArray.size)
+        assertFalse("unfriendly_check" in body)
+        assertFalse("selected_settings" in body)
         assertEquals("都不能称为 Rust 的杀手级项目", segment["content"]!!.jsonPrimitive.content)
         assertEquals("22", position["start"]!!.jsonObject["offset"]!!.jsonPrimitive.content)
         assertEquals("KFR9BNtv", position["start"]!!.jsonObject["paragraph_id"]!!.jsonPrimitive.content)

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/viewmodel/comment/RootCommentViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/viewmodel/comment/RootCommentViewModelTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.viewmodel.comment
+
+import com.github.zly2006.zhihu.navigation.SegmentCommentHolder
+import com.github.zly2006.zhihu.viewmodel.comment.RootCommentViewModel.Companion.submitCommentUrl
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class RootCommentViewModelTest {
+    @Test
+    fun segmentCommentUsesBodyTargetInsteadOfQueryParameter() {
+        val target = SegmentCommentHolder(
+            contentId = "123",
+            contentType = "answer",
+            segmentId = "segment-id",
+            segmentContent = "都不能称为 Rust 的杀手级项目",
+            paragraphId = "KFR9BNtv",
+            startOffset = 22,
+            endOffset = 39,
+        )
+
+        assertEquals(
+            "https://www.zhihu.com/api/v4/comment_v5/answers/123/segment/comment",
+            target.submitCommentUrl,
+        )
+
+        val body = target.buildSubmitCommentBody("，", replyToCommentId = null)
+        val segment = body["segment"]!!.jsonObject
+        val position = segment["position"]!!.jsonObject
+
+        assertEquals("<p>，</p>", body["content"]!!.jsonPrimitive.content)
+        assertEquals("strict", body["unfriendly_check"]!!.jsonPrimitive.content)
+        assertEquals(0, body["selected_settings"]!!.jsonArray.size)
+        assertEquals("都不能称为 Rust 的杀手级项目", segment["content"]!!.jsonPrimitive.content)
+        assertEquals("22", position["start"]!!.jsonObject["offset"]!!.jsonPrimitive.content)
+        assertEquals("KFR9BNtv", position["start"]!!.jsonObject["paragraph_id"]!!.jsonPrimitive.content)
+        assertEquals("39", position["end"]!!.jsonObject["offset"]!!.jsonPrimitive.content)
+        assertEquals("KFR9BNtv", position["end"]!!.jsonObject["paragraph_id"]!!.jsonPrimitive.content)
+        assertFalse("segment_id" in body)
+    }
+}


### PR DESCRIPTION
## 改动

- 发布段评时移除 URL 中的 `segment_id` 查询参数。
- 从正文划线节点传递划线文本、段落 ID 和起止 offset，并按官方契约写入请求体的 `segment` 对象。
- 明确省略可选的 `unfriendly_check` 与 `selected_settings`，同时保留普通评论和段评读取接口的原有行为。
- 增加段评发布 URL 与 JSON 请求体的回归测试。

## 原因

此前发布段评只把现有 `segment_id` 放进查询参数，没有提交服务端创建段评所需的正文位置结构，导致写接口契约错误。

## 影响

段评发布现在会携带准确的正文片段与位置；读取现有段评仍继续使用 `segment_id`，普通评论不受影响。

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `./gradlew :app:testLiteDebugUnitTest --max-workers=2`（7 个测试通过）
- 直接加载编译产物，断言段评 POST URL、必需的 `segment` 结构以及两个可选字段均未写入

补充：尝试执行 `:shared:jvmTest` 定向用例时，测试源集被本次未修改的 `HomeFeedStartupSnapshotTest` 现有字段不匹配编译错误阻断；本次新增测试文件本身未产生编译诊断。
