### PR TITLE
fix: 保留空详情问题的操作入口

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/QuestionScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/QuestionScreenInstrumentedTest.kt
@@ -59,6 +59,7 @@ import com.github.zly2006.zhihu.ui.QUESTION_SORT_UPDATED_TAG
 import com.github.zly2006.zhihu.ui.QUESTION_STATS_TAG
 import com.github.zly2006.zhihu.ui.QUESTION_TITLE_TAG
 import com.github.zly2006.zhihu.ui.QUESTION_VIEW_LOG_BUTTON_TAG
+import com.github.zly2006.zhihu.ui.QUESTION_WRITE_ANSWER_BUTTON_TAG
 import com.github.zly2006.zhihu.ui.QuestionScreen
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.feed.QuestionFeedViewModel
@@ -185,6 +186,25 @@ class QuestionScreenInstrumentedTest {
         } finally {
             instrumentation.removeMonitor(webviewMonitor)
         }
+    }
+
+    @Test
+    fun emptyQuestionDetailKeepsPrimaryActionsAndAnswerSortVisible() {
+        mockQuestionDetail(detail = "")
+        seedQuestionViewModel()
+
+        setScreen()
+
+        composeRule.waitUntilTextExists("345 浏览")
+        composeRule
+            .onNodeWithTag(QUESTION_SCREEN_LIST_TAG)
+            .performScrollToNode(hasTestTag(QUESTION_WRITE_ANSWER_BUTTON_TAG))
+        composeRule.onNodeWithTag(QUESTION_WRITE_ANSWER_BUTTON_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(QUESTION_FOLLOW_BUTTON_TAG).assertIsDisplayed()
+        composeRule.onNodeWithText("12 回答").assertIsDisplayed()
+        composeRule.onNodeWithTag(QUESTION_SORT_DEFAULT_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(QUESTION_SORT_UPDATED_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(QUESTION_DETAIL_CONTENT_TAG).assertDoesNotExist()
     }
 
     @Test

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/QuestionScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/QuestionScreen.kt
@@ -191,6 +191,7 @@ fun QuestionScreen(
     var commentCount by remember(question.questionId) { mutableIntStateOf(0) }
     var followerCount by remember(question.questionId) { mutableIntStateOf(0) }
     var title by remember(question.questionId, question.title) { mutableStateOf(question.title) }
+    var isQuestionLoaded by remember(question.questionId) { mutableStateOf(false) }
     var showComments by rememberSaveable(question.questionId) { mutableStateOf(false) }
     var isFollowing by remember(question.questionId) { mutableStateOf(false) }
     var showShareDialog by remember { mutableStateOf(false) }
@@ -222,6 +223,7 @@ fun QuestionScreen(
                 commentCount = questionData.commentCount
                 followerCount = questionData.followerCount
                 isFollowing = questionData.relationship.isFollowing
+                isQuestionLoaded = true
             } else {
                 userMessages.showShortMessage("获取问题详情失败")
             }
@@ -281,7 +283,7 @@ fun QuestionScreen(
                                 followerCount = followerCount,
                                 onShowComments = { showComments = true },
                             )
-                            if (questionContent.isNotEmpty()) {
+                            if (isQuestionLoaded) {
                                 QuestionAnimatedBodyHeader(
                                     questionId = question.questionId,
                                     questionContent = questionContent,
@@ -504,6 +506,7 @@ private fun QuestionAnimatedBodyHeader(
             )
         val detailPlaceable =
             subcompose("detail") {
+                if (questionContent.isEmpty()) return@subcompose
                 if (allowDetailCollapse) {
                     QuestionDetailAnimatedViewport(
                         questionId = questionId,
@@ -521,7 +524,7 @@ private fun QuestionAnimatedBodyHeader(
                         onMeasuredHeight = { fullViewportHeightPx = it },
                     )
                 }
-            }.single().measure(looseConstraints)
+            }.singleOrNull()?.measure(looseConstraints)
         val controlsPlaceable =
             subcompose("controls") {
                 Column(
@@ -565,10 +568,12 @@ private fun QuestionAnimatedBodyHeader(
                     }
                 }
             }.single().measure(looseConstraints)
-        val totalHeight = detailPlaceable.height + sectionSpacingPx + controlsPlaceable.height
+        val detailHeight = detailPlaceable?.height ?: 0
+        val controlsOffset = detailHeight + if (detailPlaceable == null) 0 else sectionSpacingPx
+        val totalHeight = controlsOffset + controlsPlaceable.height
         layout(width = constraints.maxWidth, height = totalHeight) {
-            detailPlaceable.place(0, 0)
-            controlsPlaceable.place(0, detailPlaceable.height + sectionSpacingPx)
+            detailPlaceable?.place(0, 0)
+            controlsPlaceable.place(0, controlsOffset)
         }
     }
 }


### PR DESCRIPTION
## 改动

- 将问题详情加载完成与问题描述是否为空分开处理：详情请求成功后始终显示“写回答”“关注问题”、回答数和排序入口。
- 问题描述为空时不渲染正文区域，也不额外保留正文与操作区之间的空白。
- 新增空详情问题的 instrument 回归用例，覆盖主操作、回答统计、排序入口以及正文缺席状态。

## 根因

问题页在 #528 的页面重排后，把问题描述和整组操作区放进了同一个 `detail` 非空判断。知乎允许问题只有标题而没有补充描述，因此这类合法问题会同时丢失写回答、关注和排序入口。

以 issue 中的问题为例，当前 Web 与 Android 问题详情接口都自然返回空 `detail`，但回答数、关注关系与答案列表均完整；这是客户端显示条件错误，不是服务端无回答或账号权限问题。

## 验证

- 当前版本真实 API：问题 `2068266947939153909` 的 Web/Android 详情均返回空 `detail`，答案 feed 正常分页。
- `GRADLE_USER_HOME=/tmp/issue643-gradle-home ./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process -Pkotlin.compiler.execution.strategy=in-process --max-workers=2 assembleLiteDebug`
- `GRADLE_USER_HOME=/tmp/issue643-gradle-home ./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process -Pkotlin.compiler.execution.strategy=in-process --max-workers=2 :app:assembleLiteDebugAndroidTest`
- `GRADLE_USER_HOME=/tmp/issue643-gradle-home ./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process -Pkotlin.compiler.execution.strategy=in-process --max-workers=2 ktlintFormat`
- API 31 AVD `Codex_Zhihu_PhoneLogin_API31` 定向执行 `QuestionScreenInstrumentedTest#emptyQuestionDetailKeepsPrimaryActionsAndAnswerSortVisible`：`OK (1 test)`。
- 同一 AVD 恢复有效登录态后打开 issue 的真实问题，确认写回答、关注问题、回答数、默认/最新排序和答案列表均正常显示。

## 截图

截图来自包含本提交的 Lite Debug APK，在 API 31 AVD `Codex_Zhihu_PhoneLogin_API31` 上打开 issue 的真实问题。

![空详情问题仍显示写回答、关注和排序入口](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-651/empty-question-actions.png)

Resolves #643
