### PR TITLE
fix: 初始化网页登录 d_c0 凭证

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/account/ZhihuPhoneLoginClient.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/account/ZhihuPhoneLoginClient.kt
@@ -232,6 +232,9 @@ class ZhihuPhoneLoginClient(
         val token = ZhihuJson.json.decodeFromString<TokenResponse>(body)
         check(token.accessToken.isNotBlank()) { "服务器未返回登录凭证" }
         cookies.putAll(token.cookie.values())
+        httpClient.get("https://www.zhihu.com/") {
+            applyMobileHeaders()
+        }.successBody("初始化网页登录凭证")
         return ZhihuMobileLoginToken(
             accessToken = token.accessToken,
             refreshToken = token.refreshToken,

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/account/ZhihuPhoneLoginClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/account/ZhihuPhoneLoginClientTest.kt
@@ -206,6 +206,16 @@ class ZhihuPhoneLoginClientTest {
                         )
                     }
 
+                    3 -> {
+                        assertEquals(HttpMethod.Get, request.method)
+                        assertEquals("www.zhihu.com", request.url.host)
+                        assertEquals("/", request.url.encodedPath)
+                        respond(
+                            content = "<!doctype html>",
+                            headers = headersOf(HttpHeaders.SetCookie, "d_c0=web-device-cookie; Path=/; Domain=zhihu.com"),
+                        )
+                    }
+
                     else -> error("Unexpected request #$requestIndex")
                 }
             },
@@ -219,7 +229,7 @@ class ZhihuPhoneLoginClientTest {
         assertEquals("account-refresh", token.refreshToken)
         assertEquals("bearer", token.tokenType)
         assertEquals(1_700_003_600L, token.expiresAt)
-        assertEquals("device-cookie", token.cookies["d_c0"])
+        assertEquals("web-device-cookie", token.cookies["d_c0"])
         assertEquals("account-z-cookie", token.cookies["z_c0"])
         assertEquals("account-q-cookie", token.cookies["q_c0"])
         httpClient.close()


### PR DESCRIPTION
## 改动内容

- 手机号登录成功后仅访问一次知乎网页首页，让共享 Cookie 存储接收网页侧下发的 `d_c0`
- 补充手机号登录测试，验证该次首页请求及新 `d_c0` 会覆盖登录响应中的旧值

## 原因

手机号登录接口返回的凭证不一定包含可供网页接口签名使用的最新 `d_c0`。网页凭证初始化属于登录流程的一部分，不应放在通用 `fetchJson` 请求入口重复执行。

## 影响

每次手机号登录成功后会额外请求一次知乎首页；后续业务请求不会检查或刷新 `d_c0`。

## 验证

- `./gradlew :shared:jvmTest --tests 'com.github.zly2006.zhihu.account.ZhihuPhoneLoginClientTest'`
- 结果：`BUILD SUCCESSFUL`
