### PR TITLE
feat: 支持评论输入知乎表情

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/CommentScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/CommentScreenInstrumentedTest.kt
@@ -27,10 +27,12 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -66,6 +68,9 @@ import com.github.zly2006.zhihu.ui.COMMENT_CANCEL_REPLY_TAG
 import com.github.zly2006.zhihu.ui.COMMENT_DELETE_CANCEL_TAG
 import com.github.zly2006.zhihu.ui.COMMENT_DELETE_CONFIRM_TAG
 import com.github.zly2006.zhihu.ui.COMMENT_DELETE_DIALOG_TAG
+import com.github.zly2006.zhihu.ui.COMMENT_EMOJI_BUTTON_TAG
+import com.github.zly2006.zhihu.ui.COMMENT_EMOJI_ITEM_TAG_PREFIX
+import com.github.zly2006.zhihu.ui.COMMENT_EMOJI_PICKER_TAG
 import com.github.zly2006.zhihu.ui.COMMENT_IMAGE_MENU_BROWSER_TAG
 import com.github.zly2006.zhihu.ui.COMMENT_IMAGE_MENU_OPEN_TAG
 import com.github.zly2006.zhihu.ui.COMMENT_IMAGE_MENU_SAVE_TAG
@@ -76,6 +81,7 @@ import com.github.zly2006.zhihu.ui.COMMENT_SCREEN_LIST_TAG
 import com.github.zly2006.zhihu.ui.COMMENT_SEND_BUTTON_TAG
 import com.github.zly2006.zhihu.ui.COMMENT_SORT_SCORE_TAG
 import com.github.zly2006.zhihu.ui.COMMENT_SORT_TIME_TAG
+import com.github.zly2006.zhihu.ui.CommentEmoji
 import com.github.zly2006.zhihu.ui.CommentImageMenuAction
 import com.github.zly2006.zhihu.ui.CommentScreen
 import com.github.zly2006.zhihu.ui.CommentScreenTestOverrides
@@ -180,6 +186,36 @@ class CommentScreenInstrumentedTest {
         val database = getContentFilterDatabase(composeRule.activity)
         database.blockedUserDao().clearAllUsers()
         ZhihuMockApi.install(enabled = InstrumentedTestEnvironment.isMockMode())
+    }
+
+    @Test
+    fun emojiPickerInsertsPlaceholderAtCursor() {
+        val viewModel = seedRootCommentViewModel(seedRootComments(count = 1))
+        setCommentScreen(
+            testOverrides = CommentScreenTestOverrides(
+                viewModel = viewModel,
+                commentEmojis = listOf(
+                    CommentEmoji(
+                        placeholder = "[惊喜]",
+                        inlineKey = "emoji_test",
+                    ),
+                ),
+            ),
+        )
+
+        composeRule.onNodeWithTag(COMMENT_INPUT_TAG).performTextInput("已有草稿")
+        composeRule
+            .onNodeWithTag(COMMENT_INPUT_TAG)
+            .performSemanticsAction(SemanticsActions.SetSelection) { setSelection ->
+                setSelection(0, 0, false)
+            }
+        composeRule.onNodeWithTag(COMMENT_EMOJI_BUTTON_TAG).performClick()
+        composeRule.onNodeWithTag(COMMENT_EMOJI_PICKER_TAG).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("切换到键盘").assertIsDisplayed()
+        composeRule.onNodeWithTag(COMMENT_EMOJI_ITEM_TAG_PREFIX + "[惊喜]").performClick()
+        composeRule.onNodeWithTag(COMMENT_INPUT_TAG).assertTextEquals("[惊喜]已有草稿")
+        composeRule.onNodeWithTag(COMMENT_EMOJI_BUTTON_TAG).performClick()
+        composeRule.onNodeWithContentDescription("选择表情").assertIsDisplayed()
     }
 
     @Test

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/AndroidUiRuntimes.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/AndroidUiRuntimes.kt
@@ -501,6 +501,18 @@ actual fun supportsZhihuHtmlWebView(): Boolean = true
 actual fun rememberCommentEmojiInlineContent(emojiKeys: Set<String>): Map<String, InlineTextContent> =
     remember(emojiKeys) { createEmojiInlineContent(emojiKeys) }
 
+@Composable
+actual fun rememberCommentEmojis(): List<CommentEmoji> {
+    val placeholders by EmojiManager.placeholders.collectAsState()
+    return remember(placeholders) {
+        placeholders.mapNotNull { placeholder ->
+            commentEmojiInlineKey(placeholder)?.let { inlineKey ->
+                CommentEmoji(placeholder = placeholder, inlineKey = inlineKey)
+            }
+        }
+    }
+}
+
 actual fun commentEmojiInlineKey(placeholder: String): String? {
     val emojiPath = EmojiManager.getEmojiPath(placeholder) ?: return null
     val emojiFileName = emojiPath.substringAfterLast('/')

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/util/EmojiManager.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/util/EmojiManager.kt
@@ -21,6 +21,8 @@ import android.content.Context
 import android.util.Base64
 import android.util.Log
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -58,6 +60,11 @@ object EmojiManager {
 
     // emoji文件名到本地缓存路径的映射
     private val emojiCache = mutableMapOf<String, String>()
+
+    private val mutablePlaceholders = MutableStateFlow<List<String>>(emptyList())
+
+    /** 当前已经缓存、可以用于输入和展示的表情占位符。 */
+    val placeholders = mutablePlaceholders.asStateFlow()
 
     private var isInitialized = false
 
@@ -165,6 +172,7 @@ object EmojiManager {
 
             emojiMapping.clear()
             emojiMapping.putAll(newMapping)
+            mutablePlaceholders.value = newMapping.keys.toList()
 
             Log.i(TAG, "Downloaded and cached $downloadCount emojis")
         } finally {
@@ -190,6 +198,7 @@ object EmojiManager {
                 emojiCache[fileName] = file.absolutePath
             }
         }
+        mutablePlaceholders.value = mapping.filterValues(emojiCache::containsKey).keys.toList()
     }
 
     /**

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CommentScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CommentScreen.kt
@@ -51,6 +51,9 @@ import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
@@ -67,6 +70,8 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.ThumbUp
+import androidx.compose.material.icons.outlined.EmojiEmotions
+import androidx.compose.material.icons.outlined.Keyboard
 import androidx.compose.material.icons.outlined.ThumbUp
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -95,6 +100,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -110,9 +118,11 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -140,6 +150,7 @@ import com.github.zly2006.zhihu.shared.platform.rememberImageSharer
 import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.util.twoDigitString
 import com.github.zly2006.zhihu.shared.viewmodel.CommentItem
+import com.github.zly2006.zhihu.ui.components.replaceSelection
 import com.github.zly2006.zhihu.ui.subscreens.PREF_FONT_SIZE
 import com.github.zly2006.zhihu.ui.subscreens.PREF_LINE_HEIGHT
 import com.github.zly2006.zhihu.viewmodel.comment.BaseCommentViewModel
@@ -165,6 +176,9 @@ const val COMMENT_SCREEN_LIST_TAG = "comment_screen_list"
 const val COMMENT_REPLY_BANNER_TAG = "comment_reply_banner"
 const val COMMENT_CANCEL_REPLY_TAG = "comment_cancel_reply"
 const val COMMENT_INPUT_TAG = "comment_input"
+const val COMMENT_EMOJI_BUTTON_TAG = "comment_emoji_button"
+const val COMMENT_EMOJI_PICKER_TAG = "comment_emoji_picker"
+const val COMMENT_EMOJI_ITEM_TAG_PREFIX = "comment_emoji_item_"
 const val COMMENT_SEND_BUTTON_TAG = "comment_send_button"
 const val COMMENT_SORT_SCORE_TAG = "comment_sort_score"
 const val COMMENT_SORT_TIME_TAG = "comment_sort_time"
@@ -187,6 +201,7 @@ data class CommentScreenTestOverrides(
     val viewModel: BaseCommentViewModel? = null,
     val onArchiveComment: ((CommentModel) -> Unit)? = null,
     val onImageMenuAction: ((CommentImageMenuAction, String) -> Unit)? = null,
+    val commentEmojis: List<CommentEmoji>? = null,
 )
 
 @Composable
@@ -433,12 +448,40 @@ fun CommentScreen(
     val resolvedContent = content()
     var isSending by remember { mutableStateOf(false) }
     var replyToComment by remember { mutableStateOf<CommentModel?>(null) }
+    var showEmojiPicker by remember { mutableStateOf(false) }
     var commentPendingDeletion by remember { mutableStateOf<CommentModel?>(null) }
     var isDeletingComment by remember { mutableStateOf(false) }
     var deleteCommentError by remember { mutableStateOf<String?>(null) }
     val viewModelKey = commentViewModelKey(resolvedContent)
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
+    val commentInputFocusRequester = remember { FocusRequester() }
+    var commentFieldValue by remember(resolvedContent) {
+        mutableStateOf(
+            TextFieldValue(
+                text = commentInput,
+                selection = TextRange(commentInput.length),
+            ),
+        )
+    }
+    val availableCommentEmojis = rememberCommentEmojis()
+    val commentEmojis = testOverrides?.commentEmojis ?: availableCommentEmojis
+    val emojiInlineContent = rememberCommentEmojiInlineContent(
+        remember(commentEmojis) { commentEmojis.mapTo(mutableSetOf(), CommentEmoji::inlineKey) },
+    )
+
+    LaunchedEffect(commentInput) {
+        if (commentInput != commentFieldValue.text) {
+            commentFieldValue = TextFieldValue(
+                text = commentInput,
+                selection = TextRange(commentInput.length),
+            )
+        }
+    }
+
+    PlatformBackHandler(enabled = showEmojiPicker) {
+        showEmojiPicker = false
+    }
 
     // 根据内容类型选择合适的ViewModel
     val viewModel: BaseCommentViewModel = testOverrides?.viewModel ?: when (resolvedContent) {
@@ -569,19 +612,21 @@ fun CommentScreen(
 
     // 提交评论函数
     fun submitComment() {
-        if (commentInput.isBlank() || isSending) return
+        if (commentFieldValue.text.isBlank() || isSending) return
 
         isSending = true
         viewModel.submitComment(
             content = content(),
-            commentText = commentInput,
+            commentText = commentFieldValue.text,
             environment = paginationEnvironment,
             replyToCommentId = replyToComment?.item?.id,
         ) {
             focusManager.clearFocus(force = true)
             keyboardController?.hide()
+            commentFieldValue = TextFieldValue("")
             onCommentInputChange("")
             replyToComment = null
+            showEmojiPicker = false
             isSending = false
             coroutineScope.launch {
                 listState.animateScrollToItem(
@@ -970,15 +1015,57 @@ fun CommentScreen(
                                 .padding(8.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
+                            IconButton(
+                                onClick = {
+                                    if (showEmojiPicker) {
+                                        showEmojiPicker = false
+                                        commentInputFocusRequester.requestFocus()
+                                        keyboardController?.show()
+                                    } else {
+                                        focusManager.clearFocus(force = true)
+                                        keyboardController?.hide()
+                                        showEmojiPicker = true
+                                    }
+                                },
+                                modifier = Modifier
+                                    .size(40.dp)
+                                    .testTag(COMMENT_EMOJI_BUTTON_TAG),
+                            ) {
+                                Icon(
+                                    imageVector = if (showEmojiPicker) {
+                                        Icons.Outlined.Keyboard
+                                    } else {
+                                        Icons.Outlined.EmojiEmotions
+                                    },
+                                    contentDescription = if (showEmojiPicker) {
+                                        "切换到键盘"
+                                    } else {
+                                        "选择表情"
+                                    },
+                                    tint = if (showEmojiPicker) {
+                                        MaterialTheme.colorScheme.primary
+                                    } else {
+                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                    },
+                                )
+                            }
+                            Spacer(modifier = Modifier.width(4.dp))
+
                             BasicTextField(
-                                value = commentInput,
-                                onValueChange = onCommentInputChange,
+                                value = commentFieldValue,
+                                onValueChange = {
+                                    commentFieldValue = it
+                                    onCommentInputChange(it.text)
+                                },
                                 modifier = Modifier
                                     .weight(1f)
-                                    .testTag(COMMENT_INPUT_TAG),
+                                    .focusRequester(commentInputFocusRequester)
+                                    .onFocusChanged {
+                                        if (it.isFocused) showEmojiPicker = false
+                                    }.testTag(COMMENT_INPUT_TAG),
                                 decorationBox = { inner ->
                                     Box {
-                                        if (commentInput.isEmpty()) {
+                                        if (commentFieldValue.text.isEmpty()) {
                                             Text(
                                                 if (replyToComment != null) {
                                                     "回复 ${replyToComment?.item?.author?.name}..."
@@ -1003,7 +1090,7 @@ fun CommentScreen(
                                 modifier = Modifier
                                     .size(24.dp)
                                     .testTag(COMMENT_SEND_BUTTON_TAG),
-                                enabled = !isSending && commentInput.isNotBlank(),
+                                enabled = !isSending && commentFieldValue.text.isNotBlank(),
                             ) {
                                 if (isSending) {
                                     CircularProgressIndicator(
@@ -1015,12 +1102,71 @@ fun CommentScreen(
                                     Icon(
                                         Icons.AutoMirrored.Outlined.Send,
                                         contentDescription = "发送评论",
-                                        tint = if (commentInput.isNotBlank()) {
+                                        tint = if (commentFieldValue.text.isNotBlank()) {
                                             MaterialTheme.colorScheme.primary
                                         } else {
                                             MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
                                         },
                                     )
+                                }
+                            }
+                        }
+
+                        AnimatedVisibility(
+                            visible = showEmojiPicker,
+                            enter = expandVertically() + fadeIn(),
+                            exit = shrinkVertically() + fadeOut(),
+                        ) {
+                            if (commentEmojis.isEmpty()) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(240.dp)
+                                        .testTag(COMMENT_EMOJI_PICKER_TAG),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    Text(
+                                        text = "暂无可用表情",
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            } else {
+                                LazyVerticalGrid(
+                                    columns = GridCells.Adaptive(minSize = 48.dp),
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(240.dp)
+                                        .testTag(COMMENT_EMOJI_PICKER_TAG),
+                                    contentPadding = PaddingValues(8.dp),
+                                ) {
+                                    items(
+                                        items = commentEmojis,
+                                        key = CommentEmoji::placeholder,
+                                    ) { emoji ->
+                                        IconButton(
+                                            onClick = {
+                                                val updatedValue = commentFieldValue.replaceSelection(
+                                                    insert = emoji.placeholder,
+                                                    cursorOffsetInInsert = emoji.placeholder.length,
+                                                )
+                                                commentFieldValue = updatedValue
+                                                onCommentInputChange(updatedValue.text)
+                                            },
+                                            modifier = Modifier
+                                                .size(48.dp)
+                                                .testTag(COMMENT_EMOJI_ITEM_TAG_PREFIX + emoji.placeholder),
+                                        ) {
+                                            Text(
+                                                text = remember(emoji) {
+                                                    buildAnnotatedString {
+                                                        appendInlineContent(emoji.inlineKey, emoji.placeholder)
+                                                    }
+                                                },
+                                                inlineContent = emojiInlineContent,
+                                                fontSize = 28.sp,
+                                            )
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
@@ -570,6 +570,14 @@ expect fun rememberHomeLoginRequester(): () -> Unit
 @Composable
 expect fun rememberCommentEmojiInlineContent(emojiKeys: Set<String>): Map<String, InlineTextContent>
 
+data class CommentEmoji(
+    val placeholder: String,
+    val inlineKey: String,
+)
+
+@Composable
+expect fun rememberCommentEmojis(): List<CommentEmoji>
+
 expect fun commentEmojiInlineKey(placeholder: String): String?
 
 expect fun Modifier.commentSelectionWorkaround(): Modifier

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/JvmUiRuntimes.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/ui/JvmUiRuntimes.kt
@@ -189,6 +189,16 @@ actual fun rememberCommentEmojiInlineContent(emojiKeys: Set<String>): Map<String
             }.toMap()
     }
 
+@Composable
+actual fun rememberCommentEmojis(): List<CommentEmoji> = remember {
+    desktopEmojiMapping().mapNotNull { (placeholder, fileName) ->
+        val inlineKey = "emoji_$fileName"
+        desktopEmojiFileByInlineKey(inlineKey)?.let {
+            CommentEmoji(placeholder = placeholder, inlineKey = inlineKey)
+        }
+    }
+}
+
 actual fun commentEmojiInlineKey(placeholder: String): String? =
     desktopEmojiMapping()[placeholder]?.let { fileName -> "emoji_$fileName" }
 

--- a/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/ui/NativeUiRuntimes.kt
+++ b/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/ui/NativeUiRuntimes.kt
@@ -107,6 +107,9 @@ actual fun Modifier.articleMarkdownSelectionWorkaround(): Modifier = this
 @Composable
 actual fun rememberCommentEmojiInlineContent(emojiKeys: Set<String>): Map<String, InlineTextContent> = emptyMap() // TODO: iOS 表情内联内容
 
+@Composable
+actual fun rememberCommentEmojis(): List<CommentEmoji> = emptyList() // TODO: iOS 表情选择
+
 actual fun commentEmojiInlineKey(placeholder: String): String? = null // TODO: iOS 表情内联 key
 
 actual fun Modifier.commentSelectionWorkaround(): Modifier = this


### PR DESCRIPTION
## 改动内容

- 在评论输入框左侧增加表情按钮，点击后收起系统键盘并展开知乎表情选择面板。
- 面板展开时将入口切换为键盘图标，再次点击可恢复输入焦点和系统键盘。
- 复用应用启动时已有的表情缓存，不在评论页增加网络请求；选择表情后按当前光标或选区插入对应占位符。
- 为 Android、Desktop 和 Native 补齐跨平台表情数据接口，并增加光标插入与模式切换回归测试。

## 实现原因

当前评论输入只能手动输入类似 `[惊喜]` 的表情代码，缺少可发现、可直接选择的输入入口。本改动复用现有表情下载和渲染能力，补齐评论发布前的选择交互。

## 用户影响

- 用户可以直接浏览并选择知乎表情，不再需要记忆表情代码。
- 评论草稿、回复目标和发送接口保持原有语义。
- 评论页不会因为打开表情面板产生额外请求。

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew :app:assembleLiteDebugAndroidTest`
- `./gradlew :shared:compileKotlinJvm`
- `./gradlew ktlintFormat`
- Android 15 真机验证：IME 收起、表情面板展示、表情占位符插入。
- API 35 AVD 定向运行 `CommentScreenInstrumentedTest#emojiPickerInsertsPlaceholderAtCursor`：`OK (1 test)`。

Closes #598
