### PR TITLE
feat: 支持删除单条在线历史记录

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/OnlineHistoryScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/OnlineHistoryScreenInstrumentedTest.kt
@@ -19,6 +19,7 @@ package com.github.zly2006.zhihu
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -27,6 +28,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.zly2006.zhihu.navigation.History
 import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
+import com.github.zly2006.zhihu.shared.data.ZhihuJson
 import com.github.zly2006.zhihu.test.MainActivityComposeRule
 import com.github.zly2006.zhihu.test.RecordingNavigator
 import com.github.zly2006.zhihu.test.performVerticalSwipeCycle
@@ -35,7 +37,18 @@ import com.github.zly2006.zhihu.test.resetAppPreferences
 import com.github.zly2006.zhihu.test.setScreenContent
 import com.github.zly2006.zhihu.ui.ONLINE_HISTORY_OVERFLOW_TAG
 import com.github.zly2006.zhihu.ui.OnlineHistoryScreen
+import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.feed.OnlineHistoryViewModel
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -87,6 +100,97 @@ class OnlineHistoryScreenInstrumentedTest {
             assertEquals(0, navigator.destinations.size)
             assertEquals(0, navigator.backCount)
         }
+    }
+
+    @Test
+    fun historyItemOverflowOffersSingleDeleteAction() {
+        val navigator = setOnlineHistoryScreen()
+
+        // The toolbar is the first "更多选项" node; the next one belongs to the first visible
+        // history card. Single-record deletion lives in that existing card menu rather than the
+        // global toolbar menu.
+        composeRule.onAllNodesWithContentDescription("更多选项")[1].performClick()
+        composeRule.onNodeWithText("删除").assertIsDisplayed()
+        composeRule.pressSystemBack()
+        composeRule.onNodeWithText("删除").assertDoesNotExist()
+
+        composeRule.runOnIdle {
+            assertEquals(0, navigator.destinations.size)
+            assertEquals(0, navigator.backCount)
+        }
+    }
+
+    @Test
+    fun singleDeletePostsDecodedPairAndRemovesRowAfterSuccess() {
+        val client = HttpClient(
+            MockEngine { request ->
+                assertEquals(HttpMethod.Post, request.method)
+                assertEquals("https://api.zhihu.com/read_history/batch_del", request.url.toString())
+                assertEquals(
+                    Json.parseToJsonElement(
+                        """{"pairs":[{"content_token":"123","content_type":"answer"}],"clear":false}""",
+                    ),
+                    Json.parseToJsonElement((request.body as TextContent).text),
+                )
+                respond("", HttpStatusCode.OK)
+            },
+        )
+        val response = ZhihuJson.json
+            .parseToJsonElement(
+                """
+                {
+                  "data": [
+                    {
+                      "card_type": "single_card",
+                      "data": {
+                        "header": {
+                          "icon": "https://example.com/icon.png",
+                          "title": "待删除的在线历史"
+                        },
+                        "action": {
+                          "type": "router",
+                          "url": "zhihu://answers/123"
+                        },
+                        "extra": {
+                          "content_token": "123",
+                          "content_type": "answer",
+                          "read_time": 1716120000,
+                          "question_token": "456"
+                        }
+                      }
+                    }
+                  ],
+                  "paging": {
+                    "is_end": true,
+                    "is_start": true,
+                    "totals": 1
+                  }
+                }
+                """.trimIndent(),
+            ).jsonObject
+        val environment = object : PaginationEnvironment {
+            override fun httpClient() = client
+
+            override fun authenticatedCookies() = emptyMap<String, String>()
+
+            override suspend fun fetchJson(url: String, include: String): JsonObject = response
+
+            override suspend fun handleFetchFailure(tag: String?, error: Exception) = Unit
+        }
+        val viewModel = OnlineHistoryViewModel()
+
+        composeRule.activity.runOnUiThread {
+            viewModel.refresh(environment)
+        }
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            viewModel.displayItems.singleOrNull()?.title == "待删除的在线历史"
+        }
+
+        runBlocking {
+            viewModel.deleteItem(environment, viewModel.displayItems.single())
+        }
+
+        assertEquals(0, viewModel.displayItems.size)
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/OnlineHistoryScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/OnlineHistoryScreenInstrumentedTest.kt
@@ -104,20 +104,13 @@ class OnlineHistoryScreenInstrumentedTest {
 
     @Test
     fun historyItemOverflowOffersSingleDeleteAction() {
-        val navigator = setOnlineHistoryScreen()
+        setOnlineHistoryScreen()
 
         // The toolbar is the first "更多选项" node; the next one belongs to the first visible
         // history card. Single-record deletion lives in that existing card menu rather than the
         // global toolbar menu.
         composeRule.onAllNodesWithContentDescription("更多选项")[1].performClick()
-        composeRule.onNodeWithText("删除").assertIsDisplayed()
-        composeRule.pressSystemBack()
-        composeRule.onNodeWithText("删除").assertDoesNotExist()
-
-        composeRule.runOnIdle {
-            assertEquals(0, navigator.destinations.size)
-            assertEquals(0, navigator.backCount)
-        }
+        composeRule.onNodeWithText("删除该条历史记录").assertIsDisplayed()
     }
 
     @Test

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/shared/data/OnlineHistory.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/shared/data/OnlineHistory.kt
@@ -72,3 +72,8 @@ data class OnlineHistoryExtra(
     val readTime: Long,
     val questionToken: String,
 )
+
+internal data class OnlineHistoryDeletePair(
+    val contentToken: String,
+    val contentType: String,
+)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/FollowScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/FollowScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -73,6 +74,9 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import com.github.zly2006.zhihu.navigation.LocalNavigator
 import com.github.zly2006.zhihu.navigation.Person
+import com.github.zly2006.zhihu.shared.data.DataHolder
+import com.github.zly2006.zhihu.shared.data.Feed
+import com.github.zly2006.zhihu.shared.data.target
 import com.github.zly2006.zhihu.shared.platform.UserMessageDuration
 import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
@@ -425,26 +429,55 @@ fun FollowRecommendScreen(
                 FeedCard(
                     item = item,
                     modifier = Modifier.testTag("follow_recommend_item_${item.stableKey}"),
-                    onBlockUser = { feedItem ->
-                        feedBlockActions.handleBlockUser(viewModel, feedItem) { authorInfo ->
-                            feedAuthorBlockRequest = FeedAuthorBlockRequest(
-                                FeedAuthorBlockType.CONTENT_AUTHOR,
-                                authorInfo.first,
-                                authorInfo.second,
+                    menuItems = { dismissMenu ->
+                        DropdownMenuItem(
+                            text = { Text("屏蔽用户") },
+                            onClick = {
+                                dismissMenu()
+                                feedBlockActions.handleBlockUser(viewModel, item) { authorInfo ->
+                                    feedAuthorBlockRequest = FeedAuthorBlockRequest(
+                                        FeedAuthorBlockType.CONTENT_AUTHOR,
+                                        authorInfo.first,
+                                        authorInfo.second,
+                                    )
+                                }
+                            },
+                        )
+                        val canBlockQuestionAuthor = when (item.feed?.target) {
+                            is Feed.AnswerTarget, is Feed.QuestionTarget -> true
+                            else -> item.raw is DataHolder.Answer || item.raw is DataHolder.Question
+                        }
+                        if (canBlockQuestionAuthor) {
+                            DropdownMenuItem(
+                                text = { Text("屏蔽提问者") },
+                                onClick = {
+                                    dismissMenu()
+                                    feedBlockActions.handleBlockQuestionAuthor(viewModel, item) { authorInfo ->
+                                        feedAuthorBlockRequest = FeedAuthorBlockRequest(
+                                            FeedAuthorBlockType.QUESTION_AUTHOR,
+                                            authorInfo.first,
+                                            authorInfo.second,
+                                        )
+                                    }
+                                },
                             )
                         }
-                    },
-                    onBlockQuestionAuthor = { feedItem ->
-                        feedBlockActions.handleBlockQuestionAuthor(viewModel, feedItem) { authorInfo ->
-                            feedAuthorBlockRequest = FeedAuthorBlockRequest(
-                                FeedAuthorBlockType.QUESTION_AUTHOR,
-                                authorInfo.first,
-                                authorInfo.second,
+                        val topics = when (val raw = item.raw) {
+                            is DataHolder.Answer -> raw.question.topics
+                            is DataHolder.Question -> raw.topics
+                            is DataHolder.Article -> raw.topics ?: emptyList()
+                            is DataHolder.Pin -> raw.topics ?: emptyList()
+                            else -> emptyList()
+                        }
+                        topics.forEach { topic ->
+                            DropdownMenuItem(
+                                text = { Text("屏蔽「${topic.name}」") },
+                                onClick = {
+                                    dismissMenu()
+                                    feedBlockActions.handleBlockTopic(viewModel, topic.id, topic.name)
+                                },
                             )
                         }
-                    },
-                    onBlockTopic = { topicId, topicName ->
-                        feedBlockActions.handleBlockTopic(viewModel, topicId, topicName)
                     },
                 )
             }
@@ -540,26 +573,55 @@ fun FollowDynamicScreen(
                     item = item,
                     modifier = Modifier.testTag("follow_dynamic_item_${item.stableKey}"),
                     showSourceLabel = true,
-                    onBlockUser = { feedItem ->
-                        feedBlockActions.handleBlockUser(viewModel, feedItem) { authorInfo ->
-                            feedAuthorBlockRequest = FeedAuthorBlockRequest(
-                                FeedAuthorBlockType.CONTENT_AUTHOR,
-                                authorInfo.first,
-                                authorInfo.second,
+                    menuItems = { dismissMenu ->
+                        DropdownMenuItem(
+                            text = { Text("屏蔽用户") },
+                            onClick = {
+                                dismissMenu()
+                                feedBlockActions.handleBlockUser(viewModel, item) { authorInfo ->
+                                    feedAuthorBlockRequest = FeedAuthorBlockRequest(
+                                        FeedAuthorBlockType.CONTENT_AUTHOR,
+                                        authorInfo.first,
+                                        authorInfo.second,
+                                    )
+                                }
+                            },
+                        )
+                        val canBlockQuestionAuthor = when (item.feed?.target) {
+                            is Feed.AnswerTarget, is Feed.QuestionTarget -> true
+                            else -> item.raw is DataHolder.Answer || item.raw is DataHolder.Question
+                        }
+                        if (canBlockQuestionAuthor) {
+                            DropdownMenuItem(
+                                text = { Text("屏蔽提问者") },
+                                onClick = {
+                                    dismissMenu()
+                                    feedBlockActions.handleBlockQuestionAuthor(viewModel, item) { authorInfo ->
+                                        feedAuthorBlockRequest = FeedAuthorBlockRequest(
+                                            FeedAuthorBlockType.QUESTION_AUTHOR,
+                                            authorInfo.first,
+                                            authorInfo.second,
+                                        )
+                                    }
+                                },
                             )
                         }
-                    },
-                    onBlockQuestionAuthor = { feedItem ->
-                        feedBlockActions.handleBlockQuestionAuthor(viewModel, feedItem) { authorInfo ->
-                            feedAuthorBlockRequest = FeedAuthorBlockRequest(
-                                FeedAuthorBlockType.QUESTION_AUTHOR,
-                                authorInfo.first,
-                                authorInfo.second,
+                        val topics = when (val raw = item.raw) {
+                            is DataHolder.Answer -> raw.question.topics
+                            is DataHolder.Question -> raw.topics
+                            is DataHolder.Article -> raw.topics ?: emptyList()
+                            is DataHolder.Pin -> raw.topics ?: emptyList()
+                            else -> emptyList()
+                        }
+                        topics.forEach { topic ->
+                            DropdownMenuItem(
+                                text = { Text("屏蔽「${topic.name}」") },
+                                onClick = {
+                                    dismissMenu()
+                                    feedBlockActions.handleBlockTopic(viewModel, topic.id, topic.name)
+                                },
                             )
                         }
-                    },
-                    onBlockTopic = { topicId, topicName ->
-                        feedBlockActions.handleBlockTopic(viewModel, topicId, topicName)
                     },
                 )
             }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
@@ -99,6 +99,7 @@ import com.github.zly2006.zhihu.navigation.Pin
 import com.github.zly2006.zhihu.navigation.Search
 import com.github.zly2006.zhihu.navigation.WritePin
 import com.github.zly2006.zhihu.shared.aigc.AIGC_MARKING_ENABLED_PREFERENCE_KEY
+import com.github.zly2006.zhihu.shared.data.DataHolder
 import com.github.zly2006.zhihu.shared.data.Feed
 import com.github.zly2006.zhihu.shared.data.RecommendationMode
 import com.github.zly2006.zhihu.shared.data.ZHIHU_ME_URL
@@ -109,6 +110,7 @@ import com.github.zly2006.zhihu.shared.data.target
 import com.github.zly2006.zhihu.shared.notification.rememberNotificationSettingsStore
 import com.github.zly2006.zhihu.shared.platform.UserMessageDuration
 import com.github.zly2006.zhihu.shared.platform.rememberExternalUrlOpener
+import com.github.zly2006.zhihu.shared.platform.rememberIsLiteVariant
 import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
 import com.github.zly2006.zhihu.shared.ui.TopLevelReselectAction
@@ -207,6 +209,7 @@ fun HomeScreen(
     val isDebuggable = rememberHomeIsDebuggable()
     val requestLogin = rememberHomeLoginRequester()
     val feedBlockActions = rememberFeedBlockActions()
+    val isLiteVariant = rememberIsLiteVariant()
     val viewModel: BaseFeedViewModel = when (currentRecommendationMode) {
         RecommendationMode.WEB -> viewModel { HomeFeedViewModel() }
         RecommendationMode.ANDROID -> viewModel { AndroidHomeFeedViewModel() }
@@ -645,32 +648,67 @@ fun HomeScreen(
                             is Feed.AnswerTarget -> target.thumbnail
                             else -> null
                         },
-                        onBlockUser = { feedItem ->
-                            feedBlockActions.handleBlockUser(viewModel, feedItem) { authorInfo ->
-                                feedAuthorBlockRequest = FeedAuthorBlockRequest(
-                                    type = FeedAuthorBlockType.CONTENT_AUTHOR,
-                                    userId = authorInfo.first,
-                                    userName = authorInfo.second,
+                        menuItems = { dismissMenu ->
+                            if (!isLiteVariant) {
+                                DropdownMenuItem(
+                                    text = { Text("按关键词屏蔽") },
+                                    onClick = {
+                                        dismissMenu()
+                                        feedBlockActions.handleBlockByKeywords(viewModel, item) { (_, contentInfo) ->
+                                            feedToBlockByKeywords = contentInfo.first to contentInfo.second
+                                            showBlockByKeywordsDialog = true
+                                        }
+                                    },
                                 )
                             }
-                        },
-                        onBlockQuestionAuthor = { feedItem ->
-                            feedBlockActions.handleBlockQuestionAuthor(viewModel, feedItem) { authorInfo ->
-                                feedAuthorBlockRequest = FeedAuthorBlockRequest(
-                                    type = FeedAuthorBlockType.QUESTION_AUTHOR,
-                                    userId = authorInfo.first,
-                                    userName = authorInfo.second,
+                            DropdownMenuItem(
+                                text = { Text("屏蔽用户") },
+                                onClick = {
+                                    dismissMenu()
+                                    feedBlockActions.handleBlockUser(viewModel, item) { authorInfo ->
+                                        feedAuthorBlockRequest = FeedAuthorBlockRequest(
+                                            type = FeedAuthorBlockType.CONTENT_AUTHOR,
+                                            userId = authorInfo.first,
+                                            userName = authorInfo.second,
+                                        )
+                                    }
+                                },
+                            )
+                            val canBlockQuestionAuthor = when (item.feed?.target) {
+                                is Feed.AnswerTarget, is Feed.QuestionTarget -> true
+                                else -> item.raw is DataHolder.Answer || item.raw is DataHolder.Question
+                            }
+                            if (canBlockQuestionAuthor) {
+                                DropdownMenuItem(
+                                    text = { Text("屏蔽提问者") },
+                                    onClick = {
+                                        dismissMenu()
+                                        feedBlockActions.handleBlockQuestionAuthor(viewModel, item) { authorInfo ->
+                                            feedAuthorBlockRequest = FeedAuthorBlockRequest(
+                                                type = FeedAuthorBlockType.QUESTION_AUTHOR,
+                                                userId = authorInfo.first,
+                                                userName = authorInfo.second,
+                                            )
+                                        }
+                                    },
                                 )
                             }
-                        },
-                        onBlockByKeywords = { feedItem ->
-                            feedBlockActions.handleBlockByKeywords(viewModel, feedItem) { (_, contentInfo) ->
-                                feedToBlockByKeywords = contentInfo.first to contentInfo.second
-                                showBlockByKeywordsDialog = true
+                            val topics = when (val raw = item.raw) {
+                                is DataHolder.Answer -> raw.question.topics
+                                is DataHolder.Question -> raw.topics
+                                is DataHolder.Article -> raw.topics ?: emptyList()
+                                is DataHolder.Pin -> raw.topics ?: emptyList()
+                                else -> emptyList()
                             }
-                        },
-                        onBlockTopic = { topicId, topicName ->
-                            feedBlockActions.handleBlockTopic(viewModel, topicId, topicName)
+                            topics.forEach { topic ->
+                                DropdownMenuItem(
+                                    text = { Text("屏蔽「${topic.name}」") },
+                                    onClick = {
+                                        dismissMenu()
+                                        feedBlockActions.handleBlockTopic(viewModel, topic.id, topic.name)
+                                    },
+                                )
+                            }
                         },
                     ) {
                         val feed = this.feed

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/OnlineHistoryScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/OnlineHistoryScreen.kt
@@ -54,6 +54,7 @@ import com.github.zly2006.zhihu.ui.components.FeedPullToRefresh
 import com.github.zly2006.zhihu.ui.components.PaginatedList
 import com.github.zly2006.zhihu.viewmodel.feed.OnlineHistoryViewModel
 import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 const val ONLINE_HISTORY_OVERFLOW_TAG = "online_history_overflow"
@@ -184,6 +185,18 @@ fun OnlineHistoryScreen(
             ) { item ->
                 FeedCard(
                     item,
+                    onDelete = {
+                        coroutineScope.launch {
+                            try {
+                                viewModel.deleteItem(paginationEnvironment, item)
+                                userMessages.showShortMessage("已删除")
+                            } catch (error: CancellationException) {
+                                throw error
+                            } catch (_: Exception) {
+                                userMessages.showShortMessage("操作失败")
+                            }
+                        }
+                    },
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/OnlineHistoryScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/OnlineHistoryScreen.kt
@@ -185,17 +185,23 @@ fun OnlineHistoryScreen(
             ) { item ->
                 FeedCard(
                     item,
-                    onDelete = {
-                        coroutineScope.launch {
-                            try {
-                                viewModel.deleteItem(paginationEnvironment, item)
-                                userMessages.showShortMessage("已删除")
-                            } catch (error: CancellationException) {
-                                throw error
-                            } catch (_: Exception) {
-                                userMessages.showShortMessage("操作失败")
-                            }
-                        }
+                    menuItems = { dismissMenu ->
+                        DropdownMenuItem(
+                            text = { Text("删除该条历史记录") },
+                            onClick = {
+                                dismissMenu()
+                                coroutineScope.launch {
+                                    try {
+                                        viewModel.deleteItem(paginationEnvironment, item)
+                                        userMessages.showShortMessage("已删除")
+                                    } catch (error: CancellationException) {
+                                        throw error
+                                    } catch (_: Exception) {
+                                        userMessages.showShortMessage("操作失败")
+                                    }
+                                }
+                            },
+                        )
                     },
                 )
             }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/OnlineHistoryScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/OnlineHistoryScreen.kt
@@ -182,6 +182,7 @@ fun OnlineHistoryScreen(
                 listState = listState,
                 onLoadMore = { viewModel.loadMore(paginationEnvironment) },
                 isEnd = { viewModel.isEnd },
+                key = { item -> item.stableKey },
             ) { item ->
                 FeedCard(
                     item,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
@@ -568,14 +568,20 @@ fun SearchScreen(
                     ) { item ->
                         FeedCard(
                             item = item,
-                            onBlockUser = { feedItem ->
-                                feedBlockActions.handleBlockUser(viewModel, feedItem) { authorInfo ->
-                                    feedAuthorBlockRequest = FeedAuthorBlockRequest(
-                                        FeedAuthorBlockType.CONTENT_AUTHOR,
-                                        authorInfo.first,
-                                        authorInfo.second,
-                                    )
-                                }
+                            menuItems = { dismissMenu ->
+                                DropdownMenuItem(
+                                    text = { Text("屏蔽用户") },
+                                    onClick = {
+                                        dismissMenu()
+                                        feedBlockActions.handleBlockUser(viewModel, item) { authorInfo ->
+                                            feedAuthorBlockRequest = FeedAuthorBlockRequest(
+                                                FeedAuthorBlockType.CONTENT_AUTHOR,
+                                                authorInfo.first,
+                                                authorInfo.second,
+                                            )
+                                        }
+                                    },
+                                )
                             },
                         )
                     }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
@@ -104,6 +104,7 @@ fun FeedCard(
     onBlockQuestionAuthor: ((FeedDisplayItem) -> Unit)? = null,
     onBlockByKeywords: ((FeedDisplayItem) -> Unit)? = null,
     onBlockTopic: ((topicId: String, topicName: String) -> Unit)? = null,
+    onDelete: ((FeedDisplayItem) -> Unit)? = null,
     showSourceLabel: Boolean = false,
     /**
      * 默认点击行为：优先跳转到信息流条目的详情页；如果只能识别为外链则打开外链，否则提示暂不支持。
@@ -165,6 +166,7 @@ fun FeedCard(
                     onBlockQuestionAuthor = onBlockQuestionAuthor,
                     onBlockByKeywords = if (isLiteVariant) null else onBlockByKeywords,
                     onBlockTopic = onBlockTopic,
+                    onDelete = onDelete,
                     duo3CardLayout = duo3CardLayout,
                     duo3CardLargeTitle = duo3CardLargeTitle,
                     showSourceLabel = showSourceLabel,
@@ -216,6 +218,7 @@ fun FeedCard(
                         onBlockQuestionAuthor = onBlockQuestionAuthor,
                         onBlockByKeywords = if (isLiteVariant) null else onBlockByKeywords,
                         onBlockTopic = onBlockTopic,
+                        onDelete = onDelete,
                         duo3CardLayout = duo3CardLayout,
                         duo3CardLargeTitle = duo3CardLargeTitle,
                         showSourceLabel = showSourceLabel,
@@ -241,6 +244,7 @@ private fun FeedCardMenuBox(
     onBlockQuestionAuthor: ((FeedDisplayItem) -> Unit)?,
     onBlockByKeywords: ((FeedDisplayItem) -> Unit)?,
     onBlockTopic: ((topicId: String, topicName: String) -> Unit)?,
+    onDelete: ((FeedDisplayItem) -> Unit)?,
     navigator: Navigator,
 ) {
     Box {
@@ -307,6 +311,15 @@ private fun FeedCardMenuBox(
                     )
                 }
             }
+            if (onDelete != null) {
+                DropdownMenuItem(
+                    text = { Text("删除") },
+                    onClick = {
+                        onShowMenuChange(false)
+                        onDelete(item)
+                    },
+                )
+            }
             DropdownMenuItem(
                 text = { Text("外观设置") },
                 onClick = {
@@ -345,6 +358,7 @@ private fun FeedCardContent(
     onBlockQuestionAuthor: ((FeedDisplayItem) -> Unit)?,
     onBlockByKeywords: ((FeedDisplayItem) -> Unit)?,
     onBlockTopic: ((topicId: String, topicName: String) -> Unit)?,
+    onDelete: ((FeedDisplayItem) -> Unit)?,
     duo3CardLayout: Boolean,
     duo3CardLargeTitle: Boolean,
     showSourceLabel: Boolean,
@@ -456,7 +470,7 @@ private fun FeedCardContent(
                             overflow = TextOverflow.Ellipsis,
                             modifier = Modifier.weight(1f),
                         )
-                        FeedCardMenuBox(item, showMenu, onShowMenuChange, onBlockUser, onBlockQuestionAuthor, onBlockByKeywords, onBlockTopic, navigator)
+                        FeedCardMenuBox(item, showMenu, onShowMenuChange, onBlockUser, onBlockQuestionAuthor, onBlockByKeywords, onBlockTopic, onDelete, navigator)
                     }
                 }
             }
@@ -534,7 +548,7 @@ private fun FeedCardContent(
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.weight(1f),
                         )
-                        FeedCardMenuBox(item, showMenu, onShowMenuChange, onBlockUser, onBlockQuestionAuthor, onBlockByKeywords, onBlockTopic, navigator)
+                        FeedCardMenuBox(item, showMenu, onShowMenuChange, onBlockUser, onBlockQuestionAuthor, onBlockByKeywords, onBlockTopic, onDelete, navigator)
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -76,7 +77,6 @@ import com.github.zly2006.zhihu.shared.data.officialBadge
 import com.github.zly2006.zhihu.shared.data.sourceLabel
 import com.github.zly2006.zhihu.shared.data.target
 import com.github.zly2006.zhihu.shared.platform.UserMessageDuration
-import com.github.zly2006.zhihu.shared.platform.rememberIsLiteVariant
 import com.github.zly2006.zhihu.shared.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
 import com.github.zly2006.zhihu.ui.subscreens.PREF_FONT_SIZE
@@ -87,7 +87,7 @@ import com.github.zly2006.zhihu.util.parseEmphasizedHtmlTextWithTheme
  * 信息流卡片的 Material 3 实现。
  *
  * 卡片负责展示标题、摘要、作者、徽章、缩略图和更多菜单，并根据设置支持卡片/分割线两种外观、Duo3 排版和缩略图开关。
- * 默认点击会解析 [FeedDisplayItem] 的导航目标并进入详情页；外部也可以注入屏蔽用户、按关键词屏蔽和屏蔽主题等动作。
+ * 默认点击会解析 [FeedDisplayItem] 的导航目标并进入详情页；页面可以通过 [menuItems] 直接声明自己的业务菜单项。
  *
  * 修改这个组件时要同步复核 `showFeedThumbnail`、`feedCardStyle`、`duo3_card_appearance`、
  * `duo3_card_layout` 和 `duo3_card_large_title` 对各信息流入口的影响。
@@ -100,11 +100,7 @@ fun FeedCard(
     maxHeight: Dp = 240.dp,
     thumbnailUrl: String? = null,
     horizontalPadding: Dp = 16.dp,
-    onBlockUser: ((FeedDisplayItem) -> Unit)? = null,
-    onBlockQuestionAuthor: ((FeedDisplayItem) -> Unit)? = null,
-    onBlockByKeywords: ((FeedDisplayItem) -> Unit)? = null,
-    onBlockTopic: ((topicId: String, topicName: String) -> Unit)? = null,
-    onDelete: ((FeedDisplayItem) -> Unit)? = null,
+    menuItems: @Composable ColumnScope.(dismissMenu: () -> Unit) -> Unit = { _ -> },
     showSourceLabel: Boolean = false,
     /**
      * 默认点击行为：优先跳转到信息流条目的详情页；如果只能识别为外链则打开外链，否则提示暂不支持。
@@ -115,7 +111,6 @@ fun FeedCard(
     val uriHandler = LocalUriHandler.current
     val userMessages = rememberUserMessageSink()
     val settings = rememberSettingsStore()
-    val isLiteVariant = rememberIsLiteVariant()
     var showMenu by remember { mutableStateOf(false) }
     val showFeedThumbnail = remember {
         settings.getBoolean("showFeedThumbnail", true)
@@ -162,11 +157,7 @@ fun FeedCard(
                     pinImages = pinImages,
                     showMenu = showMenu,
                     onShowMenuChange = { showMenu = it },
-                    onBlockUser = onBlockUser,
-                    onBlockQuestionAuthor = onBlockQuestionAuthor,
-                    onBlockByKeywords = if (isLiteVariant) null else onBlockByKeywords,
-                    onBlockTopic = onBlockTopic,
-                    onDelete = onDelete,
+                    menuItems = menuItems,
                     duo3CardLayout = duo3CardLayout,
                     duo3CardLargeTitle = duo3CardLargeTitle,
                     showSourceLabel = showSourceLabel,
@@ -214,11 +205,7 @@ fun FeedCard(
                         pinImages = pinImages,
                         showMenu = showMenu,
                         onShowMenuChange = { showMenu = it },
-                        onBlockUser = onBlockUser,
-                        onBlockQuestionAuthor = onBlockQuestionAuthor,
-                        onBlockByKeywords = if (isLiteVariant) null else onBlockByKeywords,
-                        onBlockTopic = onBlockTopic,
-                        onDelete = onDelete,
+                        menuItems = menuItems,
                         duo3CardLayout = duo3CardLayout,
                         duo3CardLargeTitle = duo3CardLargeTitle,
                         showSourceLabel = showSourceLabel,
@@ -232,19 +219,14 @@ fun FeedCard(
 /**
  * 信息流卡片右上角的更多菜单。
  *
- * 菜单集中承载和当前条目相关的轻量操作：按关键词屏蔽、屏蔽用户、屏蔽主题、跳转外观设置，以及对已过滤内容快速关闭质量过滤。
- * 这些入口会把用户带回对应设置项，因此新增菜单动作时要明确它是直接修改内容，还是跳转到设置页继续配置。
+ * 卡片只负责菜单的展开、收起和通用设置项；页面业务动作由 [menuItems] 直接提供。
  */
 @Composable
 private fun FeedCardMenuBox(
     item: FeedDisplayItem,
     showMenu: Boolean,
     onShowMenuChange: (Boolean) -> Unit,
-    onBlockUser: ((FeedDisplayItem) -> Unit)?,
-    onBlockQuestionAuthor: ((FeedDisplayItem) -> Unit)?,
-    onBlockByKeywords: ((FeedDisplayItem) -> Unit)?,
-    onBlockTopic: ((topicId: String, topicName: String) -> Unit)?,
-    onDelete: ((FeedDisplayItem) -> Unit)?,
+    menuItems: @Composable ColumnScope.(dismissMenu: () -> Unit) -> Unit,
     navigator: Navigator,
 ) {
     Box {
@@ -263,63 +245,7 @@ private fun FeedCardMenuBox(
             expanded = showMenu,
             onDismissRequest = { onShowMenuChange(false) },
         ) {
-            if (onBlockByKeywords != null) {
-                DropdownMenuItem(
-                    text = { Text("按关键词屏蔽") },
-                    onClick = {
-                        onShowMenuChange(false)
-                        onBlockByKeywords(item)
-                    },
-                )
-            }
-            DropdownMenuItem(
-                text = { Text("屏蔽用户") },
-                onClick = {
-                    onShowMenuChange(false)
-                    onBlockUser?.invoke(item)
-                },
-            )
-            val canBlockQuestionAuthor = onBlockQuestionAuthor != null &&
-                when (item.feed?.target) {
-                    is Feed.AnswerTarget, is Feed.QuestionTarget -> true
-                    else -> item.raw is DataHolder.Answer || item.raw is DataHolder.Question
-                }
-            if (canBlockQuestionAuthor) {
-                DropdownMenuItem(
-                    text = { Text("屏蔽提问者") },
-                    onClick = {
-                        onShowMenuChange(false)
-                        onBlockQuestionAuthor(item)
-                    },
-                )
-            }
-            if (onBlockTopic != null && item.raw != null) {
-                val topics = when (val raw = item.raw) {
-                    is com.github.zly2006.zhihu.shared.data.DataHolder.Answer -> raw.question.topics
-                    is com.github.zly2006.zhihu.shared.data.DataHolder.Question -> raw.topics
-                    is com.github.zly2006.zhihu.shared.data.DataHolder.Article -> raw.topics ?: emptyList()
-                    is com.github.zly2006.zhihu.shared.data.DataHolder.Pin -> raw.topics ?: emptyList()
-                    else -> emptyList()
-                }
-                topics.forEach { topic ->
-                    DropdownMenuItem(
-                        text = { Text("屏蔽「${topic.name}」") },
-                        onClick = {
-                            onShowMenuChange(false)
-                            onBlockTopic(topic.id, topic.name)
-                        },
-                    )
-                }
-            }
-            if (onDelete != null) {
-                DropdownMenuItem(
-                    text = { Text("删除") },
-                    onClick = {
-                        onShowMenuChange(false)
-                        onDelete(item)
-                    },
-                )
-            }
+            menuItems { onShowMenuChange(false) }
             DropdownMenuItem(
                 text = { Text("外观设置") },
                 onClick = {
@@ -354,11 +280,7 @@ private fun FeedCardContent(
     pinImages: List<DataHolder.Pin.ContentImage>,
     showMenu: Boolean,
     onShowMenuChange: (Boolean) -> Unit,
-    onBlockUser: ((FeedDisplayItem) -> Unit)?,
-    onBlockQuestionAuthor: ((FeedDisplayItem) -> Unit)?,
-    onBlockByKeywords: ((FeedDisplayItem) -> Unit)?,
-    onBlockTopic: ((topicId: String, topicName: String) -> Unit)?,
-    onDelete: ((FeedDisplayItem) -> Unit)?,
+    menuItems: @Composable ColumnScope.(dismissMenu: () -> Unit) -> Unit,
     duo3CardLayout: Boolean,
     duo3CardLargeTitle: Boolean,
     showSourceLabel: Boolean,
@@ -470,7 +392,7 @@ private fun FeedCardContent(
                             overflow = TextOverflow.Ellipsis,
                             modifier = Modifier.weight(1f),
                         )
-                        FeedCardMenuBox(item, showMenu, onShowMenuChange, onBlockUser, onBlockQuestionAuthor, onBlockByKeywords, onBlockTopic, onDelete, navigator)
+                        FeedCardMenuBox(item, showMenu, onShowMenuChange, menuItems, navigator)
                     }
                 }
             }
@@ -548,7 +470,7 @@ private fun FeedCardContent(
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.weight(1f),
                         )
-                        FeedCardMenuBox(item, showMenu, onShowMenuChange, onBlockUser, onBlockQuestionAuthor, onBlockByKeywords, onBlockTopic, onDelete, navigator)
+                        FeedCardMenuBox(item, showMenu, onShowMenuChange, menuItems, navigator)
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -35,6 +35,7 @@ import com.github.zly2006.zhihu.shared.aigc.AigcVoteVoter
 import com.github.zly2006.zhihu.shared.data.DataHolder
 import com.github.zly2006.zhihu.shared.data.Feed
 import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
+import com.github.zly2006.zhihu.shared.data.OnlineHistoryDeletePair
 import com.github.zly2006.zhihu.shared.data.ZhihuJson.decodeJson
 import com.github.zly2006.zhihu.shared.data.ZhihuPaging
 import com.github.zly2006.zhihu.shared.data.fetchZhihuAuthenticatedJson
@@ -54,6 +55,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.URLProtocol
 import io.ktor.http.contentType
+import io.ktor.http.isSuccess
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Job
@@ -306,6 +308,29 @@ suspend fun ZhihuApiEnvironment.addReadHistory(
             )
         }
     }
+}
+
+internal suspend fun ZhihuApiEnvironment.deleteOnlineHistoryItem(item: OnlineHistoryDeletePair) {
+    val response = postSigned("https://api.zhihu.com/read_history/batch_del") {
+        contentType(ContentType.Application.Json)
+        setBody(
+            buildJsonObject {
+                put(
+                    "pairs",
+                    JsonArray(
+                        listOf(
+                            buildJsonObject {
+                                put("content_token", item.contentToken)
+                                put("content_type", item.contentType)
+                            },
+                        ),
+                    ),
+                )
+                put("clear", false)
+            }.toString(),
+        )
+    }
+    check(response.status.isSuccess()) { "删除在线历史记录失败: ${response.status}" }
 }
 
 suspend fun ZhihuApiEnvironment.postSigned(

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/OnlineHistoryViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/OnlineHistoryViewModel.kt
@@ -21,17 +21,23 @@ import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.resolveContent
 import com.github.zly2006.zhihu.shared.data.Feed
 import com.github.zly2006.zhihu.shared.data.FeedDisplayItem
+import com.github.zly2006.zhihu.shared.data.OnlineHistoryDeletePair
 import com.github.zly2006.zhihu.shared.data.OnlineHistoryItem
 import com.github.zly2006.zhihu.shared.data.ZhihuJson.decodeJson
 import com.github.zly2006.zhihu.shared.data.toFeedDisplayItemNavDestinationJson
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
+import com.github.zly2006.zhihu.viewmodel.deleteOnlineHistoryItem
 import kotlinx.serialization.json.JsonArray
 
 class OnlineHistoryViewModel : BaseFeedViewModel() {
     override val initialUrl: String = "https://api.zhihu.com/unify-consumption/read_history?offset=0&limit=10"
     override val shouldLogDecodeFailures: Boolean = false
+    private val deletionPairs = mutableMapOf<FeedDisplayItem, OnlineHistoryDeletePair>()
 
     override fun processResponse(environment: PaginationEnvironment, data: List<Feed>, rawData: JsonArray) {
+        if (displayItems.isEmpty()) {
+            deletionPairs.clear()
+        }
         val response = rawData.mapNotNull { item ->
             runCatching { decodeJson<OnlineHistoryItem>(item) }.getOrNull()
         }
@@ -64,7 +70,18 @@ class OnlineHistoryViewModel : BaseFeedViewModel() {
                 },
                 authorName = item.data.content?.authorName,
             )
+            deletionPairs[displayItem] = OnlineHistoryDeletePair(
+                contentToken = item.data.extra.contentToken,
+                contentType = item.data.extra.contentType,
+            )
             displayItems.add(displayItem)
         }
+    }
+
+    suspend fun deleteItem(environment: PaginationEnvironment, item: FeedDisplayItem) {
+        val pair = checkNotNull(deletionPairs[item]) { "在线历史记录缺少删除标识" }
+        environment.deleteOnlineHistoryItem(pair)
+        displayItems.remove(item)
+        deletionPairs.remove(item)
     }
 }


### PR DESCRIPTION
## 改动

- 在在线历史卡片现有的“更多”菜单中增加“删除该条历史记录”操作
- 使用历史响应自带的 `content_token` 与 `content_type` 调用知乎 `read_history/batch_del` 接口
- 仅在服务端删除成功后移除当前卡片；失败时保留原记录并提示操作失败
- 将 `FeedCard` 原有的业务 `onXxx` 回调重构为 `menuItems` composable 插槽，由首页、关注、搜索和在线历史页面直接声明各自的菜单内容
- 补充卡片菜单与删除请求、列表状态的定向仪器测试

## 原因

当前历史页只支持清空全部记录，误触或无用内容无法单独整理。该行为已在 0.26 主线复现，并对照当前知乎网页版确认：单条删除直接提交当前记录的标识，不弹二次确认。

同时，业务操作不应持续扩张 `FeedCard` 的参数列表；菜单插槽让卡片只负责菜单容器和通用设置项，具体业务入口由页面负责。

## 影响

- 新增行为只影响在线历史页，不改变本地历史记录
- 不改变全局“清除历史记录”的既有语义
- 首页、关注页和搜索页原有屏蔽菜单迁移到调用点，展示条件和操作语义保持不变

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `./gradlew :app:compileLiteDebugAndroidTestKotlin`
- 真实登录态 API 临时写入并单条删除：写入后可见、删除后消失、历史总数恢复

Closes #562