### PR TITLE
feat: 回答编辑按钮自动收起

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/WriteAnswerScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/WriteAnswerScreenInstrumentedTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeDown
+import androidx.compose.ui.test.swipeUp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.zly2006.zhihu.navigation.WriteAnswer
+import com.github.zly2006.zhihu.test.resetAppPreferences
+import com.github.zly2006.zhihu.test.setScreenContent
+import com.github.zly2006.zhihu.ui.WRITE_ANSWER_CONTENT_TAG
+import com.github.zly2006.zhihu.ui.WRITE_ANSWER_FAB_PREVIEW_TAG
+import com.github.zly2006.zhihu.ui.WRITE_ANSWER_FAB_SAVE_TAG
+import com.github.zly2006.zhihu.ui.WriteAnswerScreen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WriteAnswerScreenInstrumentedTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Before
+    fun setUp() {
+        composeRule.resetAppPreferences()
+    }
+
+    @Test
+    fun editorActionsFollowVerticalScrollDirection() {
+        composeRule.setScreenContent {
+            WriteAnswerScreen(
+                WriteAnswer(
+                    questionId = 648,
+                    questionTitle = "离线编辑器滚动测试",
+                ),
+            )
+        }
+
+        val editor = composeRule.onNodeWithTag(WRITE_ANSWER_CONTENT_TAG)
+        editor.performTextInput((1..80).joinToString("\n") { "回答正文第 $it 行" })
+
+        composeRule.onNodeWithTag(WRITE_ANSWER_FAB_PREVIEW_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(WRITE_ANSWER_FAB_SAVE_TAG).assertIsDisplayed()
+
+        editor.performTouchInput { swipeDown(durationMillis = 700) }
+        editor.performTouchInput { swipeUp(durationMillis = 700) }
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(WRITE_ANSWER_FAB_PREVIEW_TAG).fetchSemanticsNodes().isEmpty()
+        }
+
+        editor.performTouchInput { swipeDown(durationMillis = 700) }
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(WRITE_ANSWER_FAB_PREVIEW_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag(WRITE_ANSWER_FAB_PREVIEW_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(WRITE_ANSWER_FAB_SAVE_TAG).assertIsDisplayed()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/WriteAnswerScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/WriteAnswerScreen.kt
@@ -17,6 +17,11 @@
 
 package com.github.zly2006.zhihu.ui
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
@@ -47,6 +52,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.TextFieldValue
@@ -93,6 +99,9 @@ fun WriteAnswerScreen(
     val settings = rememberSettingsStore()
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
+    var editorActionsVisible by remember { mutableStateOf(true) }
+    val actionVisibilityThreshold = with(LocalDensity.current) { 12.dp.roundToPx() }
+    var accumulatedEditorScroll by remember { mutableStateOf(0f) }
 
     var content by remember { mutableStateOf(TextFieldValue("")) }
     var tocEnabled by remember { mutableStateOf(false) }
@@ -299,19 +308,25 @@ fun WriteAnswerScreen(
             )
         },
         floatingActionButton = {
-            WriteContentFabColumn(
-                previewEnabled = !isSubmitting && content.text.isNotBlank(),
-                imageEnabled = launchImagePicker != null && !isSubmitting && !isUploadingImage,
-                saveEnabled = !isSubmitting,
-                showImageButton = launchImagePicker != null,
-                isUploadingImage = isUploadingImage,
-                previewTag = WRITE_ANSWER_FAB_PREVIEW_TAG,
-                imageTag = WRITE_ANSWER_FAB_IMAGE_TAG,
-                saveTag = WRITE_ANSWER_FAB_SAVE_TAG,
-                onPreview = ::showPreview,
-                onImage = { launchImagePicker?.invoke() },
-                onSave = { submitAnswer(publish = false) },
-            )
+            AnimatedVisibility(
+                visible = editorActionsVisible,
+                enter = fadeIn() + slideInVertically(initialOffsetY = { it / 2 }),
+                exit = fadeOut() + slideOutVertically(targetOffsetY = { it / 2 }),
+            ) {
+                WriteContentFabColumn(
+                    previewEnabled = !isSubmitting && content.text.isNotBlank(),
+                    imageEnabled = launchImagePicker != null && !isSubmitting && !isUploadingImage,
+                    saveEnabled = !isSubmitting,
+                    showImageButton = launchImagePicker != null,
+                    isUploadingImage = isUploadingImage,
+                    previewTag = WRITE_ANSWER_FAB_PREVIEW_TAG,
+                    imageTag = WRITE_ANSWER_FAB_IMAGE_TAG,
+                    saveTag = WRITE_ANSWER_FAB_SAVE_TAG,
+                    onPreview = ::showPreview,
+                    onImage = { launchImagePicker?.invoke() },
+                    onSave = { submitAnswer(publish = false) },
+                )
+            }
         },
     ) { innerPadding ->
         Box(
@@ -330,6 +345,24 @@ fun WriteAnswerScreen(
                 contentTag = WRITE_ANSWER_CONTENT_TAG,
                 enabled = !isSubmitting,
                 modifier = Modifier.fillMaxSize(),
+                bottomPadding = 280.dp,
+                onVerticalScroll = { delta ->
+                    if (accumulatedEditorScroll != 0f && (accumulatedEditorScroll > 0f) != (delta > 0f)) {
+                        accumulatedEditorScroll = delta
+                    } else {
+                        accumulatedEditorScroll += delta
+                    }
+                    when {
+                        accumulatedEditorScroll <= -actionVisibilityThreshold -> {
+                            editorActionsVisible = false
+                            accumulatedEditorScroll = 0f
+                        }
+                        accumulatedEditorScroll >= actionVisibilityThreshold -> {
+                            editorActionsVisible = true
+                            accumulatedEditorScroll = 0f
+                        }
+                    }
+                },
             )
         }
     }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/WriteContentEditor.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/WriteContentEditor.kt
@@ -17,6 +17,8 @@
 
 package com.github.zly2006.zhihu.ui.components
 
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -38,9 +40,13 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
@@ -58,10 +64,28 @@ fun WriteContentMarkdownEditor(
     modifier: Modifier = Modifier,
     topPadding: Dp = 16.dp,
     bottomPadding: Dp = 160.dp,
+    onVerticalScroll: ((Float) -> Unit)? = null,
 ) {
-    val editorScrollState = rememberScrollState()
+    val scrollState = rememberScrollState()
+    val currentOnVerticalScroll by rememberUpdatedState(onVerticalScroll)
+    val scrollDirectionObserver = Modifier.pointerInput(Unit) {
+        awaitEachGesture {
+            var previousPosition = awaitFirstDown(
+                requireUnconsumed = false,
+                pass = PointerEventPass.Initial,
+            ).position
+            do {
+                val event = awaitPointerEvent(PointerEventPass.Initial)
+                event.changes.firstOrNull()?.let { change ->
+                    val delta = change.position.y - previousPosition.y
+                    if (delta != 0f) currentOnVerticalScroll?.invoke(delta)
+                    previousPosition = change.position
+                }
+            } while (event.changes.any { it.pressed })
+        }
+    }
 
-    Box(modifier = modifier) {
+    Box(modifier = modifier.then(if (onVerticalScroll == null) Modifier else scrollDirectionObserver)) {
         BasicTextField(
             value = value,
             onValueChange = onValueChange,
@@ -82,7 +106,7 @@ fun WriteContentMarkdownEditor(
                     modifier =
                         Modifier
                             .fillMaxSize()
-                            .verticalScroll(editorScrollState)
+                            .verticalScroll(scrollState)
                             .padding(top = topPadding, bottom = bottomPadding),
                 ) {
                     if (value.text.isEmpty()) {


### PR DESCRIPTION
## 改动内容

- 回答编辑器中的“预览 / 图片 / 草稿”按钮在向下滚动正文时收起，向上滚动时恢复
- 为编辑器底部增加足够的滚动留白，确保末尾正文可以滚出按钮覆盖区域
- 使用不消费事件的指针方向观察，保留文本选择、光标和编辑滚动行为
- 增加定向 Compose instrument 回归测试，覆盖初始显示、下滑隐藏和上滑恢复

## 原因

固定在右下角的三个扩展按钮会遮挡回答正文，并容易造成误触。回答编辑器内部会消费文本滚动手势，因此需要在编辑器外层观察真实手势方向，再控制按钮可见性。

## 用户影响

编辑长回答时可以通过向下滚动暂时隐藏操作按钮，获得完整正文阅读和编辑空间；需要操作时向上滚动即可恢复按钮。

## 验证

- `GRADLE_USER_HOME=/private/tmp/gradle-issue-648 ./gradlew --no-daemon --max-workers=1 -Dkotlin.compiler.execution.strategy=in-process ktlintFormat assembleLiteDebug assembleLiteDebugAndroidTest`
- API 31 AVD 定向运行 `WriteAnswerScreenInstrumentedTest`：`OK (1 test)`

Closes #648
