### PR TITLE
feat: 支持新建和删除收藏夹

### DIFF
--- a/.agents/skills/zhihu-parallel-pr-workflow/SKILL.md
+++ b/.agents/skills/zhihu-parallel-pr-workflow/SKILL.md
@@ -9,6 +9,8 @@ description: Coordinate Zhihu++ issue and PR implementation through subagents wi
 
 This workflow is only for work with real parallel value: multiple independent issues or PRs, an explicit user request for subagents/delegation, or independently executable scopes that materially reduce wall-clock time. Do not trigger it merely because a task references one GitHub issue or will end in one PR. A single narrow issue should stay with the main agent, including implementation, validation, screenshots, and PR publication, unless the user explicitly asks to delegate it.
 
+Mentioning this skill is not authorization to use subagents. One product feature and its small accompanying workflow-documentation change remain one main-agent task unless the user explicitly requests delegation.
+
 Example: adding one menu action and adjusting that menu's sheet behavior is one bounded UI change. Spawning a worker only adds handoff and review overhead, so the main agent should complete it directly.
 
 ## Core Contract
@@ -67,6 +69,8 @@ git fetch origin master --prune
 git worktree add .worktrees/<short-name> origin/master -b codex/<short-name>
 cp local.properties .worktrees/<short-name>/local.properties 2>/dev/null || true
 ```
+
+Keep watching the main checkout throughout the task, not only at startup. Re-check it before implementation and before any intended main-checkout write; if it is dirty or another person/process has modified it, preserve those changes and create or use a fresh worktree instead.
 
 Use unique branch names such as:
 

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/CollectionScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/CollectionScreenInstrumentedTest.kt
@@ -112,6 +112,48 @@ class CollectionScreenInstrumentedTest {
         }
     }
 
+    @Test
+    fun createActionOpensExistingCollectionDialog() {
+        setCollectionScreen(seedCollections(count = 1))
+
+        composeRule.onNodeWithTag(COLLECTION_SCREEN_CREATE_BUTTON_TAG).performClick()
+
+        composeRule.onNodeWithTag(CREATE_COLLECTION_DIALOG_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(CREATE_COLLECTION_TITLE_INPUT_TAG).assertIsDisplayed()
+        composeRule.onNodeWithText("新建收藏夹").assertIsDisplayed()
+    }
+
+    @Test
+    fun onlySelectedNonDefaultCollectionOffersDeleteConfirmation() {
+        val defaultCollection = Collection(
+            id = "default-collection",
+            title = "默认收藏夹",
+            isDefault = true,
+        )
+        val selectedCollection = Collection(
+            id = "selected-collection",
+            title = "待删除收藏夹",
+        )
+        setCollectionScreen(listOf(defaultCollection, selectedCollection))
+
+        composeRule
+            .onNodeWithTag(collectionDeleteButtonTag(defaultCollection.id))
+            .assertDoesNotExist()
+        composeRule
+            .onNodeWithTag(collectionDeleteButtonTag(selectedCollection.id))
+            .performClick()
+
+        composeRule
+            .onNodeWithTag(collectionDeleteDialogTag(selectedCollection.id))
+            .assertIsDisplayed()
+        composeRule
+            .onNodeWithTag(collectionDeleteConfirmTag(selectedCollection.id))
+            .assertIsDisplayed()
+        composeRule
+            .onNodeWithText("删除后无法恢复，确认删除收藏夹“${selectedCollection.title}”吗？")
+            .assertIsDisplayed()
+    }
+
     private fun setCollectionScreen(testCollections: List<Collection>) = composeRule.setScreenContent {
         CollectionScreen(
             urlToken = "offline-test-user",
@@ -135,7 +177,16 @@ class CollectionScreenInstrumentedTest {
         const val COLLECTION_SCREEN_TITLE_TAG = "collection_screen_title"
         const val COLLECTION_SCREEN_BACK_BUTTON_TAG = "collection_screen_back_button"
         const val COLLECTION_SCREEN_LIST_TAG = "collection_screen_list"
+        const val COLLECTION_SCREEN_CREATE_BUTTON_TAG = "collection_screen_create_button"
+        const val CREATE_COLLECTION_DIALOG_TAG = "create_collection_dialog"
+        const val CREATE_COLLECTION_TITLE_INPUT_TAG = "create_collection_title_input"
 
         fun collectionItemTag(collectionId: String) = "collection_screen_item_$collectionId"
+
+        fun collectionDeleteButtonTag(collectionId: String) = "collection_screen_delete_button_$collectionId"
+
+        fun collectionDeleteDialogTag(collectionId: String) = "collection_screen_delete_dialog_$collectionId"
+
+        fun collectionDeleteConfirmTag(collectionId: String) = "collection_screen_delete_confirm_$collectionId"
     }
 }

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/CollectionsViewModelInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/CollectionsViewModelInstrumentedTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.zly2006.zhihu.ui.Collection
+import com.github.zly2006.zhihu.viewmodel.CollectionsViewModel
+import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.MockRequestHandler
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CollectionsViewModelInstrumentedTest {
+    @Test
+    fun createCollectionUsesVerifiedWebContract() = runBlocking {
+        val client = jsonClient { request ->
+            assertEquals(HttpMethod.Post, request.method)
+            assertEquals("/api/v4/collections", request.url.encodedPath)
+            assertEquals("101_3_3.0", request.headers["x-zse-93"])
+            assertTrue(request.headers["x-zse-96"].orEmpty().startsWith("2.0_"))
+            val body = Json.parseToJsonElement((request.body as TextContent).text).jsonObject
+            assertEquals("测试收藏夹", body.getValue("title").jsonPrimitive.content)
+            assertEquals("测试描述", body.getValue("description").jsonPrimitive.content)
+            assertTrue(body.getValue("is_public").jsonPrimitive.boolean)
+            respondJson(
+                """{"status":100,"message":"","collection":{"id":123}}""",
+            )
+        }
+        val viewModel = CollectionsViewModel("owner")
+
+        assertTrue(
+            viewModel.createCollection(
+                environment = testEnvironment(client),
+                title = "测试收藏夹",
+                description = "测试描述",
+                isPublic = true,
+            ),
+        )
+        assertFalse(viewModel.isCreatingCollection)
+        assertNull(viewModel.createCollectionError)
+    }
+
+    @Test
+    fun deleteCollectionTargetsOnlyTheSelectedNonDefaultCollection() = runBlocking {
+        var requestCount = 0
+        val client = jsonClient { request ->
+            requestCount++
+            assertEquals(HttpMethod.Delete, request.method)
+            assertEquals("/api/v4/collections/selected-id", request.url.encodedPath)
+            respondJson("""{"success":true}""")
+        }
+        val viewModel = CollectionsViewModel("owner")
+        val environment = testEnvironment(client)
+
+        assertTrue(
+            viewModel.deleteCollection(
+                environment,
+                Collection(id = "selected-id", title = "待删除收藏夹"),
+            ),
+        )
+        assertFalse(
+            viewModel.deleteCollection(
+                environment,
+                Collection(id = "default-id", title = "默认收藏夹", isDefault = true),
+            ),
+        )
+        assertEquals(1, requestCount)
+        assertEquals("默认收藏夹不能删除", viewModel.deleteCollectionError)
+    }
+
+    @Test
+    fun httpSuccessWithoutDeleteConfirmationIsRejected() = runBlocking {
+        val client = jsonClient { request ->
+            assertEquals(HttpMethod.Delete, request.method)
+            respondJson("""{"success":false,"message":"不能删除"}""")
+        }
+        val viewModel = CollectionsViewModel("owner")
+
+        assertFalse(
+            viewModel.deleteCollection(
+                testEnvironment(client),
+                Collection(id = "selected-id", title = "待删除收藏夹"),
+            ),
+        )
+        assertEquals("不能删除", viewModel.deleteCollectionError)
+    }
+
+    private fun jsonClient(handler: MockRequestHandler) =
+        HttpClient(MockEngine(handler)) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+
+    private fun testEnvironment(client: HttpClient) = object : ZhihuApiEnvironment {
+        override fun httpClient() = client
+
+        override fun authenticatedCookies() = mapOf("d_c0" to "test-cookie")
+
+        override suspend fun handleFetchFailure(tag: String?, error: Exception) = Unit
+    }
+
+    private fun MockRequestHandleScope.respondJson(content: String) = respond(
+        content = content,
+        status = HttpStatusCode.OK,
+        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+    )
+}

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CollectionScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CollectionScreen.kt
@@ -18,12 +18,16 @@
 package com.github.zly2006.zhihu.ui
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -32,20 +36,30 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.zly2006.zhihu.navigation.CollectionContent
 import com.github.zly2006.zhihu.navigation.LocalNavigator
+import com.github.zly2006.zhihu.shared.platform.rememberUserMessageSink
 import com.github.zly2006.zhihu.ui.Collection
+import com.github.zly2006.zhihu.ui.components.CreateCollectionDialog
 import com.github.zly2006.zhihu.ui.components.PaginatedList
 import com.github.zly2006.zhihu.ui.components.ProgressIndicatorFooter
 import com.github.zly2006.zhihu.viewmodel.CollectionsViewModel
 import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -59,9 +73,13 @@ fun CollectionScreen(
     val viewModel: CollectionsViewModel = viewModel(key = urlToken) {
         CollectionsViewModel(urlToken.orEmpty())
     }
+    val userMessages = rememberUserMessageSink()
+    val coroutineScope = rememberCoroutineScope()
     val listState = rememberLazyListState()
     val useTestCollections = testCollections != null || urlToken == null
     val collections = testCollections ?: viewModel.allData
+    var showCreateCollectionDialog by remember { mutableStateOf(false) }
+    var collectionPendingDeletion by remember { mutableStateOf<Collection?>(null) }
 
     LaunchedEffect(useTestCollections) {
         if (!useTestCollections && viewModel.allData.isEmpty()) {
@@ -87,6 +105,18 @@ fun CollectionScreen(
                         ) {
                             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
                         }
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = {
+                            viewModel.clearMutationErrors()
+                            showCreateCollectionDialog = true
+                        },
+                        enabled = !viewModel.isCreatingCollection && viewModel.deletingCollectionId == null,
+                        modifier = Modifier.testTag(COLLECTION_SCREEN_CREATE_BUTTON_TAG),
+                    ) {
+                        Icon(Icons.Filled.Add, contentDescription = "新建收藏夹")
                     }
                 },
             )
@@ -118,14 +148,117 @@ fun CollectionScreen(
                     navigator.onNavigate(CollectionContent(collection.id))
                 },
             ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Text(text = collection.title, style = MaterialTheme.typography.titleMedium)
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = collection.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.weight(1f),
+                    )
+                    if (!collection.isDefault) {
+                        IconButton(
+                            onClick = {
+                                viewModel.clearMutationErrors()
+                                collectionPendingDeletion = collection
+                            },
+                            enabled = !viewModel.isCreatingCollection && viewModel.deletingCollectionId == null,
+                            modifier = Modifier.testTag("collection_screen_delete_button_${collection.id}"),
+                        ) {
+                            Icon(
+                                Icons.Filled.Delete,
+                                contentDescription = "删除${collection.title}",
+                                tint = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                    }
                 }
             }
         }
+    }
+
+    CreateCollectionDialog(
+        showDialog = showCreateCollectionDialog,
+        onDismiss = {
+            showCreateCollectionDialog = false
+        },
+        onConfirm = { title, description, isPublic ->
+            coroutineScope.launch {
+                if (
+                    viewModel.createCollection(
+                        environment = environment,
+                        title = title,
+                        description = description,
+                        isPublic = isPublic,
+                    )
+                ) {
+                    viewModel.refresh(environment)
+                    showCreateCollectionDialog = false
+                    userMessages.showShortMessage("收藏夹已创建")
+                }
+            }
+        },
+        isSubmitting = viewModel.isCreatingCollection,
+        errorMessage = viewModel.createCollectionError,
+    )
+
+    collectionPendingDeletion?.let { collection ->
+        val isDeleting = viewModel.deletingCollectionId != null
+        AlertDialog(
+            modifier = Modifier.testTag("collection_screen_delete_dialog_${collection.id}"),
+            onDismissRequest = {
+                if (!isDeleting) {
+                    collectionPendingDeletion = null
+                }
+            },
+            title = { Text("删除收藏夹") },
+            text = {
+                Column {
+                    Text("删除后无法恢复，确认删除收藏夹“${collection.title}”吗？")
+                    viewModel.deleteCollectionError?.let {
+                        Text(
+                            text = it,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.padding(top = 8.dp),
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        coroutineScope.launch {
+                            if (viewModel.deleteCollection(environment, collection)) {
+                                viewModel.refresh(environment)
+                                collectionPendingDeletion = null
+                                userMessages.showShortMessage("收藏夹已删除")
+                            }
+                        }
+                    },
+                    enabled = !isDeleting,
+                    modifier = Modifier.testTag("collection_screen_delete_confirm_${collection.id}"),
+                ) {
+                    Text(if (isDeleting) "删除中…" else "删除")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        collectionPendingDeletion = null
+                    },
+                    enabled = !isDeleting,
+                ) {
+                    Text("取消")
+                }
+            },
+        )
     }
 }
 
 private const val COLLECTION_SCREEN_TITLE_TAG = "collection_screen_title"
 private const val COLLECTION_SCREEN_BACK_BUTTON_TAG = "collection_screen_back_button"
 private const val COLLECTION_SCREEN_LIST_TAG = "collection_screen_list"
+private const val COLLECTION_SCREEN_CREATE_BUTTON_TAG = "collection_screen_create_button"

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CollectionScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CollectionScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -107,19 +108,20 @@ fun CollectionScreen(
                         }
                     }
                 },
-                actions = {
-                    IconButton(
-                        onClick = {
-                            viewModel.clearMutationErrors()
-                            showCreateCollectionDialog = true
-                        },
-                        enabled = !viewModel.isCreatingCollection && viewModel.deletingCollectionId == null,
-                        modifier = Modifier.testTag(COLLECTION_SCREEN_CREATE_BUTTON_TAG),
-                    ) {
-                        Icon(Icons.Filled.Add, contentDescription = "新建收藏夹")
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = {
+                    if (!viewModel.isCreatingCollection && viewModel.deletingCollectionId == null) {
+                        viewModel.clearMutationErrors()
+                        showCreateCollectionDialog = true
                     }
                 },
-            )
+                modifier = Modifier.testTag(COLLECTION_SCREEN_CREATE_BUTTON_TAG),
+            ) {
+                Icon(Icons.Filled.Add, contentDescription = "新建收藏夹")
+            }
         },
     ) { innerPadding ->
         PaginatedList(

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CollectionDialogComponent.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CollectionDialogComponent.kt
@@ -148,6 +148,7 @@ fun CollectionDialogComponent(
         onDismiss = { showCreateDialog = false },
         onConfirm = { title, description, isPublic ->
             onCreateCollection(title, description, isPublic)
+            showCreateDialog = false
         },
     )
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CreateCollectionDialog.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CreateCollectionDialog.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -48,16 +49,27 @@ fun CreateCollectionDialog(
     showDialog: Boolean,
     onDismiss: () -> Unit,
     onConfirm: (title: String, description: String, Boolean) -> Unit,
+    isSubmitting: Boolean = false,
+    errorMessage: String? = null,
 ) {
     if (showDialog) {
         var title by remember { mutableStateOf("") }
         var description by remember { mutableStateOf("") }
 
-        Dialog(onDismissRequest = onDismiss) {
+        Dialog(
+            onDismissRequest = {
+                if (!isSubmitting) {
+                    onDismiss()
+                }
+            },
+        ) {
             Surface(
                 shape = RoundedCornerShape(16.dp),
                 color = MaterialTheme.colorScheme.surface,
-                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .testTag(CREATE_COLLECTION_DIALOG_TAG),
             ) {
                 Column(
                     modifier = Modifier
@@ -78,7 +90,10 @@ fun CreateCollectionDialog(
                         onValueChange = { title = it },
                         label = { Text("收藏夹名称") },
                         placeholder = { Text("请输入收藏夹名称") },
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag(CREATE_COLLECTION_TITLE_INPUT_TAG),
+                        enabled = !isSubmitting,
                         singleLine = true,
                     )
 
@@ -89,6 +104,7 @@ fun CreateCollectionDialog(
                         label = { Text("描述（可选）") },
                         placeholder = { Text("请输入收藏夹描述") },
                         modifier = Modifier.fillMaxWidth(),
+                        enabled = !isSubmitting,
                         maxLines = 3,
                     )
 
@@ -99,6 +115,7 @@ fun CreateCollectionDialog(
                         Checkbox(
                             checked = isPublic,
                             onCheckedChange = { isPublic = it },
+                            enabled = !isSubmitting,
                         )
                         Text(
                             text = "公开收藏夹",
@@ -107,12 +124,23 @@ fun CreateCollectionDialog(
                         )
                     }
 
+                    errorMessage?.let {
+                        Text(
+                            text = it,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+
                     // 按钮行
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.End,
                     ) {
-                        TextButton(onClick = onDismiss) {
+                        TextButton(
+                            onClick = onDismiss,
+                            enabled = !isSubmitting,
+                        ) {
                             Text("取消")
                         }
                         Spacer(modifier = Modifier.width(8.dp))
@@ -120,12 +148,12 @@ fun CreateCollectionDialog(
                             onClick = {
                                 if (title.isNotBlank()) {
                                     onConfirm(title.trim(), description.trim(), isPublic)
-                                    onDismiss()
                                 }
                             },
-                            enabled = title.isNotBlank(),
+                            enabled = title.isNotBlank() && !isSubmitting,
+                            modifier = Modifier.testTag(CREATE_COLLECTION_CONFIRM_TAG),
                         ) {
-                            Text("创建")
+                            Text(if (isSubmitting) "创建中…" else "创建")
                         }
                     }
                 }
@@ -133,3 +161,7 @@ fun CreateCollectionDialog(
         }
     }
 }
+
+private const val CREATE_COLLECTION_DIALOG_TAG = "create_collection_dialog"
+private const val CREATE_COLLECTION_TITLE_INPUT_TAG = "create_collection_title_input"
+private const val CREATE_COLLECTION_CONFIRM_TAG = "create_collection_confirm"

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/CollectionsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/CollectionsViewModel.kt
@@ -17,12 +17,129 @@
 
 package com.github.zly2006.zhihu.viewmodel
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import com.github.zly2006.zhihu.ui.Collection
+import io.ktor.client.call.body
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import kotlin.reflect.typeOf
 
 class CollectionsViewModel(
     val urlToken: String,
 ) : PaginationViewModel<Collection>(typeOf<Collection>()) {
+    var isCreatingCollection by mutableStateOf(false)
+        private set
+    var createCollectionError by mutableStateOf<String?>(null)
+        private set
+    var deletingCollectionId by mutableStateOf<String?>(null)
+        private set
+    var deleteCollectionError by mutableStateOf<String?>(null)
+        private set
+
     override val initialUrl: String
         get() = "https://www.zhihu.com/api/v4/people/$urlToken/collections"
+
+    suspend fun createCollection(
+        environment: ZhihuApiEnvironment,
+        title: String,
+        description: String,
+        isPublic: Boolean,
+    ): Boolean {
+        if (isCreatingCollection) return false
+        isCreatingCollection = true
+        createCollectionError = null
+        return try {
+            val response = environment.postSigned("https://www.zhihu.com/api/v4/collections") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    buildJsonObject {
+                        put("title", title)
+                        put("description", description)
+                        put("is_public", isPublic)
+                    },
+                )
+            }
+            if (!response.status.isSuccess()) {
+                error("创建收藏夹失败：${response.status}")
+            }
+            val responseBody = response.body<JsonObject>()
+            val collectionId = (responseBody["collection"] as? JsonObject)
+                ?.get("id")
+                ?.jsonPrimitive
+                ?.contentOrNull
+            if (responseBody["status"]?.jsonPrimitive?.intOrNull != 100 || collectionId.isNullOrBlank()) {
+                error(
+                    responseBody["message"]
+                        ?.jsonPrimitive
+                        ?.contentOrNull
+                        ?.takeIf(String::isNotBlank)
+                        ?: "创建收藏夹失败：响应无效",
+                )
+            }
+            true
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            createCollectionError = e.message ?: "创建收藏夹失败"
+            false
+        } finally {
+            isCreatingCollection = false
+        }
+    }
+
+    suspend fun deleteCollection(
+        environment: ZhihuApiEnvironment,
+        collection: Collection,
+    ): Boolean {
+        if (deletingCollectionId != null) return false
+        if (collection.isDefault) {
+            deleteCollectionError = "默认收藏夹不能删除"
+            return false
+        }
+        deletingCollectionId = collection.id
+        deleteCollectionError = null
+        return try {
+            val response = environment.deleteSigned(
+                "https://www.zhihu.com/api/v4/collections/${collection.id}",
+            )
+            if (!response.status.isSuccess()) {
+                error("删除收藏夹失败：${response.status}")
+            }
+            val responseBody = response.body<JsonObject>()
+            if (responseBody["success"]?.jsonPrimitive?.booleanOrNull != true) {
+                error(
+                    responseBody["message"]
+                        ?.jsonPrimitive
+                        ?.contentOrNull
+                        ?.takeIf(String::isNotBlank)
+                        ?: "删除收藏夹失败：响应无效",
+                )
+            }
+            true
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            deleteCollectionError = e.message ?: "删除收藏夹失败"
+            false
+        } finally {
+            deletingCollectionId = null
+        }
+    }
+
+    fun clearMutationErrors() {
+        createCollectionError = null
+        deleteCollectionError = null
+    }
 }


### PR DESCRIPTION
## 改动

- 在“我的收藏夹”页面右下角增加新建 FAB，复用现有新建收藏夹对话框，并展示提交中与失败状态。
- 为非默认收藏夹增加删除入口、二次确认、提交中与失败状态；默认收藏夹不提供删除操作。
- 新建或删除成功后刷新收藏夹列表。
- 随本功能补充并行 PR 工作流说明：仅提及 skill 不代表授权使用 subagent；任务期间持续检查主工作区，发现他人修改或脏状态时改用独立 worktree。

## API 证据

- 使用当前登录态真实请求验证 `POST /api/v4/collections`：JSON 参数为 `title`、`description`、`is_public`，响应需同时满足 HTTP 成功、`status = 100` 且返回收藏夹 ID。
- 仅删除本次验证新建的空临时收藏夹，验证 `DELETE /api/v4/collections/{id}` 返回 HTTP 200 与 `success = true`；列表中该 ID 随后消失。

## 验证

- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process assembleLiteDebug`
- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process ktlintFormat`
- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process :app:assembleLiteDebugAndroidTest`
- GitHub CI Android 15 / API 35：请求契约定向测试 3 项、收藏夹页面定向测试 5 项全部通过。[CI run 30539766869](https://github.com/zly2006/zhihu-plus-plus/actions/runs/30539766869) 的其他 4 个 instrument 分片、单测、构建和 KtLint 通过；Shard 3 重跑后仍仅在 diff 外的长文全选和系统状态栏用例失败。
- `zhihu-parallel-pr-workflow` skill 校验通过。

Resolves #525
