### PR TITLE
fix: 修复 Markdown 预览重复状态键崩溃

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/WriteAnswerScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/WriteAnswerScreenInstrumentedTest.kt
@@ -17,10 +17,14 @@
 
 package com.github.zly2006.zhihu
 
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeDown
@@ -77,5 +81,35 @@ class WriteAnswerScreenInstrumentedTest {
         }
         composeRule.onNodeWithTag(WRITE_ANSWER_FAB_PREVIEW_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(WRITE_ANSWER_FAB_SAVE_TAG).assertIsDisplayed()
+    }
+
+    @Test
+    fun previewRendersMarkdownWithReferenceDefinitions() {
+        composeRule.setScreenContent {
+            WriteAnswerScreen(
+                WriteAnswer(
+                    questionId = 648,
+                    questionTitle = "回答预览重复状态键测试",
+                ),
+            )
+        }
+
+        composeRule.onNodeWithTag(WRITE_ANSWER_CONTENT_TAG).performTextInput(
+            buildString {
+                appendLine("[回答预览正文][docs]")
+                appendLine()
+                repeat(12) { index ->
+                    appendLine("[引用 $index][ref-$index]")
+                    appendLine("[ref-$index]: https://example.com/preview/$index")
+                    appendLine("${'$'}${'$'}x_$index${'$'}${'$'} 同行尾随正文 $index")
+                    appendLine()
+                }
+                appendLine("[docs]: https://example.com/preview")
+            },
+        )
+        composeRule.onNodeWithTag(WRITE_ANSWER_FAB_PREVIEW_TAG).performClick()
+
+        composeRule.onNodeWithText("Markdown").assertIsDisplayed()
+        composeRule.onAllNodesWithText("回答预览正文", substring = true).assertCountEquals(2)
     }
 }

--- a/third_party/markdown/README.md
+++ b/third_party/markdown/README.md
@@ -6,7 +6,7 @@
 - 上游基线提交：`0ae14148bbe427e27629117b3581ea071d86c4c7`
 - 保持原应用行为的源码提交：`4f2ab8c13f44bf24cc070821ea6b510efe188759`
 - 内置日期：2026-07-21
-- 生产源码清单 SHA-256：`4ae22da5adf66d621696f5c403181d0f866242bcc6dcf1c34a0c04ddf8ab9046`
+- 生产源码清单 SHA-256：`2e69525d51f8de48efb393800898018b24c54ffdf4eb89d5e9e415b5c80ba6a6`
 
 替换前，应用依赖的是 `io.github.zly2006:markdown-*:0.0.1-alpha.11`。这个坐标只说明被替换的分叉构件，不是本目录的上游 base version；本目录的 base version 始终按上游实际版本记为 `1.2.9`。源码提交 `4f2ab8c...` 在 1.2.9 基础上保留了原应用所需的 `NativeBlock` 与 LaTeX 1.4.6-zly 兼容改动。
 

--- a/third_party/markdown/markdown-parser/build.gradle.kts
+++ b/third_party/markdown/markdown-parser/build.gradle.kts
@@ -40,5 +40,8 @@ kotlin {
             implementation("org.jetbrains.compose.runtime:runtime:1.11.1")
             implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
         }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
     }
 }

--- a/third_party/markdown/markdown-parser/src/commonMain/kotlin/com/hrm/markdown/parser/ast/BlockNodes.kt
+++ b/third_party/markdown/markdown-parser/src/commonMain/kotlin/com/hrm/markdown/parser/ast/BlockNodes.kt
@@ -4,10 +4,6 @@ import androidx.compose.runtime.Composable
 import com.hrm.markdown.parser.core.Attributes
 import com.hrm.markdown.parser.lint.DiagnosticResult
 
-private var nextSyntheticStableKey = -1
-
-private fun allocateSyntheticStableKey(): Int = nextSyntheticStableKey--
-
 /**
  * 文档的根节点。
  */
@@ -304,7 +300,6 @@ class NativeBlock(
     val content: @Composable () -> Unit,
 ) : LeafNode() {
     override val literal: String get() = ""
-    override val stableKey: Int = allocateSyntheticStableKey()
 
     override fun <R> accept(visitor: NodeVisitor<R>): R = visitor.visitNativeBlock(this)
 }

--- a/third_party/markdown/markdown-parser/src/commonMain/kotlin/com/hrm/markdown/parser/ast/Node.kt
+++ b/third_party/markdown/markdown-parser/src/commonMain/kotlin/com/hrm/markdown/parser/ast/Node.kt
@@ -23,17 +23,21 @@ sealed class Node {
      */
     var contentHash: Long = 0L
 
+    internal var siblingKey: Int = -1
+
     /**
-     * 用于 Compose `key()` 的稳定身份标识。
-     * 仅基于起始行号，确保：
-     * - 同一位置的块始终被 Compose 视为同一组件实例 → 复用组件、只更新内容
-     * - 不同位置的块 key 不同 → 正确分辨不同组件
+     * 用于 Compose `key()` 的稳定身份标识，在同一文档树内唯一。
+     * 容器按结构槽位分配路径；替换节点继承原路径，因此内容或节点类型更新不会无故销毁
+     * 同一位置的组件，而同一源文本行拆出的多个同类型节点也不会发生冲突。
      *
      * 注意：不包含 contentHash，因为流式输入时内容每个 token 都在变，
      * 如果 key 跟着变，Compose 会销毁旧组件再创建新组件，导致"闪缩"和状态丢失。
      */
-    open val stableKey: Int
-        get() = lineRange.startLine
+    val stableKey: String
+        get() {
+            val parentKey = parent?.takeUnless { it is Document }?.stableKey
+            return if (parentKey.isNullOrEmpty()) "$siblingKey" else "$parentKey/$siblingKey"
+        }
 
     /**
      * 接受访问者进行树遍历。
@@ -52,6 +56,7 @@ sealed class Node {
  */
 sealed class ContainerNode : Node() {
     private val _children: MutableList<Node> = mutableListOf()
+    private var nextChildKey: Int = 0
 
     /**
      * 延迟行内解析的原始内容。设置后，首次访问 [children] 时自动触发行内解析。
@@ -118,13 +123,18 @@ sealed class ContainerNode : Node() {
     }
 
     fun appendChild(child: Node) {
-        child.parent = this
+        attachChild(child)
         _children.add(child)
     }
 
     fun insertChild(index: Int, child: Node) {
-        child.parent = this
+        attachChild(child)
         _children.add(index, child)
+    }
+
+    private fun attachChild(child: Node, key: Int = nextChildKey++) {
+        child.parent = this
+        child.siblingKey = key
     }
 
     fun removeChild(child: Node): Boolean {
@@ -142,12 +152,13 @@ sealed class ContainerNode : Node() {
         val index = _children.indexOf(old)
         if (index >= 0) {
             old.parent = null
-            new.parent = this
+            attachChild(new, old.siblingKey)
             _children[index] = new
         }
     }
 
     fun replaceChildren(startIndex: Int, endIndex: Int, newChildren: List<Node>) {
+        val replacedKeys = (startIndex until endIndex).map { _children[it].siblingKey }
         for (i in startIndex until endIndex) {
             _children[i].parent = null
         }
@@ -156,7 +167,8 @@ sealed class ContainerNode : Node() {
             _children.removeAt(startIndex)
         }
         newChildren.forEachIndexed { i, child ->
-            child.parent = this
+            val replacedKey = replacedKeys.getOrNull(i)
+            if (replacedKey == null) attachChild(child) else attachChild(child, replacedKey)
             _children.add(startIndex + i, child)
         }
     }
@@ -164,6 +176,7 @@ sealed class ContainerNode : Node() {
     fun clearChildren() {
         _children.forEach { it.parent = null }
         _children.clear()
+        nextChildKey = 0
         // 同时清除 lazy 状态，避免 clear 后重新触发旧的 lazy 解析
         _lazyInlineContent = null
         _lazyInlineParser = null

--- a/third_party/markdown/markdown-parser/src/commonTest/kotlin/com/hrm/markdown/parser/StableKeyTest.kt
+++ b/third_party/markdown/markdown-parser/src/commonTest/kotlin/com/hrm/markdown/parser/StableKeyTest.kt
@@ -1,0 +1,234 @@
+package com.hrm.markdown.parser
+
+import com.hrm.markdown.parser.ast.ContainerNode
+import com.hrm.markdown.parser.ast.Document
+import com.hrm.markdown.parser.ast.Heading
+import com.hrm.markdown.parser.ast.Node
+import com.hrm.markdown.parser.ast.Paragraph
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class StableKeyTest {
+    @Test
+    fun parsedDocumentsKeepEveryNodeKeyUnique() {
+        parserFixtures.forEach { fixture ->
+            MarkdownParser().parse(fixture.markdown).assertUniqueStableKeys(fixture.name)
+        }
+    }
+
+    @Test
+    fun generatedAdversarialDocumentsKeepEveryNodeKeyUnique() {
+        repeat(64) { round ->
+            val markdown = buildString {
+                repeat(24) { index ->
+                    appendLine("[正文 $round-$index][ref-$round-$index] HTML")
+                    appendLine("[ref-$round-$index]: https://example.com/$round/$index")
+                    appendLine("*[HTML]: HyperText Markup Language")
+                    appendLine("${'$'}${'$'}x_$index${'$'}${'$'} 同行尾随正文 $index")
+                    appendLine("> 引用 **$index**")
+                    appendLine("- 列表 $index")
+                    appendLine()
+                }
+            }
+            MarkdownParser().parse(markdown).assertUniqueStableKeys("generated round $round")
+        }
+    }
+
+    @Test
+    fun reparsingSameStructureProducesTheSameKeys() {
+        parserFixtures.forEach { fixture ->
+            val firstKeys = MarkdownParser().parse(fixture.markdown).allStableKeys()
+            val secondKeys = MarkdownParser().parse(fixture.markdown).allStableKeys()
+            assertEquals(firstKeys, secondKeys, "${fixture.name} must produce deterministic keys")
+        }
+    }
+
+    @Test
+    fun changingOnlyBlockContentPreservesStructuralKeys() {
+        val first = MarkdownParser().parse("第一段\n\n第二段").allStableKeys()
+        val second = MarkdownParser().parse("内容已替换\n\n仍是第二段").allStableKeys()
+
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun sameLineAndSameTypeNodesStillReceiveDifferentKeys() {
+        val document = Document()
+        val first = Paragraph().apply { lineRange = LineRange(0, 1) }
+        val second = Paragraph().apply { lineRange = LineRange(0, 1) }
+
+        document.appendChild(first)
+        document.appendChild(second)
+
+        assertNotEquals(first.stableKey, second.stableKey)
+        document.assertUniqueStableKeys("manually constructed same-line paragraphs")
+    }
+
+    @Test
+    fun replacingNodePreservesItsStableKey() {
+        val document = Document()
+        val paragraph = Paragraph()
+        document.appendChild(paragraph)
+        val originalKey = paragraph.stableKey
+
+        val heading = Heading(level = 2)
+        document.replaceChild(paragraph, heading)
+
+        assertEquals(originalKey, heading.stableKey)
+        document.assertUniqueStableKeys("node replacement")
+    }
+
+    @Test
+    fun replacingChildRangePreservesOverlappingStableKeys() {
+        val document = Document()
+        val oldChildren = List(3) { Paragraph().also(document::appendChild) }
+        val oldKeys = oldChildren.map { it.stableKey }
+        val replacements = List(4) { Paragraph() }
+
+        document.replaceChildren(0, oldChildren.size, replacements)
+
+        assertEquals(oldKeys, replacements.take(oldKeys.size).map { it.stableKey })
+        assertTrue(replacements.last().stableKey !in oldKeys)
+        document.assertUniqueStableKeys("child range replacement")
+    }
+
+    @Test
+    fun insertingSiblingDoesNotRenumberExistingKeys() {
+        val document = Document()
+        val first = Paragraph()
+        val second = Paragraph()
+        document.appendChild(first)
+        document.appendChild(second)
+        val keysBeforeInsert = listOf(first.stableKey, second.stableKey)
+
+        val inserted = Paragraph()
+        document.insertChild(1, inserted)
+
+        assertEquals(keysBeforeInsert, listOf(first.stableKey, second.stableKey))
+        assertTrue(inserted.stableKey !in keysBeforeInsert)
+        document.assertUniqueStableKeys("sibling insertion")
+    }
+
+    @Test
+    fun nestedKeysAreRebasedWhenContainerIsAttached() {
+        val nested = Paragraph()
+        val container = Paragraph().apply { appendChild(nested) }
+        val document = Document().apply { appendChild(container) }
+
+        assertTrue(nested.stableKey.startsWith("${container.stableKey}/"))
+        document.assertUniqueStableKeys("nested attachment")
+    }
+
+    @Test
+    fun incrementalEditsAndStreamingAppendsKeepKeysUnique() {
+        val editor = MarkdownParser()
+        val initial = "第一段\n\n第二段\n\n[docs]: https://example.com/initial"
+        editor.parse(initial).assertUniqueStableKeys("edit initial")
+        editor.replace(0, 3, "# 第一段").assertUniqueStableKeys("edit replace block type")
+        editor.insert(editor.currentText().length, "\n\n${'$'}${'$'}x${'$'}${'$'} 尾随段落")
+            .assertUniqueStableKeys("edit append same-line blocks")
+
+        val streaming = MarkdownParser()
+        streaming.beginStream()
+        streaming.append("[正文][docs]\n\n").assertUniqueStableKeys("stream paragraph")
+        streaming.append("[docs]: https://example.com/").assertUniqueStableKeys("stream link definition")
+        streaming.append("\n\n${'$'}${'$'}x${'$'}${'$'} 尾随段落")
+            .assertUniqueStableKeys("stream same-line blocks")
+        streaming.endStream().assertUniqueStableKeys("stream final document")
+    }
+
+    private fun Node.assertUniqueStableKeys(context: String) {
+        val allKeys = allStableKeys(context)
+
+        assertEquals(
+            allKeys.size,
+            allKeys.toSet().size,
+            "$context contains duplicate stable keys: ${allKeys.groupingBy { it }.eachCount().filterValues { it > 1 }}",
+        )
+    }
+
+    private fun Node.allStableKeys(context: String = "document"): List<String> {
+        val allKeys = mutableListOf<String>()
+
+        fun collect(node: Node) {
+            if (node !is Document) {
+                assertTrue(node.stableKey.isNotEmpty(), "$context contains an unassigned key")
+                allKeys += node.stableKey
+            }
+            if (node is ContainerNode) node.children.forEach(::collect)
+        }
+
+        collect(this)
+        return allKeys
+    }
+
+    private data class ParserFixture(
+        val name: String,
+        val markdown: String,
+    )
+
+    private companion object {
+        val parserFixtures = listOf(
+            ParserFixture(
+                "answer preview reference definition",
+                """
+                    [回答预览正文][docs]
+
+                    [docs]: https://example.com/preview
+                """.trimIndent(),
+            ),
+            ParserFixture(
+                "multiple metadata definitions",
+                """
+                    [正文][one] HTML
+
+                    [one]: https://example.com/one
+                    [two]: https://example.com/two
+                    *[HTML]: HyperText Markup Language
+                """.trimIndent(),
+            ),
+            ParserFixture(
+                "multiline reference title",
+                """
+                    [正文][docs]
+
+                    [docs]: https://example.com/docs
+                      "跨行标题"
+                """.trimIndent(),
+            ),
+            ParserFixture(
+                "same-line math and trailing paragraph",
+                "${'$'}${'$'}x + y${'$'}${'$'} 尾随正文",
+            ),
+            ParserFixture(
+                "nested same-line blocks",
+                """
+                    > ${'$'}${'$'}x${'$'}${'$'} 引用内尾随正文
+
+                    - ${'$'}${'$'}y${'$'}${'$'} 列表内尾随正文
+                    - 第二项
+                """.trimIndent(),
+            ),
+            ParserFixture(
+                "post-processor replacements",
+                """
+                    ```mermaid
+                    graph TD; A-->B
+                    ```
+
+                    ![图](https://example.com/image.png)
+                """.trimIndent(),
+            ),
+            ParserFixture(
+                "footnote and nested formatting",
+                """
+                    正文[^note]
+
+                    [^note]: **粗体**、[链接](https://example.com) 与公式 ${'$'}x${'$'}
+                """.trimIndent(),
+            ),
+        )
+    }
+}

--- a/third_party/markdown/markdown-renderer/src/commonMain/kotlin/com/hrm/markdown/renderer/MarkdownLayouts.kt
+++ b/third_party/markdown/markdown-renderer/src/commonMain/kotlin/com/hrm/markdown/renderer/MarkdownLayouts.kt
@@ -169,8 +169,8 @@ private fun <T : Node> DeferredMarkdownBlockLayout(
     val density = LocalDensity.current
     val viewportHeightPx = LocalWindowInfo.current.containerSize.height.toFloat()
     val deferredBlockStates = rememberSaveableStateHolder()
-    val measuredHeightsPx = remember { mutableStateMapOf<Any, Int>() }
-    val blockKeys = remember(blocks) { blocks.map { it::class to it.stableKey } }
+    val measuredHeightsPx = remember { mutableStateMapOf<String, Int>() }
+    val blockKeys = remember(blocks) { blocks.map(Node::stableKey) }
     val estimatedHeightsByWidth = remember(blocks, theme, density.density, density.fontScale) {
         mutableMapOf<Int, List<Int>>()
     }
@@ -230,7 +230,7 @@ private fun <T : Node> DeferredMarkdownBlockLayout(
                 if (bottom >= visibleTop && top <= visibleBottom || requestedByNavigation) {
                     val blockKey = blockKeys[index]
                     val placeable = subcompose(blockKey) {
-                        deferredBlockStates.SaveableStateProvider(node.stableKey) {
+                        deferredBlockStates.SaveableStateProvider(blockKey) {
                             PersistentSelectionScope(
                                 scopeKey = blockKey,
                                 documentOrder = groupOrder + index,

--- a/third_party/markdown/markdown-renderer/src/jvmTest/kotlin/com/hrm/markdown/renderer/MarkdownPerformanceTest.kt
+++ b/third_party/markdown/markdown-renderer/src/jvmTest/kotlin/com/hrm/markdown/renderer/MarkdownPerformanceTest.kt
@@ -45,6 +45,39 @@ import kotlinx.serialization.json.jsonPrimitive
 @OptIn(ExperimentalTestApi::class)
 class MarkdownPerformanceTest {
     @Test
+    fun markdownPreviewIdentityStressRendersAcrossRepeatedDocumentChanges() =
+        runDesktopComposeUiTest(width = 412, height = 892) {
+            fun stressMarkdown(round: Int) = buildString {
+                appendLine("回答预览正文 $round")
+                appendLine()
+                repeat(40) { index ->
+                    appendLine("[引用 $index][ref-$round-$index]")
+                    appendLine("[ref-$round-$index]: https://example.com/$round/$index")
+                    appendLine("${'$'}${'$'}x_$index + y_$round${'$'}${'$'} 同行尾随正文 $index")
+                    appendLine()
+                }
+            }
+            var markdown by mutableStateOf(stressMarkdown(0))
+
+            setContent {
+                Markdown(
+                    markdown = markdown,
+                    modifier = Modifier.fillMaxSize(),
+                    enableScroll = true,
+                    enableSelection = true,
+                )
+            }
+
+            repeat(8) { round ->
+                runOnUiThread { markdown = stressMarkdown(round) }
+                waitForRenderedMarker("回答预览正文 $round")
+                waitForIdle()
+                onNode(hasText("回答预览正文 $round", substring = true), useUnmergedTree = true)
+                    .assertIsDisplayed()
+            }
+        }
+
+    @Test
     fun preparedLatexDrawsAndSurvivesCompositionDisposal() = runDesktopComposeUiTest(width = 412, height = 892) {
         val cache = LatexRenderCache()
         var showFormula by mutableStateOf(true)


### PR DESCRIPTION
## 改动内容

- 将 Markdown AST 的 `stableKey` 从裸起始行号改为容器分配的结构路径，保证同一文档树内节点身份唯一
- 插入节点时保留已有兄弟节点的身份；单节点和范围替换时继承原结构槽位，避免无故销毁 Compose 状态
- 删除 `NativeBlock` 的全局负数 ID，让所有节点统一由所属容器分配身份
- 让 `SubcomposeLayout`、`SaveableStateHolder`、测量缓存和持久选择状态共同使用同一份 key
- 增加 parser 身份不变量、renderer 重组压力和写回答真实预览入口测试

## 问题与根因

写回答后点击预览时，部分包含引用定义、同行公式等结构的 Markdown 会触发：

```text
java.lang.IllegalArgumentException: Key 0 was used multiple times
    at androidx.compose.runtime.saveable.SaveableStateHolderImpl...
```

预览调用链为：

```text
WriteAnswerScreen
  -> WriteContentPreviewSheet
  -> RenderMarkdownText
  -> MarkdownParser
  -> DeferredMarkdownBlockLayout
  -> SaveableStateHolder.SaveableStateProvider
```

旧实现直接使用 `lineRange.startLine` 作为节点身份。引用定义等解析器生成节点可能保留默认行号 `0`，而且一行 Markdown 本来就可能合法拆成多个同类型节点，因此行号无法唯一标识 AST 节点。

延迟 renderer 还存在两套身份口径：外层 subcompose 使用“节点类型 + 起始行”，内层 `SaveableStateHolder` 只使用起始行。外层没有碰撞时，内层仍会以重复的 `0` 注册多个 provider，最终由 Compose 主动抛错。

## 为什么此前性能优化没有测出

此前性能与持久选择验收主要覆盖文章页 HTML AST、长文首帧、滚动范围、公式、表格和离屏状态恢复。HTML 转换路径会为节点分配顺序化虚拟行位置，恰好绕过 Markdown parser 的重复第 0 行问题；测试也没有直接声明和验证“整棵 AST 的 key 必须唯一”这一底层不变量，且缺少“写回答 -> 点击预览”的真实入口。

因此这次不是简单增加相同测试次数，而是补齐输入来源和身份契约两个缺失维度。

## 设计动机

新的 key 是从文档根到节点的结构槽位路径，例如：

```text
0
1
1/0
1/1
2
```

每个容器为直属子节点单调分配槽位。新插入节点不会让已有兄弟重编号；替换节点继承旧槽位；额外替换节点领取新槽位。

没有使用 `contentHash`，因为流式输入会逐 token 改变内容，以内容构造身份会让 Compose 反复重建状态。也没有采用全局 ID，避免重新解析不确定、跨文档耦合和 KMP 并发问题。

## 关键 diff

```diff
- open val stableKey: Int
-     get() = lineRange.startLine
+ internal var siblingKey: Int = -1
+
+ val stableKey: String
+     get() {
+         val parentKey = parent?.takeUnless { it is Document }?.stableKey
+         return if (parentKey.isNullOrEmpty()) "$siblingKey" else "$parentKey/$siblingKey"
+     }
```

```diff
+ private var nextChildKey: Int = 0
+
+ private fun attachChild(child: Node, key: Int = nextChildKey++) {
+     child.parent = this
+     child.siblingKey = key
+ }

  fun replaceChild(old: Node, new: Node) {
      ...
-     new.parent = this
+     attachChild(new, old.siblingKey)
  }
```

```diff
- val blockKeys = remember(blocks) { blocks.map { it::class to it.stableKey } }
+ val blockKeys = remember(blocks) { blocks.map(Node::stableKey) }
  ...
- deferredBlockStates.SaveableStateProvider(node.stableKey) {
+ deferredBlockStates.SaveableStateProvider(blockKey) {
```

## 未采用方案

- `"$index:${node.stableKey}"`：依赖列表位置，只会在单个 renderer 调用点掩盖 AST 身份错误，已完全移除
- “节点类型 + 行号”：同行同类型节点仍可能碰撞
- `contentHash`：流式更新会持续改变 key 并丢失状态
- 全局原子 ID：同一输入重新解析不确定，且跨文档耦合
- 只补引用定义的行号：无法覆盖同行拆块等合法结构

## 测试强度

Parser 契约测试会遍历整棵 AST，断言除文档根外所有已挂载节点的 key 非空且全局唯一，并覆盖：

- 7 组高风险固定夹具
- 64 轮、每轮 24 组生成式复合结构，共 1536 组
- 同一输入重复解析的确定性
- 仅内容变化时结构 key 稳定
- 同行同类型节点
- 单节点与范围替换身份继承
- 中间插入不重编号已有节点
- 嵌套结构、增量编辑和流式追加

将实现临时恢复为旧裸行号后，新契约套件中的 9 条测试有 6 条稳定失败；恢复修复并补充范围替换后全部通过。

Renderer 测试在同一存活 Compose composition 中连续切换 8 轮文档，每轮包含 40 组引用定义和同行公式/尾随正文。Android 定向用例则真实打开写回答页面，输入 12 组同类结构并点击预览。

## 验证

- Android 31 模拟器定向运行 `WriteAnswerScreenInstrumentedTest#previewRendersMarkdownWithReferenceDefinitions`：1/1 通过
- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process :markdown-parser:jvmTest :markdown-renderer:jvmTest :markdown-parser:compileAndroidMain :markdown-renderer:compileAndroidMain :app:compileLiteDebugAndroidTestKotlin ktlintCheck`：通过，154 个任务
- 真实布局性能基准的 16 个场景中位数为 7.743–29.480 ms，长公式压力场景中位数为 17.851 ms，未发现中位数层面的实质回退
- vendored source manifest 已重新计算并更新

本修复保留视口惰性布局和持久选择能力，没有通过关闭懒加载换取正确性。
