### PR TITLE
fix: 修复「关注的问题有新回答」通知跳转错误

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/NotificationScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/NotificationScreen.kt
@@ -573,16 +573,6 @@ internal fun MobileNotificationTimelineItem.avatarUrl(): String =
         ?: ""
 
 internal fun MobileNotificationTimelineItem.navDestination(): NavDestination? {
-    target
-        ?.takeIf { it.type == "people" && (it.urlToken.isNotBlank() || it.id.isNotBlank()) }
-        ?.let {
-            return Person(
-                id = it.id.ifBlank { Person.EMPTY_ID },
-                urlToken = it.urlToken,
-                name = it.name.ifBlank { "loading..." },
-            )
-        }
-
     val destinations = listOf(
         content?.targetLink,
         content?.subTargetLink,
@@ -592,6 +582,7 @@ internal fun MobileNotificationTimelineItem.navDestination(): NavDestination? {
         link?.takeIf { it.isNotBlank() }?.let(::resolveContent)
     }
     val destination = destinations.firstOrNull { it is Notification.Message }
+        ?: destinations.firstOrNull { it !is Person }
         ?: destinations.firstOrNull()
     return if (destination is Notification.Message) {
         destination.copy(
@@ -599,7 +590,15 @@ internal fun MobileNotificationTimelineItem.navDestination(): NavDestination? {
             avatarUrl = avatarUrl(),
         )
     } else {
-        destination
+        destination ?: target
+            ?.takeIf { it.type == "people" && (it.urlToken.isNotBlank() || it.id.isNotBlank()) }
+            ?.let {
+                Person(
+                    id = it.id.ifBlank { Person.EMPTY_ID },
+                    urlToken = it.urlToken,
+                    name = it.name.ifBlank { "loading..." },
+                )
+            }
     }
 }
 

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/ui/NotificationScreenTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/ui/NotificationScreenTest.kt
@@ -19,13 +19,60 @@ package com.github.zly2006.zhihu.ui
 
 import com.github.zly2006.zhihu.data.MobileNotificationContent
 import com.github.zly2006.zhihu.data.MobileNotificationHead
+import com.github.zly2006.zhihu.data.MobileNotificationTarget
+import com.github.zly2006.zhihu.data.MobileNotificationTargetSource
 import com.github.zly2006.zhihu.data.MobileNotificationTimelineItem
+import com.github.zly2006.zhihu.navigation.Article
+import com.github.zly2006.zhihu.navigation.ArticleType
 import com.github.zly2006.zhihu.navigation.Notification
+import com.github.zly2006.zhihu.navigation.Person
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 class NotificationScreenTest {
+    @Test
+    fun newAnswerNotificationPrefersAnswerLinkOverActorProfile() {
+        val notification = MobileNotificationTimelineItem(
+            content = MobileNotificationContent(
+                title = "关注的问题有了新回答",
+                targetLink = "https://www.zhihu.com/people/answerer",
+            ),
+            targetSource = MobileNotificationTargetSource(
+                targetLink = "https://www.zhihu.com/question/123/answer/456",
+            ),
+            target = MobileNotificationTarget(
+                id = "answerer-id",
+                type = "people",
+                name = "回答者",
+                urlToken = "answerer",
+            ),
+        )
+
+        val destination = assertIs<Article>(notification.navDestination())
+
+        assertEquals(ArticleType.Answer, destination.type)
+        assertEquals(456L, destination.id)
+    }
+
+    @Test
+    fun followNotificationFallsBackToTargetProfile() {
+        val notification = MobileNotificationTimelineItem(
+            content = MobileNotificationContent(title = "测试用户 关注了你"),
+            target = MobileNotificationTarget(
+                id = "follower-id",
+                type = "people",
+                name = "测试用户",
+                urlToken = "tester",
+            ),
+        )
+
+        val destination = assertIs<Person>(notification.navDestination())
+
+        assertEquals("follower-id", destination.id)
+        assertEquals("tester", destination.urlToken)
+    }
+
     @Test
     fun conversationPrefersInboxLinkOverNotificationEntryLink() {
         val notification = MobileNotificationTimelineItem(


### PR DESCRIPTION
## 问题

“关注的问题有了新回答”通知同时携带回答者信息和内容链接。此前导航在解析内容链接之前，只要结构化 `target` 是用户就直接进入回答者主页，导致回答链接永远不会生效。

## 修改

- 先解析通知卡片的目标链接，并保持私信链接最高优先级
- 在多个链接中优先选择回答等内容目标，用户主页仅作为链接回退
- 只有通知没有可用链接时，才回退到结构化用户目标
- 增加“用户目标 + 回答链接”和普通关注通知两组回归测试

## 取证

- 使用当前账号的 Android 通知接口检查 `follow` 分类，确认当前数据模型中的卡片链接和用户目标均来自真实移动端通知结构
- 当前账号近期没有目标文案样本，因此未把该账号数据冒充为完整 UI 复现证据
- 代码路径可以确定复现旧行为：结构化用户目标会在任何内容链接解析前提前返回

## 验证

- `GRADLE_USER_HOME=<隔离目录> ./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process :shared:jvmTest --tests com.github.zly2006.zhihu.ui.NotificationScreenTest`
- `GRADLE_USER_HOME=<隔离目录> ./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process ktlintFormat`
- `git diff --check`

以上均通过。首次使用共享 Gradle home 的测试曾被另一个 worktree 的 `gradle --stop` 中断，改用隔离 Gradle home 后完整通过。

本次没有视觉变化，无需截图。

Resolves #634