### PR TITLE
fix: 朗读正文时跳过视频链接

### DIFF
--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/reading/ContentReadingService.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/reading/ContentReadingService.kt
@@ -410,7 +410,7 @@ class ContentReadingService : Service() {
             contentType = resolvedItem.contentType,
             title = resolvedItem.title,
             author = resolvedItem.author,
-            body = Ksoup.parse(resolvedItem.bodyHtml.orEmpty()).text(),
+            body = htmlToReadingText(resolvedItem.bodyHtml.orEmpty()),
             publishedAt = resolvedItem.publishedAt,
             voteUpCount = resolvedItem.voteUpCount,
             comments = comments,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayer.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayer.kt
@@ -414,6 +414,11 @@ fun buildReadingSpeechText(
         .trim()
 }
 
+fun htmlToReadingText(html: String): String = Ksoup
+    .parse(html)
+    .also { document -> document.select("a.video-box").remove() }
+    .text()
+
 fun buildReadingTemplatePreview(preferences: ReadingPreferences): String {
     val normalized = preferences.normalized()
     return normalized.fieldOrder

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayerTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayerTest.kt
@@ -69,13 +69,14 @@ class ReadingPlayerTest {
 
     @Test
     fun readingTextSkipsVideoLinksButKeepsRegularLinks() {
-        val html = """
-            <p>视频前的正文。</p>
-            <a class="video-box" href="https://link.zhihu.com/?target=https%3A//www.zhihu.com/video/123">
-                https://www.zhihu.com/video/123
-            </a>
-            <p>查看<a href="https://www.zhihu.com/question/1">普通链接</a>后的正文。</p>
-        """.trimIndent()
+        val html =
+            """
+                <p>视频前的正文。</p>
+                <a class="video-box" href="https://link.zhihu.com/?target=https%3A//www.zhihu.com/video/123">
+                    https://www.zhihu.com/video/123
+                </a>
+                <p>查看<a href="https://www.zhihu.com/question/1">普通链接</a>后的正文。</p>
+            """.trimIndent()
 
         assertEquals("视频前的正文。 查看普通链接后的正文。", htmlToReadingText(html))
     }

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayerTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayerTest.kt
@@ -68,6 +68,19 @@ class ReadingPlayerTest {
     }
 
     @Test
+    fun readingTextSkipsVideoLinksButKeepsRegularLinks() {
+        val html = """
+            <p>视频前的正文。</p>
+            <a class="video-box" href="https://link.zhihu.com/?target=https%3A//www.zhihu.com/video/123">
+                https://www.zhihu.com/video/123
+            </a>
+            <p>查看<a href="https://www.zhihu.com/question/1">普通链接</a>后的正文。</p>
+        """.trimIndent()
+
+        assertEquals("视频前的正文。 查看普通链接后的正文。", htmlToReadingText(html))
+    }
+
+    @Test
     fun relativePublishedTimeUsesLastEditAndSelectedPrecision() {
         val content = ResolvedReadingContent(
             contentType = ReadingContentType.Article,

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayerTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayerTest.kt
@@ -71,11 +71,11 @@ class ReadingPlayerTest {
     fun readingTextSkipsVideoLinksButKeepsRegularLinks() {
         val html =
             """
-                <p>视频前的正文。</p>
-                <a class="video-box" href="https://link.zhihu.com/?target=https%3A//www.zhihu.com/video/123">
-                    https://www.zhihu.com/video/123
-                </a>
-                <p>查看<a href="https://www.zhihu.com/question/1">普通链接</a>后的正文。</p>
+            <p>视频前的正文。</p>
+            <a class="video-box" href="https://link.zhihu.com/?target=https%3A//www.zhihu.com/video/123">
+                https://www.zhihu.com/video/123
+            </a>
+            <p>查看<a href="https://www.zhihu.com/question/1">普通链接</a>后的正文。</p>
             """.trimIndent()
 
         assertEquals("视频前的正文。 查看普通链接后的正文。", htmlToReadingText(html))


### PR DESCRIPTION
## 改动

- 在正文 HTML 转换为朗读文本前移除知乎 `video-box` 视频节点
- 保留普通链接的可见文字和其余正文内容
- 增加回归测试，覆盖视频链接跳过与普通链接保留

## 原因

朗读服务此前直接对整段正文执行 HTML 纯文本提取。视频节点中的可见链接文字也会被提取并交给 TTS，导致朗读回答时念出视频 URL。

## 影响

只改变回答、文章等正文生成朗读文本时对视频节点的处理，不修改 Compose Markdown 正文展示、WebView 路径或普通链接行为。

## 验证

- `:shared:jvmTest --tests com.github.zly2006.zhihu.reading.ReadingPlayerTest`：通过
- 按要求跳过其余本地验证，完整构建与检查交给 GitHub CI

Resolves #627