### PR TITLE
feat: 新增原生手机号登录（减少需要CAPTCHA的次数）

### DIFF
--- a/app/src/main/java/com/github/zly2006/zhihu/LoginActivity.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/LoginActivity.kt
@@ -49,6 +49,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
@@ -57,6 +59,7 @@ import com.github.zly2006.zhihu.account.SharedQrLoginPane
 import com.github.zly2006.zhihu.account.ZHIHU_DESKTOP_USER_AGENT
 import com.github.zly2006.zhihu.account.ZHIHU_HOME_URL
 import com.github.zly2006.zhihu.account.ZHIHU_SIGNIN_URL
+import com.github.zly2006.zhihu.account.ZhihuMobileLoginToken
 import com.github.zly2006.zhihu.account.parseCookieAssignments
 import com.github.zly2006.zhihu.data.AccountData
 import com.github.zly2006.zhihu.theme.ZhihuTheme
@@ -69,6 +72,7 @@ import kotlinx.coroutines.launch
 
 private const val LOGIN_MODE_WEB = 0
 private const val LOGIN_MODE_QR = 1
+private const val LOGIN_MODE_PHONE = 2
 
 class LoginActivity : ComponentActivity() {
     private var isCompletingLogin = false
@@ -80,11 +84,12 @@ class LoginActivity : ComponentActivity() {
         setContent {
             ZhihuTheme {
                 var currentNoticeStep by rememberSaveable { mutableIntStateOf(0) }
-                var loginMode by rememberSaveable { mutableIntStateOf(LOGIN_MODE_WEB) }
+                var loginMode by rememberSaveable { mutableIntStateOf(LOGIN_MODE_PHONE) }
 
                 Surface(
                     modifier = Modifier
                         .fillMaxSize()
+                        .semantics { testTagsAsResourceId = true }
                         .systemBarsPadding(),
                 ) {
                     if (currentNoticeStep >= 3) {
@@ -214,13 +219,23 @@ class LoginActivity : ComponentActivity() {
         }
     }
 
-    suspend fun finalizeLoginFromCookies(cookies: Map<String, String>): Boolean {
+    suspend fun finalizeLoginFromCookies(cookies: Map<String, String>): Boolean =
+        finalizeLogin {
+            AccountData.verifyLogin(this, cookies)
+        }
+
+    suspend fun finalizeMobileLogin(token: ZhihuMobileLoginToken): Boolean =
+        finalizeLogin {
+            AccountData.verifyMobileLogin(this, token)
+        }
+
+    private suspend fun finalizeLogin(verifyLogin: suspend () -> Boolean): Boolean {
         if (isCompletingLogin) {
             return false
         }
         isCompletingLogin = true
         return try {
-            if (AccountData.verifyLogin(this, cookies)) {
+            if (verifyLogin()) {
                 val data = AccountData.loadData(this)
                 AlertDialog
                     .Builder(this)
@@ -269,11 +284,11 @@ private fun LoginModeScreen(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             LoginModeButton(
-                text = "网页登录",
-                selected = loginMode == LOGIN_MODE_WEB,
-                tag = "login_mode_web",
+                text = "手机号登录",
+                selected = loginMode == LOGIN_MODE_PHONE,
+                tag = "login_mode_phone",
                 modifier = Modifier.weight(1f),
-                onClick = { onModeChanged(LOGIN_MODE_WEB) },
+                onClick = { onModeChanged(LOGIN_MODE_PHONE) },
             )
             LoginModeButton(
                 text = "扫码登录",
@@ -282,6 +297,13 @@ private fun LoginModeScreen(
                 modifier = Modifier.weight(1f),
                 onClick = { onModeChanged(LOGIN_MODE_QR) },
             )
+            LoginModeButton(
+                text = "备用网页登录",
+                selected = loginMode == LOGIN_MODE_WEB,
+                tag = "login_mode_web",
+                modifier = Modifier.weight(1f),
+                onClick = { onModeChanged(LOGIN_MODE_WEB) },
+            )
         }
 
         Box(
@@ -289,15 +311,18 @@ private fun LoginModeScreen(
                 .fillMaxWidth()
                 .weight(1f),
         ) {
-            if (loginMode == LOGIN_MODE_WEB) {
-                WebviewComp(
-                    modifier = Modifier.fillMaxSize(),
-                    onLoad = { webView ->
-                        activity.configureWebLogin(webView)
-                    },
-                )
-            } else {
-                QrLoginPane(activity = activity)
+            when (loginMode) {
+                LOGIN_MODE_WEB -> {
+                    WebviewComp(
+                        modifier = Modifier.fillMaxSize(),
+                        onLoad = { webView ->
+                            activity.configureWebLogin(webView)
+                        },
+                    )
+                }
+
+                LOGIN_MODE_QR -> QrLoginPane(activity = activity)
+                LOGIN_MODE_PHONE -> PhoneLoginPane(activity = activity)
             }
         }
     }

--- a/app/src/main/java/com/github/zly2006/zhihu/PhoneLoginPane.kt
+++ b/app/src/main/java/com/github/zly2006/zhihu/PhoneLoginPane.kt
@@ -1,0 +1,417 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.BitmapFactory
+import android.os.Build
+import android.os.Environment
+import android.os.StatFs
+import android.util.Base64
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.core.app.NotificationManagerCompat
+import com.github.zly2006.zhihu.account.ZhihuPhoneDigitsResult
+import com.github.zly2006.zhihu.account.ZhihuPhoneLoginClient
+import com.github.zly2006.zhihu.account.ZhihuPhoneLoginDeviceInfo
+import com.github.zly2006.zhihu.data.AccountData
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.TimeZone
+import kotlin.time.Clock
+
+@Composable
+internal fun PhoneLoginPane(activity: LoginActivity) {
+    val context = LocalContext.current
+    val cookies = remember { mutableMapOf<String, String>() }
+    val httpClient = remember { AccountData.httpClient(context, cookies) }
+    val deviceInfo = remember(context) { context.phoneLoginDeviceInfo() }
+    val loginClient = remember {
+        ZhihuPhoneLoginClient(
+            httpClient = httpClient,
+            cookies = cookies,
+            deviceInfo = deviceInfo,
+            nowEpochSeconds = { Clock.System.now().toEpochMilliseconds() / 1000 },
+        )
+    }
+    DisposableEffect(httpClient) {
+        onDispose(httpClient::close)
+    }
+
+    val scope = rememberCoroutineScope()
+    var phoneNumber by remember { mutableStateOf("") }
+    var digits by remember { mutableStateOf("") }
+    var captchaInput by remember { mutableStateOf("") }
+    var captchaImageBase64 by remember { mutableStateOf<String?>(null) }
+    var captchaRequired by remember { mutableStateOf(false) }
+    var agreementAccepted by remember { mutableStateOf(false) }
+    var hasRequestedDigits by remember { mutableStateOf(false) }
+    var isSendingDigits by remember { mutableStateOf(false) }
+    var isLoggingIn by remember { mutableStateOf(false) }
+    var resendSeconds by remember { mutableIntStateOf(0) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(resendSeconds) {
+        if (resendSeconds > 0) {
+            delay(1_000)
+            resendSeconds--
+        }
+    }
+
+    val sendDigits: suspend () -> Unit = {
+        errorMessage = null
+        isSendingDigits = true
+        try {
+            when (val result = loginClient.requestDigits(phoneNumber)) {
+                ZhihuPhoneDigitsResult.Sent -> {
+                    hasRequestedDigits = true
+                    captchaRequired = false
+                    captchaImageBase64 = null
+                    captchaInput = ""
+                    resendSeconds = 60
+                }
+
+                is ZhihuPhoneDigitsResult.CaptchaRequired -> {
+                    captchaRequired = true
+                    captchaImageBase64 = result.imageBase64
+                    if (result.imageBase64 == null) {
+                        errorMessage = "服务器未返回图形验证码，请换一张重试"
+                    }
+                }
+            }
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            errorMessage = error.message ?: "发送验证码失败"
+        } finally {
+            isSendingDigits = false
+        }
+    }
+    val verifyCaptchaAndSend: suspend () -> Unit = {
+        isSendingDigits = true
+        errorMessage = null
+        try {
+            if (loginClient.verifyCaptcha(captchaInput)) {
+                isSendingDigits = false
+                sendDigits()
+            } else {
+                errorMessage = "图形验证码不正确"
+            }
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            errorMessage = error.message ?: "验证图形验证码失败"
+        } finally {
+            isSendingDigits = false
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = "手机号登录",
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        Text(
+            text = "使用知乎官方 Android 登录协议。是否需要图形验证码由知乎风控实时决定。",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        OutlinedTextField(
+            value = phoneNumber,
+            onValueChange = { value ->
+                val nextPhoneNumber = value.filter(Char::isDigit).take(11)
+                if (phoneNumber != nextPhoneNumber) {
+                    phoneNumber = nextPhoneNumber
+                    digits = ""
+                    hasRequestedDigits = false
+                    captchaRequired = false
+                    captchaImageBase64 = null
+                    captchaInput = ""
+                }
+            },
+            label = { Text("手机号") },
+            leadingIcon = { Text("+86") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Phone,
+                imeAction = ImeAction.Next,
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("phone_login_phone"),
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { agreementAccepted = !agreementAccepted }
+                .testTag("phone_login_agreement"),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Checkbox(
+                checked = agreementAccepted,
+                onCheckedChange = { agreementAccepted = it },
+            )
+            Text(
+                text = "我已阅读并同意《知乎协议》《个人信息保护指引》",
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.weight(1f),
+            )
+        }
+
+        Button(
+            onClick = { scope.launch { sendDigits() } },
+            enabled = agreementAccepted &&
+                phoneNumber.length == 11 &&
+                resendSeconds == 0 &&
+                !isSendingDigits &&
+                !isLoggingIn,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("phone_login_send_digits"),
+        ) {
+            if (isSendingDigits) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                )
+            } else {
+                Text(
+                    if (resendSeconds > 0) {
+                        "$resendSeconds 秒后可重新发送"
+                    } else {
+                        "发送验证码"
+                    },
+                )
+            }
+        }
+
+        if (captchaRequired) {
+            val captchaBitmap = remember(captchaImageBase64) {
+                runCatching {
+                    val image = captchaImageBase64.orEmpty()
+                    val encoded = image.substringAfter("base64,", image)
+                    val bytes = Base64.decode(encoded, Base64.DEFAULT)
+                    BitmapFactory.decodeByteArray(bytes, 0, bytes.size)?.asImageBitmap()
+                }.getOrNull()
+            }
+            captchaBitmap?.let { image ->
+                Image(
+                    bitmap = image,
+                    contentDescription = "图形验证码",
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(96.dp)
+                        .testTag("phone_login_captcha_image"),
+                )
+            }
+            OutlinedTextField(
+                value = captchaInput,
+                onValueChange = { captchaInput = it },
+                label = { Text("图形验证码") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        if (captchaInput.isNotBlank() && !isSendingDigits) {
+                            scope.launch { verifyCaptchaAndSend() }
+                        }
+                    },
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("phone_login_captcha_input"),
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                OutlinedButton(
+                    onClick = {
+                        scope.launch {
+                            isSendingDigits = true
+                            errorMessage = null
+                            try {
+                                captchaImageBase64 = loginClient.refreshCaptcha()
+                                if (captchaImageBase64 == null) {
+                                    errorMessage = "服务器未返回图形验证码，请稍后重试"
+                                }
+                            } catch (error: CancellationException) {
+                                throw error
+                            } catch (error: Exception) {
+                                errorMessage = error.message ?: "刷新图形验证码失败"
+                            } finally {
+                                isSendingDigits = false
+                            }
+                        }
+                    },
+                    enabled = !isSendingDigits,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text("换一张")
+                }
+                Button(
+                    onClick = {
+                        scope.launch { verifyCaptchaAndSend() }
+                    },
+                    enabled = captchaInput.isNotBlank() && !isSendingDigits,
+                    modifier = Modifier
+                        .weight(1f)
+                        .testTag("phone_login_verify_captcha"),
+                ) {
+                    Text("验证并发送")
+                }
+            }
+        }
+
+        OutlinedTextField(
+            value = digits,
+            onValueChange = { value ->
+                digits = value.filter(Char::isDigit).take(6)
+            },
+            label = { Text("短信验证码") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.NumberPassword,
+                imeAction = ImeAction.Done,
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("phone_login_digits"),
+        )
+
+        Button(
+            onClick = {
+                scope.launch {
+                    isLoggingIn = true
+                    errorMessage = null
+                    try {
+                        val token = loginClient.signIn(phoneNumber, digits)
+                        if (!activity.finalizeMobileLogin(token)) {
+                            errorMessage = "登录凭证验证失败，请重试"
+                        }
+                    } catch (error: CancellationException) {
+                        throw error
+                    } catch (error: Exception) {
+                        errorMessage = error.message ?: "登录失败"
+                    } finally {
+                        isLoggingIn = false
+                    }
+                }
+            },
+            enabled = agreementAccepted &&
+                hasRequestedDigits &&
+                phoneNumber.length == 11 &&
+                digits.length == 6 &&
+                !isSendingDigits &&
+                !isLoggingIn,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("phone_login_submit"),
+        ) {
+            if (isLoggingIn) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                )
+            } else {
+                Text("登录")
+            }
+        }
+
+        errorMessage?.let { message ->
+            Text(
+                text = message,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.testTag("phone_login_error"),
+            )
+        }
+    }
+}
+
+private fun Context.phoneLoginDeviceInfo(): ZhihuPhoneLoginDeviceInfo {
+    val runtime = Runtime.getRuntime()
+    val storage = StatFs(Environment.getDataDirectory().path)
+    val installTime = runCatching {
+        packageManager.getPackageInfo(packageName, 0).firstInstallTime
+    }.getOrDefault(0L)
+    return ZhihuPhoneLoginDeviceInfo(
+        timezoneOffsetSeconds = TimeZone.getDefault().rawOffset / 1_000L,
+        appInstallTimeMillis = installTime,
+        notificationEnabled = NotificationManagerCompat.from(this).areNotificationsEnabled(),
+        bluetoothAvailable = packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH),
+        phoneBrand = Build.BRAND,
+        phoneModel = Build.MODEL,
+        androidRelease = Build.VERSION.RELEASE,
+        cpuType = Build.SUPPORTED_ABIS.firstOrNull().orEmpty(),
+        cpuCount = runtime.availableProcessors(),
+        cpuUsage = "0.0",
+        totalMemoryMegabytes = (runtime.totalMemory() / 1_048_576L).toInt(),
+        freeMemoryMegabytes = (runtime.freeMemory() / 1_048_576L).toInt(),
+        totalStorageMegabytes = (storage.totalBytes / 1_048_576L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
+        freeStorageMegabytes = (storage.availableBytes / 1_048_576L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
+    )
+}

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/data/AccountData.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/data/AccountData.kt
@@ -31,6 +31,7 @@ import com.github.zly2006.zhihu.account.ZhihuAccountRepository
 import com.github.zly2006.zhihu.account.ZhihuAccountSession
 import com.github.zly2006.zhihu.account.ZhihuAccountSessionStore
 import com.github.zly2006.zhihu.account.ZhihuIdentityClient
+import com.github.zly2006.zhihu.account.ZhihuMobileLoginToken
 import com.github.zly2006.zhihu.data.Person
 import com.github.zly2006.zhihu.data.ZhihuJson
 import com.github.zly2006.zhihu.data.installZhihuCommonClientConfig
@@ -158,6 +159,11 @@ object AccountData {
 
     suspend fun verifyLogin(context: Context, cookies: Map<String, String>): Boolean =
         accountClient(context).verifyAndSave(cookies.toMutableMap())
+
+    suspend fun verifyMobileLogin(
+        context: Context,
+        token: ZhihuMobileLoginToken,
+    ): Boolean = accountClient(context).verifyMobileAndSave(token)
 
     fun delete(context: Context) {
         accountClient(context).clear()

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/account/ZhihuAccountClient.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/account/ZhihuAccountClient.kt
@@ -94,6 +94,25 @@ class ZhihuAccountClient(
         }
     }
 
+    suspend fun verifyMobileAndSave(token: ZhihuMobileLoginToken): Boolean {
+        val cookies = token.cookies.toMutableMap()
+        val temporaryClient = temporaryHttpClient(cookies)
+        try {
+            val verified = fetchVerifiedZhihuSession(temporaryClient, cookies, load().userAgent) ?: return false
+            save(
+                verified.copy(
+                    mobileAccessToken = token.accessToken,
+                    mobileRefreshToken = token.refreshToken,
+                    mobileTokenType = token.tokenType,
+                    mobileTokenExpiresAt = token.expiresAt,
+                ),
+            )
+            return true
+        } finally {
+            temporaryClient.close()
+        }
+    }
+
     suspend fun refreshAndSaveProfile(): ZhihuAccountSession? {
         val currentSession = load()
         val refreshed = fetchVerifiedZhihuSession(httpClient(), currentSession.cookies, currentSession.userAgent)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/account/ZhihuPhoneLoginClient.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/account/ZhihuPhoneLoginClient.kt
@@ -1,0 +1,411 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.account
+
+import com.github.zly2006.zhihu.data.ZhihuJson
+import com.github.zly2006.zhihu.util.ZhihuMessageBodyEncryptor
+import com.github.zly2006.zhihu.util.hmacSha1Hex
+import io.ktor.client.HttpClient
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.accept
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.Parameters
+import io.ktor.http.contentType
+import io.ktor.http.formUrlEncode
+import io.ktor.http.isSuccess
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+private const val PHONE_LOGIN_API_BASE_URL = "https://api.zhihu.com"
+private const val DEVICE_GUEST_INIT_PATH = "/api/account/prod/init/udid_guest"
+private const val CAPTCHA_PATH = "/captcha"
+private const val AUTH_DIGITS_PATH = "/api/account/prod/auth/digits"
+private const val SIGN_IN_PATH = "/api/account/prod/sign_in"
+
+private const val MOBILE_CLIENT_ID = "8d5227e0aaaa4797a763ac64e0c3b8"
+private const val MOBILE_CLIENT_SECRET = "ecbefbf6b17e47ecb9035107866380"
+private const val MOBILE_SOURCE = "com.zhihu.android"
+private const val DIGITS_GRANT_TYPE = "digits"
+private const val CLOUD_APP_ID = "1355"
+private const val CLOUD_APP_SECRET = "dd49a835-56e7-4a0f-95b5-efd51ea5397f"
+private const val CLOUD_SIGN_VERSION = "2"
+
+const val ZHIHU_ANDROID_PHONE_LOGIN_USER_AGENT =
+    "com.zhihu.android/Futureve/11.4.0 Mozilla/5.0 (Linux; Android 12; Android SDK built for arm64 " +
+        "Build/SE1A.220621.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 " +
+        "Chrome/57.0.1000.10 Mobile Safari/537.36"
+
+data class ZhihuMobileLoginToken(
+    val accessToken: String,
+    val refreshToken: String?,
+    val tokenType: String,
+    val expiresAt: Long?,
+    val cookies: Map<String, String>,
+)
+
+data class ZhihuPhoneLoginDeviceInfo(
+    val timezoneOffsetSeconds: Long,
+    val appInstallTimeMillis: Long,
+    val notificationEnabled: Boolean,
+    val bluetoothAvailable: Boolean,
+    val phoneBrand: String,
+    val phoneModel: String,
+    val androidRelease: String,
+    val cpuType: String,
+    val cpuCount: Int,
+    val cpuUsage: String,
+    val totalMemoryMegabytes: Int,
+    val freeMemoryMegabytes: Int,
+    val totalStorageMegabytes: Int,
+    val freeStorageMegabytes: Int,
+) {
+    internal fun formParameters(): Parameters = Parameters.build {
+        append("app_build", "40408")
+        append("app_install_time", appInstallTimeMillis.toString())
+        append("app_ticket", "interface is empty")
+        append("app_version", "11.4.0")
+        append("bt_ck", if (bluetoothAvailable) "1" else "0")
+        append("bundle_id", MOBILE_SOURCE)
+        append("cp_ct", cpuCount.toString())
+        append("cp_tp", cpuType)
+        append("cp_us", cpuUsage)
+        append("d_n", phoneModel)
+        append("fr_mem", freeMemoryMegabytes.toString())
+        append("fr_st", freeStorageMegabytes.toString())
+        append("latitude", "0.0")
+        append("longitude", "0.0")
+        append("nt_st", if (notificationEnabled) "1" else "0")
+        append("ph_br", phoneBrand)
+        append("ph_md", phoneModel)
+        append("ph_os", "Android $androidRelease")
+        append("pre_install", "InterfaceIsNull")
+        append("tt_mem", totalMemoryMegabytes.toString())
+        append("tt_st", totalStorageMegabytes.toString())
+        append("tz_of", timezoneOffsetSeconds.toString())
+        append("zx_expired", "0")
+    }
+}
+
+sealed interface ZhihuPhoneDigitsResult {
+    data object Sent : ZhihuPhoneDigitsResult
+
+    data class CaptchaRequired(
+        val imageBase64: String?,
+    ) : ZhihuPhoneDigitsResult
+}
+
+class ZhihuPhoneLoginException(
+    message: String,
+    val statusCode: Int,
+    val errorCode: Int? = null,
+) : IllegalStateException(message)
+
+/**
+ * 知乎 Android 客户端手机号登录协议。
+ *
+ * Captcha 是服务端条件分支：正常情况下服务端会直接允许发送短信，但风控要求验证时必须先完成 `/captcha`，
+ * 不能把当前抓包中没有出现验证码误解成可以永久绕过验证码。
+ */
+class ZhihuPhoneLoginClient(
+    private val httpClient: HttpClient,
+    private val cookies: MutableMap<String, String>,
+    private val deviceInfo: ZhihuPhoneLoginDeviceInfo,
+    private val nowEpochSeconds: () -> Long,
+) {
+    private var authorization = "oauth $MOBILE_CLIENT_ID"
+    private var deviceId: String? = null
+
+    suspend fun requestDigits(phoneNumber: String): ZhihuPhoneDigitsResult {
+        val username = normalizePhoneNumber(phoneNumber)
+        ensureGuestToken()
+
+        val captchaState = requestCaptchaState()
+        if (captchaState.showCaptcha) {
+            return ZhihuPhoneDigitsResult.CaptchaRequired(refreshCaptcha())
+        }
+
+        return sendDigits(username, recheckCaptchaWhenRequested = true)
+    }
+
+    private suspend fun sendDigits(
+        username: String,
+        recheckCaptchaWhenRequested: Boolean,
+    ): ZhihuPhoneDigitsResult {
+        val response = httpClient.post("$PHONE_LOGIN_API_BASE_URL$AUTH_DIGITS_PATH") {
+            applyMobileHeaders()
+            setEncryptedForm(
+                "username" to username,
+                "client_id" to MOBILE_CLIENT_ID,
+            )
+        }
+        val body = response.bodyAsText()
+        if (response.status.isSuccess()) {
+            return ZhihuPhoneDigitsResult.Sent
+        }
+
+        val error = response.decodeError(body)
+        if (error.code in CAPTCHA_INVALID_ERROR_CODES) {
+            return ZhihuPhoneDigitsResult.CaptchaRequired(refreshCaptcha())
+        }
+        if (error.code == CAPTCHA_NEEDED_ERROR_CODE && recheckCaptchaWhenRequested) {
+            val captchaState = requestCaptchaState()
+            return if (captchaState.showCaptcha) {
+                ZhihuPhoneDigitsResult.CaptchaRequired(refreshCaptcha())
+            } else {
+                sendDigits(username, recheckCaptchaWhenRequested = false)
+            }
+        }
+        throw error.toException(response)
+    }
+
+    suspend fun refreshCaptcha(): String? {
+        ensureGuestToken()
+        val response = httpClient.put("$PHONE_LOGIN_API_BASE_URL$CAPTCHA_PATH") {
+            applyMobileHeaders()
+        }
+        val body = response.successBody("获取图形验证码")
+        return ZhihuJson.json.decodeFromString<CaptchaResponse>(body).imageBase64
+    }
+
+    suspend fun verifyCaptcha(input: String): Boolean {
+        require(input.isNotBlank()) { "图形验证码不能为空" }
+        ensureGuestToken()
+        val response = httpClient.post("$PHONE_LOGIN_API_BASE_URL$CAPTCHA_PATH") {
+            applyMobileHeaders()
+            setEncryptedForm("input_text" to input.trim())
+        }
+        val body = response.successBody("验证图形验证码")
+        return ZhihuJson.json.decodeFromString<CaptchaVerificationResponse>(body).success
+    }
+
+    suspend fun signIn(
+        phoneNumber: String,
+        digits: String,
+    ): ZhihuMobileLoginToken {
+        val username = normalizePhoneNumber(phoneNumber)
+        require(digits.isNotBlank()) { "短信验证码不能为空" }
+        ensureGuestToken()
+
+        val timestamp = nowEpochSeconds()
+        val signature = hmacSha1Hex(
+            MOBILE_CLIENT_SECRET,
+            "$DIGITS_GRANT_TYPE$MOBILE_CLIENT_ID$MOBILE_SOURCE$timestamp",
+        )
+        val response = httpClient.post("$PHONE_LOGIN_API_BASE_URL$SIGN_IN_PATH") {
+            applyMobileHeaders()
+            setEncryptedForm(
+                "client_id" to MOBILE_CLIENT_ID,
+                "digits" to digits.trim(),
+                "grant_type" to DIGITS_GRANT_TYPE,
+                "signature" to signature,
+                "source" to MOBILE_SOURCE,
+                "timestamp" to timestamp.toString(),
+                "username" to username,
+            )
+        }
+        val body = response.successBody("手机号登录")
+        val token = ZhihuJson.json.decodeFromString<TokenResponse>(body)
+        check(token.accessToken.isNotBlank()) { "服务器未返回登录凭证" }
+        cookies.putAll(token.cookie.values())
+        return ZhihuMobileLoginToken(
+            accessToken = token.accessToken,
+            refreshToken = token.refreshToken,
+            tokenType = token.tokenType,
+            expiresAt = token.expiresIn?.let(timestamp::plus),
+            cookies = cookies.toMap(),
+        )
+    }
+
+    private suspend fun ensureGuestToken() {
+        if (!authorization.startsWith("oauth ")) return
+
+        val timestamp = nowEpochSeconds().toString()
+        val form = deviceInfo.formParameters().formUrlEncode()
+        val signature = hmacSha1Hex(
+            CLOUD_APP_SECRET,
+            CLOUD_APP_ID + CLOUD_SIGN_VERSION + form + timestamp,
+        )
+        val response = httpClient.post("$PHONE_LOGIN_API_BASE_URL$DEVICE_GUEST_INIT_PATH") {
+            applyMobileHeaders()
+            header("x-app-id", CLOUD_APP_ID)
+            header("x-sign-version", CLOUD_SIGN_VERSION)
+            header("x-req-ts", timestamp)
+            header("x-req-signature", signature)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(ZhihuMessageBodyEncryptor.encrypt(form))
+        }
+        val body = response.successBody("初始化手机号登录")
+        val initialization = ZhihuJson.json.decodeFromString<DeviceGuestInitializationResponse>(body)
+        val guest = initialization.guest
+        check(guest.accessToken.isNotBlank()) { "服务器未返回访客凭证" }
+        check(initialization.deviceId.isNotBlank()) { "服务器未返回设备凭证" }
+        cookies.putAll(guest.cookie.values())
+        deviceId = initialization.deviceId
+        authorization = "${guest.tokenType.ifBlank { "bearer" }} ${guest.accessToken}"
+    }
+
+    private suspend fun requestCaptchaState(): CaptchaResponse {
+        val response = httpClient.get("$PHONE_LOGIN_API_BASE_URL$CAPTCHA_PATH") {
+            applyMobileHeaders()
+        }
+        return ZhihuJson.json.decodeFromString(response.successBody("检查图形验证码"))
+    }
+
+    private fun HttpRequestBuilder.applyMobileHeaders() {
+        accept(ContentType.Application.Json)
+        header(HttpHeaders.UserAgent, ZHIHU_ANDROID_PHONE_LOGIN_USER_AGENT)
+        header(HttpHeaders.Authorization, authorization)
+        deviceId?.let { header("x-udid", it) }
+        header("x-api-version", "3.0.93")
+        header("x-app-version", "11.4.0")
+        header("x-app-build", "release")
+        header("x-app-bundleid", MOBILE_SOURCE)
+        header("x-app-flavor", "honor")
+        header(
+            "x-app-za",
+            "OS=Android&Release=12&Model=Android+SDK+built+for+arm64&VersionName=11.4.0&VersionCode=40408&" +
+                "Product=com.zhihu.android&Width=1080&Height=2274&Installer=%E8%8D%A3%E8%80%80%E5%95%86%E5%BA%97&" +
+                "DeviceType=AndroidPhone&Brand=Android",
+        )
+        header("x-network-type", "3G")
+        header("x-page-id", "44")
+        header("x-zse-93", "101_1_1.0")
+    }
+
+    private fun HttpRequestBuilder.setEncryptedForm(vararg entries: Pair<String, String>) {
+        contentType(ContentType.Application.FormUrlEncoded)
+        val form = Parameters
+            .build {
+                entries.forEach { (name, value) -> append(name, value) }
+            }.formUrlEncode()
+        setBody(ZhihuMessageBodyEncryptor.encrypt(form))
+    }
+}
+
+private fun normalizePhoneNumber(phoneNumber: String): String {
+    val compact = phoneNumber
+        .trim()
+        .replace(" ", "")
+        .replace("-", "")
+    val local = when {
+        compact.startsWith("+86") -> compact.removePrefix("+86")
+        compact.startsWith("86") && compact.length == 13 -> compact.removePrefix("86")
+        else -> compact
+    }
+    require(local.length == 11 && local.all(Char::isDigit) && local.startsWith('1')) {
+        "请输入正确的中国大陆手机号"
+    }
+    return "+86$local"
+}
+
+private suspend fun HttpResponse.successBody(operation: String): String {
+    val body = bodyAsText()
+    if (status.isSuccess()) return body
+    throw decodeError(body).toException(this, operation)
+}
+
+private fun HttpResponse.decodeError(body: String): PhoneLoginError = runCatching {
+    val root = ZhihuJson.json.parseToJsonElement(body).jsonObject
+    val error = root["error"]?.jsonObject ?: root
+    PhoneLoginError(
+        code = error["code"]?.jsonPrimitive?.content?.toIntOrNull(),
+        message = error["message"]?.jsonPrimitive?.content,
+    )
+}.getOrDefault(PhoneLoginError())
+
+private fun PhoneLoginError.toException(
+    response: HttpResponse,
+    operation: String = "发送短信验证码",
+): ZhihuPhoneLoginException = ZhihuPhoneLoginException(
+    message = message?.let { "$operation 失败：$it" } ?: "$operation 失败（HTTP ${response.status.value}）",
+    statusCode = response.status.value,
+    errorCode = code,
+)
+
+@Serializable
+private data class GuestTokenResponse(
+    @SerialName("access_token")
+    val accessToken: String,
+    @SerialName("token_type")
+    val tokenType: String = "bearer",
+    val cookie: LoginCookie = LoginCookie(),
+)
+
+@Serializable
+private data class DeviceGuestInitializationResponse(
+    @SerialName("udid")
+    val deviceId: String,
+    val guest: GuestTokenResponse,
+)
+
+@Serializable
+private data class CaptchaResponse(
+    @SerialName("show_captcha")
+    val showCaptcha: Boolean = false,
+    @SerialName("img_base64")
+    val imageBase64: String? = null,
+)
+
+@Serializable
+private data class CaptchaVerificationResponse(
+    val success: Boolean = false,
+)
+
+@Serializable
+private data class TokenResponse(
+    @SerialName("access_token")
+    val accessToken: String,
+    @SerialName("refresh_token")
+    val refreshToken: String? = null,
+    @SerialName("token_type")
+    val tokenType: String = "bearer",
+    @SerialName("expires_in")
+    val expiresIn: Long? = null,
+    val cookie: LoginCookie = LoginCookie(),
+)
+
+@Serializable
+private data class LoginCookie(
+    @SerialName("q_c0")
+    val qCookie: String? = null,
+    @SerialName("z_c0")
+    val zCookie: String? = null,
+) {
+    fun values(): Map<String, String> = buildMap {
+        qCookie?.takeIf(String::isNotBlank)?.let { put("q_c0", it) }
+        zCookie?.takeIf(String::isNotBlank)?.let { put("z_c0", it) }
+    }
+}
+
+private data class PhoneLoginError(
+    val code: Int? = null,
+    val message: String? = null,
+)
+
+private val CAPTCHA_INVALID_ERROR_CODES = setOf(120001, 120002)
+private const val CAPTCHA_NEEDED_ERROR_CODE = 120005

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/account/ZhihuAccountClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/account/ZhihuAccountClientTest.kt
@@ -157,6 +157,52 @@ class ZhihuAccountClientTest {
         assertEquals(1234, repository.load().mobileTokenExpiresAt)
     }
 
+    @Test
+    fun mobileLoginVerifiesProfileAndSavesCookiesAndTokensTogether() = runTest {
+        val store = ClientInMemoryAccountSessionStore()
+        val repository = ZhihuAccountRepository(store)
+        val accountClient = ZhihuAccountClient(
+            repository = repository,
+            createClient = { cookies, session, onCookieChanged, _ ->
+                HttpClient(
+                    MockEngine { request ->
+                        assertEquals("/api/v4/me", request.url.encodedPath)
+                        respond(
+                            content = """{"id":"1","name":"alice","url_token":"alice","user_type":"people"}""",
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                        )
+                    },
+                ) {
+                    installZhihuCommonClientConfig(cookies, session.userAgent, onCookieChanged)
+                }
+            },
+        )
+
+        val verified = accountClient.verifyMobileAndSave(
+            ZhihuMobileLoginToken(
+                accessToken = "mobile-access",
+                refreshToken = "mobile-refresh",
+                tokenType = "bearer",
+                expiresAt = 1_700_003_600L,
+                cookies = mapOf(
+                    "q_c0" to "q-cookie",
+                    "z_c0" to "z-cookie",
+                ),
+            ),
+        )
+
+        val saved = repository.load()
+        assertEquals(true, verified)
+        assertEquals(1, store.writeCount)
+        assertEquals("alice", saved.username)
+        assertEquals("z-cookie", saved.cookies["z_c0"])
+        assertEquals("mobile-access", saved.mobileAccessToken)
+        assertEquals("mobile-refresh", saved.mobileRefreshToken)
+        assertEquals("bearer", saved.mobileTokenType)
+        assertEquals(1_700_003_600L, saved.mobileTokenExpiresAt)
+    }
+
     private fun testHttpClient(
         cookies: MutableMap<String, String>,
         session: ZhihuAccountSession,
@@ -181,10 +227,13 @@ class ZhihuAccountClientTest {
 private class ClientInMemoryAccountSessionStore(
     var text: String? = null,
 ) : ZhihuAccountSessionStore {
+    var writeCount: Int = 0
+
     override fun readText(): String? = text
 
     override fun writeText(text: String) {
         this.text = text
+        writeCount++
     }
 
     override fun delete() {

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/account/ZhihuPhoneLoginClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/account/ZhihuPhoneLoginClientTest.kt
@@ -1,0 +1,365 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.account
+
+import com.github.zly2006.zhihu.data.installZhihuCommonClientConfig
+import com.github.zly2006.zhihu.util.ZhihuMessageBodyEncryptor
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class ZhihuPhoneLoginClientTest {
+    @Test
+    fun guestCaptchaCheckAndDigitsRequestMatchOfficialProtocol() = runTest {
+        val cookies = mutableMapOf<String, String>()
+        var requestIndex = 0
+        val httpClient = phoneLoginTestClient(
+            MockEngine { request ->
+                requestIndex++
+                when (requestIndex) {
+                    1 -> {
+                        assertEquals(HttpMethod.Post, request.method)
+                        assertEquals("/api/account/prod/init/udid_guest", request.url.encodedPath)
+                        assertTrue(request.headers[HttpHeaders.Authorization].orEmpty().startsWith("oauth "))
+                        assertEquals("1355", request.headers["x-app-id"])
+                        assertEquals("2", request.headers["x-sign-version"])
+                        assertEquals("1700000000", request.headers["x-req-ts"])
+                        assertEquals(
+                            "32a3795d4beccbacb11cb806d67e155158e3566a",
+                            request.headers["x-req-signature"],
+                        )
+                        assertEquals("11.4.0", request.headers["x-app-version"])
+                        assertEquals("44", request.headers["x-page-id"])
+                        assertEquals("101_1_1.0", request.headers["x-zse-93"])
+                        assertTrue(
+                            request.headers[HttpHeaders.UserAgent]
+                                .orEmpty()
+                                .contains("Android SDK built for arm64"),
+                        )
+                        assertTrue(request.headers["x-app-za"].orEmpty().contains("Width=1080&Height=2274"))
+                        assertEncryptedBody(DEVICE_FORM, request.body)
+                        respondJson(
+                            """
+                            {
+                              "udid": "device-id",
+                              "guest": {
+                                "access_token": "guest-access",
+                                "token_type": "bearer",
+                                "cookie": {"q_c0": "guest-cookie"}
+                              }
+                            }
+                            """.trimIndent(),
+                        )
+                    }
+
+                    2 -> {
+                        assertEquals(HttpMethod.Get, request.method)
+                        assertEquals("/captcha", request.url.encodedPath)
+                        assertEquals("bearer guest-access", request.headers[HttpHeaders.Authorization])
+                        assertEquals("device-id", request.headers["x-udid"])
+                        assertTrue(request.headers[HttpHeaders.Cookie].orEmpty().contains("q_c0=guest-cookie"))
+                        respondJson("""{"show_captcha":false}""")
+                    }
+
+                    3 -> {
+                        assertEquals(HttpMethod.Post, request.method)
+                        assertEquals("/api/account/prod/auth/digits", request.url.encodedPath)
+                        assertEquals("bearer guest-access", request.headers[HttpHeaders.Authorization])
+                        assertEncryptedBody(
+                            "username=%2B8613800138000&client_id=8d5227e0aaaa4797a763ac64e0c3b8",
+                            request.body,
+                        )
+                        respondJson("""{"success":true}""")
+                    }
+
+                    else -> error("Unexpected request #$requestIndex")
+                }
+            },
+            cookies,
+        )
+        val client = ZhihuPhoneLoginClient(httpClient, cookies, DEVICE_INFO) { 1_700_000_000L }
+
+        val result = client.requestDigits("138 0013 8000")
+
+        assertIs<ZhihuPhoneDigitsResult.Sent>(result)
+        assertEquals("guest-cookie", cookies["q_c0"])
+        assertEquals(3, requestIndex)
+        httpClient.close()
+    }
+
+    @Test
+    fun captchaBranchLoadsImageAndVerifiesUserInputBeforeSendingDigits() = runTest {
+        val cookies = mutableMapOf<String, String>()
+        var requestIndex = 0
+        val httpClient = phoneLoginTestClient(
+            MockEngine { request ->
+                requestIndex++
+                when (requestIndex) {
+                    1 -> respondJson(INITIALIZATION_RESPONSE)
+
+                    2 -> {
+                        assertEquals(HttpMethod.Get, request.method)
+                        assertEquals("/captcha", request.url.encodedPath)
+                        respondJson("""{"show_captcha":true}""")
+                    }
+
+                    3 -> {
+                        assertEquals(HttpMethod.Put, request.method)
+                        assertEquals("/captcha", request.url.encodedPath)
+                        respondJson("""{"show_captcha":true,"img_base64":"image-data"}""")
+                    }
+
+                    4 -> {
+                        assertEquals(HttpMethod.Post, request.method)
+                        assertEquals("/captcha", request.url.encodedPath)
+                        assertEncryptedBody("input_text=a7Bc", request.body)
+                        respondJson("""{"success":true}""")
+                    }
+
+                    else -> error("Unexpected request #$requestIndex")
+                }
+            },
+            cookies,
+        )
+        val client = ZhihuPhoneLoginClient(httpClient, cookies, DEVICE_INFO) { 1_700_000_000L }
+
+        val result = client.requestDigits("13800138000")
+        assertEquals("image-data", assertIs<ZhihuPhoneDigitsResult.CaptchaRequired>(result).imageBase64)
+        assertTrue(client.verifyCaptcha(" a7Bc "))
+
+        assertEquals(4, requestIndex)
+        httpClient.close()
+    }
+
+    @Test
+    fun signInUsesDigitsSignatureAndReturnsCompleteMobileSession() = runTest {
+        val cookies = mutableMapOf("d_c0" to "device-cookie")
+        var requestIndex = 0
+        val httpClient = phoneLoginTestClient(
+            MockEngine { request ->
+                requestIndex++
+                when (requestIndex) {
+                    1 -> respondJson(
+                        """
+                        {
+                          "udid": "device-id",
+                          "guest": {
+                            "access_token": "guest-access",
+                            "token_type": "bearer",
+                            "cookie": {"q_c0": "guest-cookie"}
+                          }
+                        }
+                        """.trimIndent(),
+                    )
+
+                    2 -> {
+                        assertEquals(HttpMethod.Post, request.method)
+                        assertEquals("/api/account/prod/sign_in", request.url.encodedPath)
+                        assertEquals("bearer guest-access", request.headers[HttpHeaders.Authorization])
+                        assertEncryptedBody(
+                            "client_id=8d5227e0aaaa4797a763ac64e0c3b8&digits=123456&grant_type=digits&" +
+                                "signature=096465d8a44361e0393c87ab61b0d48a088b2cfb&source=com.zhihu.android&" +
+                                "timestamp=1700000000&username=%2B8613800138000",
+                            request.body,
+                        )
+                        respondJson(
+                            """
+                            {
+                              "access_token": "account-access",
+                              "refresh_token": "account-refresh",
+                              "token_type": "bearer",
+                              "expires_in": 3600,
+                              "cookie": {
+                                "q_c0": "account-q-cookie",
+                                "z_c0": "account-z-cookie"
+                              }
+                            }
+                            """.trimIndent(),
+                        )
+                    }
+
+                    else -> error("Unexpected request #$requestIndex")
+                }
+            },
+            cookies,
+        )
+        val client = ZhihuPhoneLoginClient(httpClient, cookies, DEVICE_INFO) { 1_700_000_000L }
+
+        val token = client.signIn("+8613800138000", "123456")
+
+        assertEquals("account-access", token.accessToken)
+        assertEquals("account-refresh", token.refreshToken)
+        assertEquals("bearer", token.tokenType)
+        assertEquals(1_700_003_600L, token.expiresAt)
+        assertEquals("device-cookie", token.cookies["d_c0"])
+        assertEquals("account-z-cookie", token.cookies["z_c0"])
+        assertEquals("account-q-cookie", token.cookies["q_c0"])
+        httpClient.close()
+    }
+
+    @Test
+    fun exposesServerErrorCodeForInvalidPhoneNumber() = runTest {
+        val cookies = mutableMapOf<String, String>()
+        var requestIndex = 0
+        val httpClient = phoneLoginTestClient(
+            MockEngine { request ->
+                requestIndex++
+                when (requestIndex) {
+                    1 -> respondJson(INITIALIZATION_RESPONSE)
+                    2 -> respondJson("""{"show_captcha":false}""")
+                    3 -> respondJson(
+                        body =
+                            """
+                            {
+                              "error": {
+                                "code": 100030,
+                                "name": "ERR_BAD_PHONE_NO_FORMAT",
+                                "message": "手机号格式错误"
+                              }
+                            }
+                            """.trimIndent(),
+                        status = HttpStatusCode.BadRequest,
+                    )
+
+                    else -> error("Unexpected request #$requestIndex")
+                }
+            },
+            cookies,
+        )
+        val client = ZhihuPhoneLoginClient(httpClient, cookies, DEVICE_INFO) { 1_700_000_000L }
+
+        val error = assertFailsWith<ZhihuPhoneLoginException> {
+            client.requestDigits("13800138000")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest.value, error.statusCode)
+        assertEquals(100030, error.errorCode)
+        assertTrue(error.message.orEmpty().contains("手机号格式错误"))
+        httpClient.close()
+    }
+
+    @Test
+    fun ticketNeededErrorRechecksCaptchaAndRetriesDigitsOnce() = runTest {
+        val cookies = mutableMapOf<String, String>()
+        var requestIndex = 0
+        val httpClient = phoneLoginTestClient(
+            MockEngine { request ->
+                requestIndex++
+                when (requestIndex) {
+                    1 -> respondJson(INITIALIZATION_RESPONSE)
+                    2 -> respondJson("""{"show_captcha":false}""")
+                    3 -> respondJson(
+                        body = """{"error":{"code":120005,"message":"需要重新检查验证码"}}""",
+                        status = HttpStatusCode.BadRequest,
+                    )
+
+                    4 -> {
+                        assertEquals(HttpMethod.Get, request.method)
+                        assertEquals("/captcha", request.url.encodedPath)
+                        respondJson("""{"show_captcha":false}""")
+                    }
+
+                    5 -> {
+                        assertEquals("/api/account/prod/auth/digits", request.url.encodedPath)
+                        respondJson("""{"success":true}""")
+                    }
+
+                    else -> error("Unexpected request #$requestIndex")
+                }
+            },
+            cookies,
+        )
+        val client = ZhihuPhoneLoginClient(httpClient, cookies, DEVICE_INFO) { 1_700_000_000L }
+
+        assertIs<ZhihuPhoneDigitsResult.Sent>(client.requestDigits("13800138000"))
+        assertEquals(5, requestIndex)
+        httpClient.close()
+    }
+
+    private fun phoneLoginTestClient(
+        engine: MockEngine,
+        cookies: MutableMap<String, String>,
+    ): HttpClient = HttpClient(engine) {
+        installZhihuCommonClientConfig(
+            cookies = cookies,
+            userAgent = "test-agent",
+        )
+    }
+
+    private fun MockRequestHandleScope.respondJson(
+        body: String,
+        status: HttpStatusCode = HttpStatusCode.OK,
+    ) = respond(
+        content = body,
+        status = status,
+        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+    )
+
+    private fun assertEncryptedBody(
+        expectedPlainText: String,
+        body: Any,
+    ) {
+        assertEquals(
+            ZhihuMessageBodyEncryptor.encrypt(expectedPlainText),
+            (body as TextContent).text,
+        )
+    }
+
+    private companion object {
+        val DEVICE_INFO = ZhihuPhoneLoginDeviceInfo(
+            timezoneOffsetSeconds = 28_800,
+            appInstallTimeMillis = 1_700_000_000_000,
+            notificationEnabled = false,
+            bluetoothAvailable = true,
+            phoneBrand = "Android",
+            phoneModel = "Android SDK built for arm64",
+            androidRelease = "12",
+            cpuType = "aarch64",
+            cpuCount = 4,
+            cpuUsage = "0.0",
+            totalMemoryMegabytes = 256,
+            freeMemoryMegabytes = 128,
+            totalStorageMegabytes = 65_536,
+            freeStorageMegabytes = 32_768,
+        )
+
+        const val DEVICE_FORM =
+            "app_build=40408&app_install_time=1700000000000&app_ticket=interface+is+empty&" +
+                "app_version=11.4.0&bt_ck=1&bundle_id=com.zhihu.android&cp_ct=4&cp_tp=aarch64&" +
+                "cp_us=0.0&d_n=Android+SDK+built+for+arm64&fr_mem=128&fr_st=32768&latitude=0.0&" +
+                "longitude=0.0&nt_st=0&ph_br=Android&ph_md=Android+SDK+built+for+arm64&" +
+                "ph_os=Android+12&pre_install=InterfaceIsNull&tt_mem=256&tt_st=65536&tz_of=28800&" +
+                "zx_expired=0"
+
+        const val INITIALIZATION_RESPONSE =
+            """{"udid":"device-id","guest":{"access_token":"guest-access","token_type":"bearer"}}"""
+    }
+}


### PR DESCRIPTION
## 改动内容

- 将原生手机号登录设为默认登录方式，入口顺序调整为“手机号登录、扫码登录、备用网页登录”。
- 按知乎 Android 客户端的真实请求链路实现设备访客初始化、条件式 captcha 检查、短信验证码发送和手机号登录。
- captcha 仍由服务端风控决定；正常链路不会主动弹出，但服务端要求时会展示并完成图形验证码，不做绕过。
- 登录成功后请求 `/api/v4/me` 验证身份，并一次性保存账号资料、Cookie、移动端 access/refresh token、类型与过期时间。
- 保留原 WebView 登录作为备用方式，并保留扫码登录。
- 增加协议请求、签名/加密、captcha 分支、错误码重试和会话原子落盘测试。

## 请求预算

无 captcha 的首次登录链路为 5 次请求：设备访客初始化、captcha 状态检查、发送短信、提交验证码、验证本人资料。当前页面内重发短信会复用访客凭证，只需 captcha 状态检查和短信请求。

## 为什么这样改

原 WebView 登录更容易进入网页风控和频繁 captcha。知乎官方 Android 客户端使用原生协议，并非永久跳过 captcha，而是仅在服务端明确要求时进入验证码分支。将这条链路作为主入口可以减少不必要的网页验证，同时保留原方式处理兼容情况。

## 用户影响

- 中国大陆手机号可以直接在应用内收取短信并登录。
- 登录页默认打开手机号登录，不再先创建 WebView。
- 服务端触发风险控制时仍会显示图形验证码。
- 既有扫码登录和 WebView 登录能力不删除。

## 验证

- `:shared:jvmTest`：手机号协议与账号会话定向测试通过。
- `:app:compileLiteDebugKotlin`：最新 `origin/master` 基线编译通过。
- app/shared 相关 ktlint 检查与 `git diff --check` 通过。
- 真实 Android 15 荣耀手机端到端验证：未触发 captcha 即成功发送短信，填写短信验证码后登录成功；会话文件包含完整资料、Cookie 和移动 token；重新启动进入主界面且无崩溃。
- 测试后已恢复手机原有 Zhihu++ 0.27.2 APK，未修改代理、证书或抓包配置。
- 预热 JVM MockEngine happy-path（本地签名、加密、三次协议请求构造与解析，不含真实网络）本次为 27 ms，低于 30 ms 桌面目标；该数字只用于本机性能边界，不作为网络耗时 SLA。