### PR TITLE
feat: 支持按用户搜索

### DIFF
--- a/.agents/skills/github-pr-assets/SKILL.md
+++ b/.agents/skills/github-pr-assets/SKILL.md
@@ -72,6 +72,10 @@ Keep asset commits narrow:
 - Avoid committing large or reusable generated assets unless the PR requirement needs them.
 - Prefer descriptive names like `answer-voters-sheet.png` over timestamp-only names.
 
+### 截图夹具不得伪造产品数据资产
+
+截图中的头像、封面、图片等远端产品资产必须来自该响应真实返回的 URL，并确认在截图执行面实际加载成功。不能为了让布局看起来完整，临时生成字母头像、纯色图片或其他人工占位资产，再把它作为功能效果截图发布；这种做法只能证明控件能显示任意图片，不能证明真实数据链路。如果真实资产因凭据、网络或防盗链暂时无法加载，应先移除不合格截图，继续修复执行面或明确报告阻塞，不能用伪造内容补齐画面。
+
 ## Troubleshooting
 
 ### 创建 skill 的指令不能降级成普通记录

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/SearchScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/SearchScreenInstrumentedTest.kt
@@ -187,6 +187,22 @@ class SearchScreenInstrumentedTest {
     }
 
     @Test
+    fun peopleTabHidesGeneralSearchFilterAndSwitchingBackRestoresIt() {
+        ZhihuMockApi.mockJsonPrefix(
+            method = HttpMethod.Get,
+            urlPrefix = "https://www.zhihu.com/api/v4/search_v3",
+            body = """{"data":[],"paging":{"is_end":true,"is_start":true,"totals":0,"next":""}}""",
+        )
+        composeRule.setScreenContent { SearchScreen(search = Search(query = "用户")) }
+
+        composeRule.onAllNodesWithTag("search_filter_button").assertCountEquals(1)
+        composeRule.onNodeWithTag("search_tab_People").performClick()
+        composeRule.onAllNodesWithTag("search_filter_button").assertCountEquals(0)
+        composeRule.onNodeWithTag("search_tab_General").performClick()
+        composeRule.onAllNodesWithTag("search_filter_button").assertCountEquals(1)
+    }
+
+    @Test
     fun searchHistoryRendersRecordsSearchesAndSupportsMenuActions() {
         // This disables hot-search so the history surface can be tested without network requests.
         // Expected behavior:

--- a/app/src/test/java/com/github/zly2006/zhihu/SearchViewModelUrlTest.kt
+++ b/app/src/test/java/com/github/zly2006/zhihu/SearchViewModelUrlTest.kt
@@ -90,6 +90,18 @@ class SearchViewModelUrlTest {
     }
 
     @Test
+    fun buildsPeopleSearchUrlWithPeopleSearchType() {
+        val params = URL(
+            zhihuSearchUrl("周源", contentType = SearchContentType.People),
+        ).queryParameters()
+
+        assertEquals("people", params["t"])
+        assertEquals("Filter", params["search_source"])
+        assertNull(params["vertical"])
+        assertNull(params["vertical_info"])
+    }
+
+    @Test
     fun buildsMemberRestrictedSearchUrlWithEncodedRestrictionParameters() {
         val url = zhihuSearchUrl(
             query = "用户 创作",

--- a/app/src/test/java/com/github/zly2006/zhihu/SearchViewModelUrlTest.kt
+++ b/app/src/test/java/com/github/zly2006/zhihu/SearchViewModelUrlTest.kt
@@ -19,6 +19,7 @@ package com.github.zly2006.zhihu
 
 import com.github.zly2006.zhihu.viewmodel.feed.SearchContentType
 import com.github.zly2006.zhihu.viewmodel.feed.SearchSortOption
+import com.github.zly2006.zhihu.viewmodel.feed.SearchTab
 import com.github.zly2006.zhihu.viewmodel.feed.SearchTimeRange
 import com.github.zly2006.zhihu.viewmodel.feed.zhihuSearchUrl
 import org.junit.Assert.assertEquals
@@ -92,11 +93,11 @@ class SearchViewModelUrlTest {
     @Test
     fun buildsPeopleSearchUrlWithPeopleSearchType() {
         val params = URL(
-            zhihuSearchUrl("周源", contentType = SearchContentType.People),
+            zhihuSearchUrl("周源", searchTab = SearchTab.People),
         ).queryParameters()
 
         assertEquals("people", params["t"])
-        assertEquals("Filter", params["search_source"])
+        assertEquals("Normal", params["search_source"])
         assertNull(params["vertical"])
         assertNull(params["vertical_info"])
     }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/data/SearchResult.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/data/SearchResult.kt
@@ -17,6 +17,7 @@
 
 package com.github.zly2006.zhihu.data
 
+import com.fleeksoft.ksoup.Ksoup
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -32,9 +33,12 @@ import kotlinx.serialization.encoding.decodeStructure
 import kotlinx.serialization.encoding.encodeStructure
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
@@ -50,6 +54,11 @@ data class SearchResult(
     val index: Int? = null,
     val hitLabels: String? = null,
 ) {
+    val people: DataHolder.People?
+        get() = (obj as? SearchObjectPeople)?.people?.let { people ->
+            people.copy(name = Ksoup.parse(people.name).text())
+        }
+
     /**
      * Convert search result to Feed for display
      * Returns null if the result type doesn't have displayable content
@@ -78,7 +87,7 @@ object SearchResultSerializer : KSerializer<SearchResult> {
     override val descriptor: SerialDescriptor = buildClassSerialDescriptor("SearchResult") {
         element<String>("type")
         element<String>("id")
-        element("object", SearchObject.serializer().descriptor, isOptional = true)
+        element("object", JsonElement.serializer().descriptor, isOptional = true)
         element("highlight", Highlight.serializer().descriptor, isOptional = true)
         element<Int>("index", isOptional = true)
         element<String>("hit_labels", isOptional = true)
@@ -115,8 +124,16 @@ object SearchResultSerializer : KSerializer<SearchResult> {
                         // Parse object field based on type
                         obj = when (type) {
                             "search_result" -> {
-                                val target = decodeSerializableElement(descriptor, 2, Feed.Target.serializer())
-                                SearchObjectResult(target)
+                                val element = decodeSerializableElement(descriptor, 2, JsonElement.serializer())
+                                if (element.jsonObject["type"]?.jsonPrimitive?.content == "people") {
+                                    SearchObjectPeople(
+                                        decoder.json.decodeFromJsonElement(DataHolder.People.serializer(), element),
+                                    )
+                                } else {
+                                    SearchObjectResult(
+                                        decoder.json.decodeFromJsonElement(Feed.Target.serializer(), element),
+                                    )
+                                }
                             }
                             "koc_box" -> decodeSerializableElement(descriptor, 2, SearchObjectKocBox.serializer())
                             "knowledge_ad" -> decodeSerializableElement(descriptor, 2, SearchObjectKnowledgeAd.serializer())
@@ -150,6 +167,12 @@ sealed interface SearchObject
 @SerialName("search_result")
 data class SearchObjectResult(
     val target: Feed.Target,
+) : SearchObject
+
+@Serializable
+@SerialName("search_people")
+data class SearchObjectPeople(
+    val people: DataHolder.People,
 ) : SearchObject
 
 /**

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/data/SearchResult.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/data/SearchResult.kt
@@ -53,12 +53,15 @@ data class SearchResult(
     val index: Int? = null,
     val hitLabels: String? = null,
 ) {
-    val people: DataHolder.People?
+    val people: PeopleSearchResult?
         get() = (obj as? SearchObjectPeople)?.people?.let { people ->
-            people.copy(
-                name = people.name
-                    .replace("<em>", "")
-                    .replace("</em>", ""),
+            PeopleSearchResult(
+                people = people.copy(
+                    name = people.name
+                        .replace("<em>", "")
+                        .replace("</em>", ""),
+                ),
+                highlightedName = people.name,
             )
         }
 
@@ -82,6 +85,11 @@ data class SearchResult(
         null
     }
 }
+
+data class PeopleSearchResult(
+    val people: DataHolder.People,
+    val highlightedName: String,
+)
 
 /**
  * Custom serializer for SearchResult that handles polymorphic object field

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/data/SearchResult.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/data/SearchResult.kt
@@ -17,7 +17,6 @@
 
 package com.github.zly2006.zhihu.data
 
-import com.fleeksoft.ksoup.Ksoup
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -56,7 +55,11 @@ data class SearchResult(
 ) {
     val people: DataHolder.People?
         get() = (obj as? SearchObjectPeople)?.people?.let { people ->
-            people.copy(name = Ksoup.parse(people.name).text())
+            people.copy(
+                name = people.name
+                    .replace("<em>", "")
+                    .replace("</em>", ""),
+            )
         }
 
     /**

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
@@ -75,6 +75,9 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -587,7 +590,8 @@ fun SearchScreen(
                     modifier = Modifier.fillMaxSize(),
                     state = peopleListState,
                 ) {
-                    items(viewModel.peopleResults, key = { it.id }) { people ->
+                    items(viewModel.peopleResults, key = { it.people.id }) { result ->
+                        val people = result.people
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -616,7 +620,34 @@ fun SearchScreen(
                                     .padding(start = 12.dp),
                             ) {
                                 Text(
-                                    text = people.name,
+                                    text = buildAnnotatedString {
+                                        var cursor = 0
+                                        val openingTag = "<em>"
+                                        val closingTag = "</em>"
+                                        while (cursor < result.highlightedName.length) {
+                                            val highlightStart = result.highlightedName.indexOf(openingTag, cursor)
+                                            if (highlightStart < 0) {
+                                                append(result.highlightedName.substring(cursor))
+                                                break
+                                            }
+                                            append(result.highlightedName.substring(cursor, highlightStart))
+                                            val contentStart = highlightStart + openingTag.length
+                                            val highlightEnd = result.highlightedName.indexOf(closingTag, contentStart)
+                                            if (highlightEnd < 0) {
+                                                append(result.highlightedName.substring(contentStart))
+                                                break
+                                            }
+                                            pushStyle(
+                                                SpanStyle(
+                                                    color = MaterialTheme.colorScheme.primary,
+                                                    fontWeight = FontWeight.Bold,
+                                                ),
+                                            )
+                                            append(result.highlightedName.substring(contentStart, highlightEnd))
+                                            pop()
+                                            cursor = highlightEnd + closingTag.length
+                                        }
+                                    },
                                     style = MaterialTheme.typography.titleMedium,
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
@@ -53,11 +53,11 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
-import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -391,19 +391,21 @@ fun SearchScreen(
                     }
                 },
                 actions = {
-                    IconButton(
-                        onClick = { filterMenuExpanded = true },
-                        enabled = search.query.isNotEmpty() && viewModel.searchTab == SearchTab.General,
-                        modifier = Modifier.testTag("search_filter_button"),
-                    ) {
-                        Icon(Icons.Default.FilterList, contentDescription = "筛选搜索结果")
+                    if (viewModel.searchTab == SearchTab.General) {
+                        IconButton(
+                            onClick = { filterMenuExpanded = true },
+                            enabled = search.query.isNotEmpty(),
+                            modifier = Modifier.testTag("search_filter_button"),
+                        ) {
+                            Icon(Icons.Default.FilterList, contentDescription = "筛选搜索结果")
+                        }
+                        SearchFilterMenu(
+                            expanded = filterMenuExpanded,
+                            onDismissRequest = { filterMenuExpanded = false },
+                            viewModel = viewModel,
+                            paginationEnvironment = paginationEnvironment,
+                        )
                     }
-                    SearchFilterMenu(
-                        expanded = filterMenuExpanded,
-                        onDismissRequest = { filterMenuExpanded = false },
-                        viewModel = viewModel,
-                        paginationEnvironment = paginationEnvironment,
-                    )
                 },
             )
         },

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
@@ -75,9 +75,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -101,6 +98,7 @@ import com.github.zly2006.zhihu.ui.components.FeedCard
 import com.github.zly2006.zhihu.ui.components.FeedPullToRefresh
 import com.github.zly2006.zhihu.ui.components.PaginatedList
 import com.github.zly2006.zhihu.ui.components.ProgressIndicatorFooter
+import com.github.zly2006.zhihu.util.parseEmphasizedHtmlTextWithTheme
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.feed.SearchContentType
 import com.github.zly2006.zhihu.viewmodel.feed.SearchSortOption
@@ -620,34 +618,7 @@ fun SearchScreen(
                                     .padding(start = 12.dp),
                             ) {
                                 Text(
-                                    text = buildAnnotatedString {
-                                        var cursor = 0
-                                        val openingTag = "<em>"
-                                        val closingTag = "</em>"
-                                        while (cursor < result.highlightedName.length) {
-                                            val highlightStart = result.highlightedName.indexOf(openingTag, cursor)
-                                            if (highlightStart < 0) {
-                                                append(result.highlightedName.substring(cursor))
-                                                break
-                                            }
-                                            append(result.highlightedName.substring(cursor, highlightStart))
-                                            val contentStart = highlightStart + openingTag.length
-                                            val highlightEnd = result.highlightedName.indexOf(closingTag, contentStart)
-                                            if (highlightEnd < 0) {
-                                                append(result.highlightedName.substring(contentStart))
-                                                break
-                                            }
-                                            pushStyle(
-                                                SpanStyle(
-                                                    color = MaterialTheme.colorScheme.primary,
-                                                    fontWeight = FontWeight.Bold,
-                                                ),
-                                            )
-                                            append(result.highlightedName.substring(contentStart, highlightEnd))
-                                            pop()
-                                            cursor = highlightEnd + closingTag.length
-                                        }
-                                    },
+                                    text = parseEmphasizedHtmlTextWithTheme(result.highlightedName),
                                     style = MaterialTheme.typography.titleMedium,
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
@@ -56,6 +56,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -102,6 +104,7 @@ import com.github.zly2006.zhihu.util.parseEmphasizedHtmlTextWithTheme
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.feed.SearchContentType
 import com.github.zly2006.zhihu.viewmodel.feed.SearchSortOption
+import com.github.zly2006.zhihu.viewmodel.feed.SearchTab
 import com.github.zly2006.zhihu.viewmodel.feed.SearchTimeRange
 import com.github.zly2006.zhihu.viewmodel.feed.SearchViewModel
 import com.github.zly2006.zhihu.viewmodel.feed.ZHIHU_HOT_SEARCH_URL
@@ -160,6 +163,8 @@ fun SearchScreen(
         append(viewModel.sortOption.name)
         append(':')
         append(viewModel.contentType.name)
+        append(':')
+        append(viewModel.searchTab.name)
         append(':')
         append(viewModel.timeRange.name)
         append(':')
@@ -388,7 +393,7 @@ fun SearchScreen(
                 actions = {
                     IconButton(
                         onClick = { filterMenuExpanded = true },
-                        enabled = search.query.isNotEmpty(),
+                        enabled = search.query.isNotEmpty() && viewModel.searchTab == SearchTab.General,
                         modifier = Modifier.testTag("search_filter_button"),
                     ) {
                         Icon(Icons.Default.FilterList, contentDescription = "筛选搜索结果")
@@ -408,6 +413,18 @@ fun SearchScreen(
                 .fillMaxSize()
                 .padding(innerPadding),
         ) {
+            if (search.query.isNotEmpty() && !isMemberSearch) {
+                PrimaryTabRow(selectedTabIndex = viewModel.searchTab.ordinal) {
+                    SearchTab.entries.forEach { tab ->
+                        Tab(
+                            selected = viewModel.searchTab == tab,
+                            onClick = { viewModel.updateSearchTab(paginationEnvironment, tab) },
+                            text = { Text(tab.label) },
+                            modifier = Modifier.testTag("search_tab_${tab.name}"),
+                        )
+                    }
+                }
+            }
             if (viewModel.displayItems.isEmpty() && !viewModel.isLoading && viewModel.searchQuery.isEmpty()) {
                 val shouldShowHistory = showSearchHistory.value && searchHistoryItems.isNotEmpty()
                 val shouldShowHotSearch = showHotSearch.value && hotSearchItems.isNotEmpty()
@@ -570,7 +587,7 @@ fun SearchScreen(
                         )
                     }
                 }
-            } else if (viewModel.contentType == SearchContentType.People) {
+            } else if (viewModel.searchTab == SearchTab.People) {
                 val shouldLoadMorePeople by remember {
                     derivedStateOf {
                         val lastVisibleIndex = peopleListState.layoutInfo.visibleItemsInfo

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
@@ -28,7 +28,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -56,6 +60,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -64,17 +69,21 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil3.compose.AsyncImage
 import com.github.zly2006.zhihu.data.ZhihuJson
 import com.github.zly2006.zhihu.navigation.Account
 import com.github.zly2006.zhihu.navigation.LocalNavigator
+import com.github.zly2006.zhihu.navigation.Person
 import com.github.zly2006.zhihu.navigation.Search
 import com.github.zly2006.zhihu.platform.SettingsStore
 import com.github.zly2006.zhihu.platform.UserMessageDuration
@@ -165,6 +174,7 @@ fun SearchScreen(
     val searchInputFocusRequester = remember { FocusRequester() }
     var searchText by remember { mutableStateOf(search.query) }
     val coroutineScope = rememberCoroutineScope()
+    val peopleListState = rememberLazyListState()
     val isMemberSearch = search.isRestrictedToMember
     val memberSearchName = search.restrictedMemberName.ifBlank { "TA" }
     val searchPlaceholder = if (isMemberSearch) "搜索 $memberSearchName 的创作" else "搜索内容"
@@ -557,6 +567,79 @@ fun SearchScreen(
                                 .fillMaxWidth()
                                 .padding(16.dp),
                         )
+                    }
+                }
+            } else if (viewModel.contentType == SearchContentType.People) {
+                val shouldLoadMorePeople by remember {
+                    derivedStateOf {
+                        val lastVisibleIndex = peopleListState.layoutInfo.visibleItemsInfo
+                            .lastOrNull()
+                            ?.index ?: -1
+                        lastVisibleIndex >= peopleListState.layoutInfo.totalItemsCount - 3
+                    }
+                }
+                LaunchedEffect(shouldLoadMorePeople, viewModel.isLoading, viewModel.isEnd) {
+                    if (shouldLoadMorePeople && !viewModel.isLoading && !viewModel.isEnd) {
+                        viewModel.loadMore(paginationEnvironment)
+                    }
+                }
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    state = peopleListState,
+                ) {
+                    items(viewModel.peopleResults, key = { it.id }) { people ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    navigator.onNavigate(
+                                        Person(
+                                            id = people.id,
+                                            urlToken = people.urlToken.orEmpty(),
+                                            name = people.name,
+                                        ),
+                                    )
+                                }.padding(horizontal = 16.dp, vertical = 12.dp)
+                                .testTag("search_people_result_${people.id}"),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            AsyncImage(
+                                model = people.avatarUrl,
+                                contentDescription = "${people.name}的头像",
+                                modifier = Modifier
+                                    .size(48.dp)
+                                    .clip(CircleShape),
+                            )
+                            Column(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(start = 12.dp),
+                            ) {
+                                Text(
+                                    text = people.name,
+                                    style = MaterialTheme.typography.titleMedium,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                                if (people.headline.isNotEmpty()) {
+                                    Text(
+                                        text = people.headline,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        maxLines = 2,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                }
+                                Text(
+                                    text = "${people.followerCount} 粉丝 · ${people.answerCount} 回答",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                    item {
+                        ProgressIndicatorFooter(peopleListState)
                     }
                 }
             } else {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/SearchViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/SearchViewModel.kt
@@ -18,8 +18,10 @@
 package com.github.zly2006.zhihu.viewmodel.feed
 
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import com.github.zly2006.zhihu.data.DataHolder
 import com.github.zly2006.zhihu.data.Feed
 import com.github.zly2006.zhihu.data.SearchResult
 import com.github.zly2006.zhihu.data.ZhihuJson
@@ -37,6 +39,7 @@ open class SearchViewModel(
     val searchQuery: String,
     val restrictedMemberHashId: String = "",
 ) : BaseFeedViewModel() {
+    val peopleResults = mutableStateListOf<DataHolder.People>()
     var sortOption by mutableStateOf(SearchSortOption.Default)
         private set
     var contentType by mutableStateOf(SearchContentType.All)
@@ -80,6 +83,11 @@ open class SearchViewModel(
         refresh(environment)
     }
 
+    override fun refresh(environment: PaginationEnvironment) {
+        peopleResults.clear()
+        super.refresh(environment)
+    }
+
     override suspend fun fetchFeeds(environment: PaginationEnvironment) {
         try {
             val url = lastPaging?.next ?: initialUrl
@@ -87,14 +95,18 @@ open class SearchViewModel(
             val jsonArray = jojo["data"]!!.jsonArray
 
             // Parse search results and convert to Feed objects
-            val feeds = jsonArray.mapNotNull { element ->
+            val results = jsonArray.mapNotNull { element ->
                 try {
-                    val searchResult = ZhihuJson.decodeJson<SearchResult>(element)
-                    searchResult.toFeed()
+                    ZhihuJson.decodeJson<SearchResult>(element)
                 } catch (e: Exception) {
                     environment.logDecodeFailure("SearchViewModel", element, e)
                     null
                 }
+            }
+            val feeds = results.mapNotNull(SearchResult::toFeed)
+            val existingPeopleIds = peopleResults.mapTo(mutableSetOf(), DataHolder.People::id)
+            results.mapNotNull(SearchResult::people).forEach { people ->
+                if (existingPeopleIds.add(people.id)) peopleResults.add(people)
             }
 
             processResponse(environment, feeds, jsonArray)
@@ -146,6 +158,7 @@ enum class SearchContentType(
     Answer("回答", "answer"),
     Article("文章", "article"),
     Video("视频", "zvideo"),
+    People("用户", "people"),
 }
 
 enum class SearchTimeRange(
@@ -173,7 +186,7 @@ fun zhihuSearchUrl(
         timeRange != SearchTimeRange.All
     val params = buildList {
         add("gk_version" to "gz-gaokao")
-        add("t" to "general")
+        add("t" to if (contentType == SearchContentType.People) "people" else "general")
         add("q" to query)
         add("correction" to "1")
         add("offset" to "0")
@@ -187,7 +200,7 @@ fun zhihuSearchUrl(
             add("restricted_field" to "member_hash_id")
             add("restricted_value" to restrictedMemberHashId)
         }
-        if (contentType.value.isNotEmpty()) {
+        if (contentType.value.isNotEmpty() && contentType != SearchContentType.People) {
             add("vertical" to contentType.value)
             add("vertical_info" to SEARCH_VERTICAL_INFO)
         }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/SearchViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/SearchViewModel.kt
@@ -44,6 +44,8 @@ open class SearchViewModel(
         private set
     var contentType by mutableStateOf(SearchContentType.All)
         private set
+    var searchTab by mutableStateOf(SearchTab.General)
+        private set
     var timeRange by mutableStateOf(SearchTimeRange.All)
         private set
 
@@ -51,7 +53,7 @@ open class SearchViewModel(
         get() = initialUrl
 
     override val initialUrl: String
-        get() = zhihuSearchUrl(searchQuery, sortOption, contentType, timeRange, restrictedMemberHashId)
+        get() = zhihuSearchUrl(searchQuery, searchTab, sortOption, contentType, timeRange, restrictedMemberHashId)
 
     // Override include to request necessary fields for search results
     override val include = "data[*].highlight,object,type"
@@ -71,6 +73,15 @@ open class SearchViewModel(
     ) {
         if (contentType == type) return
         contentType = type
+        refresh(environment)
+    }
+
+    fun updateSearchTab(
+        environment: PaginationEnvironment,
+        tab: SearchTab,
+    ) {
+        if (searchTab == tab) return
+        searchTab = tab
         refresh(environment)
     }
 
@@ -158,7 +169,13 @@ enum class SearchContentType(
     Answer("回答", "answer"),
     Article("文章", "article"),
     Video("视频", "zvideo"),
-    People("用户", "people"),
+}
+
+enum class SearchTab(
+    val label: String,
+) {
+    General("全站"),
+    People("用户"),
 }
 
 enum class SearchTimeRange(
@@ -176,6 +193,7 @@ enum class SearchTimeRange(
 
 fun zhihuSearchUrl(
     query: String,
+    searchTab: SearchTab = SearchTab.General,
     sortOption: SearchSortOption = SearchSortOption.Default,
     contentType: SearchContentType = SearchContentType.All,
     timeRange: SearchTimeRange = SearchTimeRange.All,
@@ -186,7 +204,7 @@ fun zhihuSearchUrl(
         timeRange != SearchTimeRange.All
     val params = buildList {
         add("gk_version" to "gz-gaokao")
-        add("t" to if (contentType == SearchContentType.People) "people" else "general")
+        add("t" to if (searchTab == SearchTab.People) "people" else "general")
         add("q" to query)
         add("correction" to "1")
         add("offset" to "0")
@@ -200,7 +218,7 @@ fun zhihuSearchUrl(
             add("restricted_field" to "member_hash_id")
             add("restricted_value" to restrictedMemberHashId)
         }
-        if (contentType.value.isNotEmpty() && contentType != SearchContentType.People) {
+        if (contentType.value.isNotEmpty()) {
             add("vertical" to contentType.value)
             add("vertical_info" to SEARCH_VERTICAL_INFO)
         }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/SearchViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/SearchViewModel.kt
@@ -21,8 +21,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import com.github.zly2006.zhihu.data.DataHolder
 import com.github.zly2006.zhihu.data.Feed
+import com.github.zly2006.zhihu.data.PeopleSearchResult
 import com.github.zly2006.zhihu.data.SearchResult
 import com.github.zly2006.zhihu.data.ZhihuJson
 import com.github.zly2006.zhihu.data.ZhihuPaging
@@ -39,7 +39,7 @@ open class SearchViewModel(
     val searchQuery: String,
     val restrictedMemberHashId: String = "",
 ) : BaseFeedViewModel() {
-    val peopleResults = mutableStateListOf<DataHolder.People>()
+    val peopleResults = mutableStateListOf<PeopleSearchResult>()
     var sortOption by mutableStateOf(SearchSortOption.Default)
         private set
     var contentType by mutableStateOf(SearchContentType.All)
@@ -104,9 +104,9 @@ open class SearchViewModel(
                 }
             }
             val feeds = results.mapNotNull(SearchResult::toFeed)
-            val existingPeopleIds = peopleResults.mapTo(mutableSetOf(), DataHolder.People::id)
-            results.mapNotNull(SearchResult::people).forEach { people ->
-                if (existingPeopleIds.add(people.id)) peopleResults.add(people)
+            val existingPeopleIds = peopleResults.mapTo(mutableSetOf()) { it.people.id }
+            results.mapNotNull(SearchResult::people).forEach { result ->
+                if (existingPeopleIds.add(result.people.id)) peopleResults.add(result)
             }
 
             processResponse(environment, feeds, jsonArray)

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/viewmodel/feed/SearchViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/viewmodel/feed/SearchViewModelTest.kt
@@ -20,6 +20,8 @@ package com.github.zly2006.zhihu.viewmodel.feed
 import com.github.zly2006.zhihu.data.CommonFeed
 import com.github.zly2006.zhihu.data.Feed
 import com.github.zly2006.zhihu.data.Person
+import com.github.zly2006.zhihu.data.SearchResult
+import com.github.zly2006.zhihu.data.ZhihuJson
 import com.github.zly2006.zhihu.data.target
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import io.ktor.client.HttpClient
@@ -74,6 +76,38 @@ class SearchViewModelTest {
                     ?.id
             },
         )
+    }
+
+    @Test
+    fun decodesPeopleSearchResultAsStronglyTypedPeople() {
+        val result = ZhihuJson.decodeJson<SearchResult>(
+            ZhihuJson.json.parseToJsonElement(
+                """
+                {
+                  "type": "search_result",
+                  "id": 460104019,
+                  "object": {
+                    "id": "6733f12c60e7e98ea7491f20de46f79e",
+                    "url_token": "zhouyuan",
+                    "type": "people",
+                    "url": "https://api.zhihu.com/people/6733f12c60e7e98ea7491f20de46f79e",
+                "name": "<em>周源</em>",
+                    "user_type": "people",
+                    "headline": "知乎 001 号员工",
+                    "gender": 1,
+                    "avatar_url": "https://pic.example/avatar.jpg",
+                    "follower_count": 1048300,
+                    "answer_count": 371
+                  }
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        assertEquals("zhouyuan", result.people?.urlToken)
+        assertEquals("周源", result.people?.name)
+        assertEquals(1048300, result.people?.followerCount)
+        assertNull(result.toFeed())
     }
 
     private class TestSearchViewModel : SearchViewModel("query") {

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/viewmodel/feed/SearchViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/viewmodel/feed/SearchViewModelTest.kt
@@ -104,9 +104,10 @@ class SearchViewModelTest {
             ),
         )
 
-        assertEquals("zhouyuan", result.people?.urlToken)
-        assertEquals("周源", result.people?.name)
-        assertEquals(1048300, result.people?.followerCount)
+        assertEquals("zhouyuan", result.people?.people?.urlToken)
+        assertEquals("周源", result.people?.people?.name)
+        assertEquals("<em>周源</em>", result.people?.highlightedName)
+        assertEquals(1048300, result.people?.people?.followerCount)
         assertNull(result.toFeed())
     }
 


### PR DESCRIPTION
## 改动内容

- 在搜索结果顶部增加“全站 / 用户”两个 Tab；默认“全站”对应 `t=general`，“用户”对应 `t=people`
- 将用户搜索与全站筛选拆开：用户不再出现在内容类型筛选菜单，用户 Tab 下隐藏全站专属筛选入口，切回全站后恢复
- 使用知乎真实 `search_v3?t=people` 分页契约，并将不同返回结构的用户结果强类型解码为现有用户模型
- 展示头像、用户名、简介、粉丝数和回答数，点击可进入现有个人主页
- 复用现有 `parseEmphasizedHtmlTextWithTheme` 解析用户名 `<em>` 命中范围，以主题主色显示高亮，且不直接暴露 HTML 标签

## 验证

- `zhurl` 真实请求确认 `t=people` 返回用户 ID、`url_token`、头像、简介及统计字段
- `:shared:jvmTest --tests com.github.zly2006.zhihu.viewmodel.feed.SearchViewModelTest.decodesPeopleSearchResultAsStronglyTypedPeople`
- `:app:testLiteDebugUnitTest --tests com.github.zly2006.zhihu.SearchViewModelUrlTest`
- `ktlintFormat`
- `assembleLiteDebug`
- 定向 instrument 用例覆盖：全站显示筛选入口、用户隐藏筛选入口、切回全站恢复

Resolves #642
