### PR TITLE
feat: 支持隐藏质量屏蔽卡片

### DIFF
--- a/docs/ai-ui-design-guide.md
+++ b/docs/ai-ui-design-guide.md
@@ -104,7 +104,7 @@ URL 解析集中在 `resolveContent()`。支持知乎问题、回答、文章、
 | --- | --- | --- | --- |
 | `recommendationMode` | 推荐算法 | Web、Android、本地、混合推荐 | 枚举在 `RecommendationMode.kt` |
 | `loginForRecommendation` | 推荐内容时登录 | 获取推荐时是否带登录凭证 | 影响服务端推荐结果 |
-| `enableQualityFilter` | 质量过滤规则 | 按赞同数、关注数等指标过滤 | 查 content filter settings/runtime |
+| `qualityFilterMode` | 质量屏蔽 | 不屏蔽、显示屏蔽规则或隐藏低质量内容 | 默认 `RULES`，旧布尔设置不迁移 |
 | `enableContentFilter` | 智能内容过滤 | 过滤重复出现但未点击内容 | 关闭时相关子统计/开关应弱化 |
 | `filterFollowedUserContent` | 过滤已关注用户内容 | 是否过滤关注用户内容 | 仅智能过滤开启时可操作 |
 | `enableKeywordBlocking` | 关键词屏蔽 | 命中关键词时过滤 | 管理入口在 Blocklist |

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
@@ -62,6 +62,8 @@ import com.github.zly2006.zhihu.util.buildOfflineArticleExportHtml
 import com.github.zly2006.zhihu.util.clipboardManager
 import com.github.zly2006.zhihu.util.exportCollectionItemsToZip
 import com.github.zly2006.zhihu.util.saveBitmapToGallery
+import com.github.zly2006.zhihu.viewmodel.QUALITY_FILTER_MODE_PREFERENCE_KEY
+import com.github.zly2006.zhihu.viewmodel.QualityFilterMode
 import com.github.zly2006.zhihu.viewmodel.filter.BlockedKeywordService
 import com.github.zly2006.zhihu.viewmodel.filter.BlockedQuestionAuthor
 import com.github.zly2006.zhihu.viewmodel.filter.BlockedUser
@@ -282,7 +284,9 @@ open class SharedAndroidPaginationEnvironment(
     }
 
     override fun feedDisplaySettings(): FeedDisplaySettings = FeedDisplaySettings(
-        enableQualityFilter = settingsStore.getBoolean("enableQualityFilter", true),
+        qualityFilterMode = QualityFilterMode.entries.firstOrNull {
+            it.name == settingsStore.getString(QUALITY_FILTER_MODE_PREFERENCE_KEY, QualityFilterMode.RULES.name)
+        } ?: QualityFilterMode.RULES,
         reverseBlock = settingsStore.getBoolean("reverseBlock", false),
     )
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/data/ZhihuDataCore.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/data/ZhihuDataCore.kt
@@ -31,6 +31,7 @@ data class FeedDisplayItem(
     val authorName: String? = null,
     val authorBadgeV2: DataHolder.BadgeV2? = null,
     val isFiltered: Boolean = false,
+    val isQualityFiltered: Boolean = false,
     val content: String? = null,
     var raw: DataHolder.Content? = null,
 ) {
@@ -111,6 +112,7 @@ private fun Feed.toTargetDisplayItem(
             details = target!!.detailsText,
             feed = this,
             isFiltered = true,
+            isQualityFiltered = true,
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/HomeScreen.kt
@@ -145,6 +145,8 @@ import com.github.zly2006.zhihu.ui.subscreens.SystemUpdateState
 import com.github.zly2006.zhihu.ui.subscreens.rememberSystemUpdateRuntime
 import com.github.zly2006.zhihu.ui.topLevelReselectAction
 import com.github.zly2006.zhihu.util.Log
+import com.github.zly2006.zhihu.viewmodel.QUALITY_FILTER_MODE_PREFERENCE_KEY
+import com.github.zly2006.zhihu.viewmodel.QualityFilterMode
 import com.github.zly2006.zhihu.viewmodel.feed.BaseFeedViewModel
 import com.github.zly2006.zhihu.viewmodel.feed.HomeFeedInteractionViewModel
 import com.github.zly2006.zhihu.viewmodel.feed.HomeFeedViewModel
@@ -312,6 +314,18 @@ fun HomeScreen(
                     }
                 }
             }
+        }
+    }
+
+    val completedPageCount = viewModel.completedPageCount
+    LaunchedEffect(completedPageCount) {
+        if (completedPageCount > 0 &&
+            currentRecommendationMode == RecommendationMode.WEB &&
+            settings.getString(QUALITY_FILTER_MODE_PREFERENCE_KEY, QualityFilterMode.RULES.name) == QualityFilterMode.HIDE.name &&
+            viewModel.displayItems.isEmpty() &&
+            !viewModel.isEnd
+        ) {
+            viewModel.loadMore(paginationEnvironment)
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
@@ -84,6 +84,7 @@ import com.github.zly2006.zhihu.platform.rememberUserMessageSink
 import com.github.zly2006.zhihu.ui.subscreens.PREF_FONT_SIZE
 import com.github.zly2006.zhihu.ui.subscreens.PREF_LINE_HEIGHT
 import com.github.zly2006.zhihu.util.parseEmphasizedHtmlTextWithTheme
+import com.github.zly2006.zhihu.viewmodel.QUALITY_FILTER_MODE_PREFERENCE_KEY
 
 /**
  * 信息流卡片的 Material 3 实现。
@@ -258,12 +259,12 @@ private fun FeedCardMenuBox(
                     navigator.onNavigate(Account.AppearanceSettings())
                 },
             )
-            if (item.isFiltered) {
+            if (item.isQualityFiltered) {
                 DropdownMenuItem(
-                    text = { Text("不再屏蔽低赞内容") },
+                    text = { Text("调整质量屏蔽") },
                     onClick = {
                         onShowMenuChange(false)
-                        navigator.onNavigate(Account.RecommendSettings("enableQualityFilter"))
+                        navigator.onNavigate(Account.RecommendSettings(QUALITY_FILTER_MODE_PREFERENCE_KEY))
                     },
                 )
             }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/ContentFilterSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/ContentFilterSettingsScreen.kt
@@ -75,6 +75,8 @@ import com.github.zly2006.zhihu.ui.components.SettingItem
 import com.github.zly2006.zhihu.ui.components.SettingItemGroup
 import com.github.zly2006.zhihu.ui.components.SettingItemWithSwitch
 import com.github.zly2006.zhihu.util.Log
+import com.github.zly2006.zhihu.viewmodel.QUALITY_FILTER_MODE_PREFERENCE_KEY
+import com.github.zly2006.zhihu.viewmodel.QualityFilterMode
 import com.github.zly2006.zhihu.viewmodel.filter.getContentFilterDatabase
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -233,17 +235,58 @@ fun ContentFilterSettingsScreen(
 
             val enableContentFilter = remember { mutableStateOf(settings.getBoolean("enableContentFilter", true)) }
             SettingItemGroup {
-                val enableQualityFilter = remember { mutableStateOf(settings.getBoolean("enableQualityFilter", true)) }
-                SettingItemWithSwitch(
-                    title = { Text("启用质量过滤规则") },
-                    description = { Text("根据赞同数、关注数等指标过滤低质量内容") },
-                    checked = enableQualityFilter.value,
-                    onCheckedChange = {
-                        enableQualityFilter.value = it
-                        settings.putBoolean("enableQualityFilter", it)
-                    },
-                    settingKey = "enableQualityFilter",
+                var qualityFilterModeExpanded by remember { mutableStateOf(false) }
+                val qualityFilterMode = remember {
+                    mutableStateOf(
+                        QualityFilterMode.entries.firstOrNull {
+                            it.name == settings.getString(QUALITY_FILTER_MODE_PREFERENCE_KEY, QualityFilterMode.RULES.name)
+                        } ?: QualityFilterMode.RULES,
+                    )
+                }
+                val qualityFilterModeOptions = listOf(
+                    QualityFilterMode.OFF to "不屏蔽",
+                    QualityFilterMode.RULES to "屏蔽规则",
+                    QualityFilterMode.HIDE to "隐藏",
+                )
+                SettingItem(
+                    title = { Text("质量屏蔽") },
+                    description = { Text("根据赞同数、关注数等指标处理低质量内容") },
+                    settingKey = QUALITY_FILTER_MODE_PREFERENCE_KEY,
                     highlightedKey = highlightedSetting,
+                    endAction = {
+                        ExposedDropdownMenuBox(
+                            expanded = qualityFilterModeExpanded,
+                            onExpandedChange = { qualityFilterModeExpanded = it },
+                        ) {
+                            OutlinedTextField(
+                                value = qualityFilterModeOptions.first { it.first == qualityFilterMode.value }.second,
+                                onValueChange = {},
+                                readOnly = true,
+                                trailingIcon = {
+                                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = qualityFilterModeExpanded)
+                                },
+                                modifier = Modifier
+                                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+                                    .width(160.dp),
+                                colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
+                            )
+                            ExposedDropdownMenu(
+                                expanded = qualityFilterModeExpanded,
+                                onDismissRequest = { qualityFilterModeExpanded = false },
+                            ) {
+                                qualityFilterModeOptions.forEach { (mode, label) ->
+                                    DropdownMenuItem(
+                                        text = { Text(label) },
+                                        onClick = {
+                                            qualityFilterMode.value = mode
+                                            settings.putString(QUALITY_FILTER_MODE_PREFERENCE_KEY, mode.name)
+                                            qualityFilterModeExpanded = false
+                                        },
+                                    )
+                                }
+                            }
+                        }
+                    },
                 )
 
                 SettingItemWithSwitch(

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
@@ -59,6 +59,7 @@ import com.github.zly2006.zhihu.ui.ANSWER_DOUBLE_TAP_ACTION_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.ARTICLE_USE_WEBVIEW_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.components.SettingItem
 import com.github.zly2006.zhihu.ui.components.SettingItemGroup
+import com.github.zly2006.zhihu.viewmodel.QUALITY_FILTER_MODE_PREFERENCE_KEY
 
 const val SETTINGS_SEARCH_INPUT_TAG = "settingsSearch.input"
 const val SETTINGS_SEARCH_RESULTS_TAG = "settingsSearch.results"
@@ -201,7 +202,7 @@ private val settingsSearchEntries = buildList {
 
     add(recommendEntry("recommend.recommendationMode", "推荐算法", "选择 Web、Android、本地或混合推荐。", "recommendationMode", listOf("推荐来源", "Web 推荐", "Android 推荐", "本地推荐", "混合推荐")))
     add(recommendEntry("recommend.loginForRecommendation", "推荐内容时登录", "获取推荐内容时是否带登录凭证。", "loginForRecommendation"))
-    add(recommendEntry("recommend.enableQualityFilter", "启用质量过滤规则", "按赞同数、关注数等指标过滤内容。", "enableQualityFilter", listOf("低质量")))
+    add(recommendEntry("recommend.qualityFilterMode", "质量屏蔽", "选择不屏蔽、显示屏蔽规则或直接隐藏低质量内容。", QUALITY_FILTER_MODE_PREFERENCE_KEY, listOf("低质量", "屏蔽规则", "隐藏")))
     add(recommendEntry("recommend.enableContentFilter", "启用智能内容过滤", "过滤重复出现但未点击内容。", "enableContentFilter"))
     add(recommendEntry("recommend.filterFollowedUserContent", "过滤已关注用户内容", "控制是否过滤已关注用户的内容。", "filterFollowedUserContent"))
     add(recommendEntry("recommend.enableKeywordBlocking", "启用关键词屏蔽", "按关键词过滤内容。", "enableKeywordBlocking", listOf("关键词", "屏蔽词")))

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -564,9 +564,17 @@ interface PaginationEnvironment :
     ArticleExportContentEnvironment
 
 data class FeedDisplaySettings(
-    val enableQualityFilter: Boolean = true,
+    val qualityFilterMode: QualityFilterMode = QualityFilterMode.RULES,
     val reverseBlock: Boolean = false,
 )
+
+enum class QualityFilterMode {
+    OFF,
+    RULES,
+    HIDE,
+}
+
+const val QUALITY_FILTER_MODE_PREFERENCE_KEY = "qualityFilterMode"
 
 data class HomeFeedFilterResult(
     val foregroundItems: List<FeedDisplayItem>,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/BaseFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/BaseFeedViewModel.kt
@@ -18,6 +18,7 @@
 package com.github.zly2006.zhihu.viewmodel.feed
 
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -31,6 +32,7 @@ import com.github.zly2006.zhihu.viewmodel.FeedDisplayEnvironment
 import com.github.zly2006.zhihu.viewmodel.HomeFeedFilterResult
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationViewModel
+import com.github.zly2006.zhihu.viewmodel.QualityFilterMode
 import com.github.zly2006.zhihu.viewmodel.filter.BlockedTopic
 import com.github.zly2006.zhihu.viewmodel.filter.ContentDetailProvider
 import com.github.zly2006.zhihu.viewmodel.filter.getContentFilterDatabase
@@ -42,6 +44,7 @@ import kotlin.reflect.typeOf
 abstract class BaseFeedViewModel : PaginationViewModel<Feed>(typeOf<Feed>()) {
     var displayItems = mutableStateListOf<FeedDisplayItem>()
     internal var latestLoadedDisplayItems = mutableStateOf<List<FeedDisplayItem>>(emptyList())
+    internal var completedPageCount by mutableIntStateOf(0)
     var isPullToRefresh by mutableStateOf(false)
         protected set
 
@@ -78,7 +81,7 @@ abstract class BaseFeedViewModel : PaginationViewModel<Feed>(typeOf<Feed>()) {
     open fun createDisplayItem(environment: FeedDisplayEnvironment, feed: Feed): FeedDisplayItem {
         val settings = environment.feedDisplaySettings()
         return feed.toDisplayItem(
-            enableQualityFilter = settings.enableQualityFilter,
+            enableQualityFilter = settings.qualityFilterMode != QualityFilterMode.OFF,
             reverseBlock = settings.reverseBlock,
         )
     }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
@@ -30,6 +30,7 @@ import com.github.zly2006.zhihu.navigation.Question
 import com.github.zly2006.zhihu.util.Log
 import com.github.zly2006.zhihu.viewmodel.ContentInteractionEnvironment
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
+import com.github.zly2006.zhihu.viewmodel.QualityFilterMode
 import com.github.zly2006.zhihu.viewmodel.filter.ContentDetailProvider
 import com.github.zly2006.zhihu.viewmodel.filter.extractTopicIds
 import com.github.zly2006.zhihu.viewmodel.postSigned
@@ -174,9 +175,14 @@ class HomeFeedViewModel :
         debugData.addAll(rawData)
 
         viewModelScope.launch {
-            val newItems = data
+            val loadedItems = data
                 .flattenFeeds()
                 .map { feed -> createDisplayItem(environment, feed) }
+            val newItems = if (environment.feedDisplaySettings().qualityFilterMode == QualityFilterMode.HIDE) {
+                loadedItems.filterNot { it.isQualityFiltered }
+            } else {
+                loadedItems
+            }
 
             val filterResult = environment.applyHomeFeedFilters(newItems)
             if (!filterResult.reverseBlock) {
@@ -193,6 +199,7 @@ class HomeFeedViewModel :
             withContext(Dispatchers.Main) {
                 displayItems.replaceHomeFeedItemsWithFilteredResult(filterResult)
                 latestLoadedDisplayItems.value = filterResult.filteredItems
+                completedPageCount++
             }
         }
     }

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/viewmodel/feed/QualityFilterModeTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/viewmodel/feed/QualityFilterModeTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.viewmodel.feed
+
+import com.github.zly2006.zhihu.data.CommonFeed
+import com.github.zly2006.zhihu.data.Feed
+import com.github.zly2006.zhihu.data.Person
+import com.github.zly2006.zhihu.viewmodel.FeedDisplayEnvironment
+import com.github.zly2006.zhihu.viewmodel.FeedDisplaySettings
+import com.github.zly2006.zhihu.viewmodel.QualityFilterMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class QualityFilterModeTest {
+    private val lowQualityArticle = CommonFeed(
+        target = Feed.ArticleTarget(
+            id = 637,
+            url = "https://zhuanlan.zhihu.com/p/637",
+            author = Person(
+                id = "author",
+                url = "https://api.zhihu.com/people/author",
+                userType = "people",
+                name = "作者",
+                headline = "",
+                avatarUrl = "",
+                followersCount = 0,
+                isFollowing = false,
+            ),
+            voteupCount = 0,
+            title = "低赞文章",
+        ),
+    )
+
+    @Test
+    fun offModeKeepsOriginalCard() {
+        val item = HomeFeedViewModel().createDisplayItem(
+            object : FeedDisplayEnvironment {
+                override fun feedDisplaySettings() = FeedDisplaySettings(qualityFilterMode = QualityFilterMode.OFF)
+            },
+            lowQualityArticle,
+        )
+
+        assertEquals("低赞文章", item.title)
+        assertFalse(item.isFiltered)
+        assertFalse(item.isQualityFiltered)
+    }
+
+    @Test
+    fun rulesAndHideModesMarkQualityFilteredCards() {
+        listOf(QualityFilterMode.RULES, QualityFilterMode.HIDE).forEach { mode ->
+            val item = HomeFeedViewModel().createDisplayItem(
+                object : FeedDisplayEnvironment {
+                    override fun feedDisplaySettings() = FeedDisplaySettings(qualityFilterMode = mode)
+                },
+                lowQualityArticle,
+            )
+
+            assertEquals("已屏蔽", item.title)
+            assertTrue(item.isFiltered)
+            assertTrue(item.isQualityFiltered)
+        }
+    }
+}

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
@@ -177,7 +177,7 @@ class DesktopPaginationEnvironment(
     }
 
     override fun feedDisplaySettings(): FeedDisplaySettings = FeedDisplaySettings(
-        enableQualityFilter = false,
+        qualityFilterMode = QualityFilterMode.OFF,
         reverseBlock = settingsStore.toFeedFilterSettings().reverseBlock,
     )
 


### PR DESCRIPTION
## 改动

- 将质量屏蔽从布尔开关改为不屏蔽、屏蔽规则、隐藏三态下拉，默认保持屏蔽规则
- 为质量规则占位增加独立标记，隐藏模式只移除低质量占位，不影响广告或其他过滤来源
- Web 首页整页均被隐藏时自动继续分页，避免停留在空白页
- 更新设置搜索、卡片快捷入口和 UI 设计文档；按要求不迁移旧布尔设置

## 验证

- shared JVM 定向测试：QualityFilterModeTest 通过
- commonMain ktlint 检查通过
- assembleLiteDebug 通过
- Lite Debug APK 安装到本地 API 31 AVD，确认默认值、三项下拉、隐藏选中态与 HIDE 偏好持久化

## 截图

截图来自实际运行的 Lite Debug APK 与本地 API 31 AVD。

### 三态下拉

![质量屏蔽三态下拉](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-672/quality-filter-dropdown.png)

### 选择隐藏

![质量屏蔽隐藏选中态](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-672/quality-filter-hidden.png)

Resolves #637