### PR TITLE
fix: 修复个人主页 GitHub 链接跳转

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/PeopleScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/PeopleScreenInstrumentedTest.kt
@@ -528,7 +528,7 @@ class PeopleScreenInstrumentedTest {
                         DataHolder.SocialMedia(
                             icon = "https://example.invalid/github.png",
                             title = "GitHub·zly2006",
-                            link = "https://github.com/zly2006",
+                            link = "zhihu://hybrid?zh_hide_nav_bar=true&zh_url=https:%2F%2Fwww.zhihu.com%2Fappview%2Fgithub%2Fdetail%3Fhash_id=ea09b6c82124e0162caa10d658058c10",
                             modules = listOf(
                                 DataHolder.SocialMediaModule("被关注人", "169"),
                                 DataHolder.SocialMediaModule("公开仓库数", "119"),

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PeopleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PeopleScreen.kt
@@ -556,8 +556,19 @@ internal fun DataHolder.People.githubSocialUiState(): GithubSocialUiState? = soc
         ?.value
         ?.takeIf { it.isNotBlank() }
         ?: return@firstNotNullOfOrNull null
-    val profileUrl = media.link.takeIf { it.isNotBlank() }
+    val profileLink = media.link.takeIf { it.isNotBlank() }
         ?: return@firstNotNullOfOrNull null
+    val profileUrl = if (profileLink.startsWith("zhihu://", ignoreCase = true)) {
+        // link 是知乎内部 AppView，GitHub 用户名来自同一条社交资料的标题。
+        val username = media.title
+            .substringAfter('·', missingDelimiterValue = "")
+            .trim()
+            .takeIf { it.isNotBlank() }
+            ?: return@firstNotNullOfOrNull null
+        "https://github.com/$username"
+    } else {
+        profileLink
+    }
 
     GithubSocialUiState(
         title = media.title,

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/ui/PeopleScreenProfileUrlTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/ui/PeopleScreenProfileUrlTest.kt
@@ -77,7 +77,7 @@ class PeopleScreenProfileUrlTest {
                     {
                       "icon": "https://example.invalid/github.png",
                       "title": "GitHub·zly2006",
-                      "link": "https://github.com/zly2006",
+                      "link": "zhihu://hybrid?zh_hide_nav_bar=true&zh_url=https:%2F%2Fwww.zhihu.com%2Fappview%2Fgithub%2Fdetail%3Fhash_id=ea09b6c82124e0162caa10d658058c10",
                       "modules": [
                         {"title": "被关注人", "value": "169"},
                         {"title": "公开仓库数", "value": "119"},
@@ -147,6 +147,7 @@ class PeopleScreenProfileUrlTest {
 
         assertTrue(viewModel.isBlocking)
         assertEquals("4.0k", viewModel.githubSocial?.starCount)
+        assertEquals("https://github.com/zly2006", viewModel.githubSocial?.profileUrl)
         assertEquals(
             listOf(
                 "https://api.zhihu.com/people/profile-user" to PEOPLE_PROFILE_INCLUDE_PATH,


### PR DESCRIPTION
## 必填：AI 使用与验证材料

请如实勾选：

- [ ] 未使用 AI 编写、改写或批量生成代码
- [x] 使用了 AI 编写、改写或批量生成代码

如果使用了 AI，本 PR 必须附上以下验证材料，否则不会进入 review：

- [ ] 已上传测试截图
- [ ] 已上传测试录屏

## 变更说明

- 识别个人主页 GitHub 社交资料返回的知乎内部 `zhihu://hybrid` 链接。
- 从同一社交资料标题中取得 GitHub 用户名，生成 `https://github.com/{username}` 后再交给现有 external URL opener。
- 保留服务端已经直接返回 HTTPS GitHub 主页链接时的原有行为，不增加网络请求或平台分支。
- 用真实 API scheme 更新共享回归样本和 Android UI 夹具。

## 根因

个人主页此前把 `socialMedias.link` 原样交给外部 URL opener。当前知乎 API 返回的是官方客户端内部 AppView scheme，系统浏览器不能将它当作 GitHub 主页打开。

## 真实接口证据

- `profile/detail` 与 `profile?profile_new_version=1&profile_v4=1` 当前都返回 `GitHub·zly2006`，其 `link` 为指向知乎 AppView 的 `zhihu://hybrid` scheme。
- 本次复用现有详情请求，新增请求数为 0。

## 测试与验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- 隔离 worktree 中运行 `./gradlew --no-daemon :shared:jvmTest --tests 'com.github.zly2006.zhihu.ui.PeopleScreenProfileUrlTest'`，通过。
- 隔离 worktree 中运行 `ANDROID_HOME=/Users/zhaoliyan/Library/Android/sdk ./gradlew --no-daemon assembleLiteDebugAndroidTest`，通过。
- `git diff --check`

## 实际运行材料

Draft 阶段暂未附图：本机没有可用 AVD，远端短生命周期 AVD 在验证期间被另一并发会话多次重启和接管，因此没有把旧截图、Launcher 截图或混合构建截图冒充为本提交证据。待取得独占运行面后补充当前提交的截图与录屏。
