### PR TITLE
fix: 提示登录 Cookie 不完整

### DIFF
--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/AndroidUiRuntimes.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/ui/AndroidUiRuntimes.kt
@@ -105,6 +105,7 @@ actual fun rememberAppVersionInfo(): String = LocalContext.current.zhihuVersionI
 
 fun AccountData.Data.toAccountSettingsAccountState(): AccountSettingsAccountState = AccountSettingsAccountState(
     login = login,
+    hasRequiredCookie = cookies["d_c0"].isNullOrBlank().not(),
     username = username,
     avatarUrl = self?.avatarUrl,
     id = self?.id ?: "",

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/account/ZhihuPhoneLoginClient.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/account/ZhihuPhoneLoginClient.kt
@@ -232,9 +232,10 @@ class ZhihuPhoneLoginClient(
         val token = ZhihuJson.json.decodeFromString<TokenResponse>(body)
         check(token.accessToken.isNotBlank()) { "服务器未返回登录凭证" }
         cookies.putAll(token.cookie.values())
-        httpClient.get("https://www.zhihu.com/") {
+        val webSessionResponse = httpClient.get("https://www.zhihu.com/") {
             applyMobileHeaders()
-        }.successBody("初始化网页登录凭证")
+        }
+        webSessionResponse.successBody("初始化网页登录凭证")
         return ZhihuMobileLoginToken(
             accessToken = token.accessToken,
             refreshToken = token.refreshToken,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.material.icons.filled.MarkUnreadChatAlt
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.CircularProgressIndicator
@@ -72,6 +73,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -234,6 +236,18 @@ fun HomeScreen(
     }
 
     val account = rememberAccountSettingsAccountState().value
+    if (account.login && !account.hasRequiredCookie) {
+        AlertDialog(
+            onDismissRequest = {},
+            title = { Text("Cookie 不完整") },
+            text = { Text("当前登录信息缺少必要的 Cookie d_c0，请重新登录。") },
+            confirmButton = {
+                TextButton(onClick = { paginationEnvironment.requestLogin() }) {
+                    Text("重新登录")
+                }
+            },
+        )
+    }
     val updateState by rememberSystemUpdateRuntime().state.collectAsState()
     val updateAnnouncement = updateState as? SystemUpdateState.UpdateAvailable
     val versionName = rememberAppVersionInfo().substringBefore(' ').takeIf { it.firstOrNull()?.isDigit() == true }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/UiSupportFiles.kt
@@ -466,6 +466,7 @@ fun rememberZhihuMainPreferenceState(
 
 data class AccountSettingsAccountState(
     val login: Boolean = false,
+    val hasRequiredCookie: Boolean = true,
     val username: String = "",
     val avatarUrl: String? = null,
     val id: String = "",


### PR DESCRIPTION
## 改动内容

- Home 页面发现账号处于已登录状态但缺少非空 d_c0 时，显示不可关闭的 Cookie 不完整提示。
- 提示仅提供“重新登录”操作，并复用现有登录入口；Cookie 状态恢复完整后弹窗自动消失。
- Android 账户展示状态补充必要 Cookie 完整性字段，Desktop 与 Native 默认行为不变。
- 修复手机号登录初始化网页登录凭证处的既有 ktlint 链式调用格式问题，不改变请求行为。

## 原因

账号可能保留已登录标记，但 Cookie 集合缺少知乎网页请求所需的 d_c0。此前 Home 会继续按已登录状态运行，用户无法直接识别登录信息不完整。

## 影响

Cookie 完整的已登录账号和未登录账号行为不变。只有“已登录且缺少 d_c0”的 Android 账号会被强制引导重新登录。

## 验证

- ./gradlew :shared:ktlintCommonMainSourceSetCheck :shared:ktlintAndroidMainSourceSetCheck :app:compileLiteDebugKotlin
- git diff --check