### PR TITLE
feat: 主分页返回键优先回到首页而不是退出app

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -119,6 +119,7 @@ import com.github.zly2006.zhihu.navigation.SentenceSimilarityTest
 import com.github.zly2006.zhihu.navigation.TopLevelDestination
 import com.github.zly2006.zhihu.navigation.WriteAnswer
 import com.github.zly2006.zhihu.navigation.WritePin
+import com.github.zly2006.zhihu.platform.PlatformBackHandler
 import com.github.zly2006.zhihu.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.reading.rememberReadingPlayerController
 import com.github.zly2006.zhihu.reading.saveReadingPlaybackSpeed
@@ -140,8 +141,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 import kotlin.reflect.typeOf
-
-const val SURVEY_URL = "https://v.wjx.cn/vm/Ppfw2R4.aspx#"
 
 private sealed class MainTabPage(
     val bottomDestination: TopLevelDestination,
@@ -346,6 +345,12 @@ fun ZhihuMain(
         mainTabPages.getOrNull(mainPagerState.currentPage)?.bottomDestination?.let { destination ->
             currentMainTabDestination = destination
             setCurrentMainTabOpenFrom(destination.openFrom)
+        }
+    }
+
+    PlatformBackHandler(mainPagerState.currentPage != 0) {
+        coroutineScope.launch {
+            mainPagerState.animateScrollToPage(0)
         }
     }
 


### PR DESCRIPTION
## 改动内容

- 在主分页不处于首页时拦截平台返回操作，并平滑切回首页
- 移除未使用的问卷地址常量

## 改动原因

为主分页新增符合直觉的返回行为：用户从其他主分页按返回键时，先回到主首页，避免直接退出或触发外层返回行为。

## 影响范围

仅调整主分页的返回键行为，不改变各分页自身的内容与导航入口。

## 验证

按用户要求跳过格式化、构建和测试验证。
