### PR TITLE
fix: 修复搜索人物结果徽章显示

### DIFF
--- a/app/src/androidTest/assets/search-badge-general.json
+++ b/app/src/androidTest/assets/search-badge-general.json
@@ -1,0 +1,397 @@
+{
+  "paging": {
+    "is_end": true,
+    "next": ""
+  },
+  "data": [
+    {
+      "type": "search_result",
+      "highlight": {
+        "description": "传递法治观点，科普法律知识。你朋友圈的法律人。",
+        "title": "<em>法律</em>贫道"
+      },
+      "object": {
+        "id": "anon-general-people-001",
+        "url_token": "anon-general-people-001",
+        "honor_label": "",
+        "type": "people",
+        "url": "https://www.zhihu.com/people/anon-general-people-001",
+        "name": "<em>匿名</em>用户甲",
+        "user_type": "people",
+        "headline": "匿名用户简介",
+        "gender": 1,
+        "avatar_url": "https://pic.example/anon-general-people-001.png",
+        "badge": [
+          {
+            "type": "identity",
+            "description": "已认证的个人",
+            "topics": []
+          },
+          {
+            "type": "best_answerer",
+            "description": "优秀回答者",
+            "topics": [
+              {
+                "id": "19550874",
+                "name": "法律",
+                "introduction": "法律，是国家的产物，是指统治阶级（泛指政治、经济、思想形态上占支配地位的阶级），为了实现统治并管理国家的目的，经过一定立法程序，所颁布的基本法律和普通法律。法律是统治阶级意志的体现，国家的统治工具。法律是由享有立法权的立法机关（全国人民代表大会和全国人民代表大会常务委员会）行使国家立法权，依照法定程序制定、修改并颁布，并由国家强制力保证实施的基本法律和普通法律总称。包括基本法律、普通法律。法，可划分为1、宪法，2、法律，3、行政法规，4、地方性法规，5、自治条例和单行条例。宪法是高于其它法律部门（法律、行政法规、地方性法规、自治条例和单行条例）的国家根本大法，它规定国家制度和社会制度最基本的原则，公民基本权利和义务，国家机构的组织及其活动的原则等。法律是从属于宪法的强制性规范，是宪法的具体化。宪法是国家法的基础与核心，法律则是国家法的重要组成部分。法律可划分为基本法律（如刑法、刑事诉讼法、民法通则、民事诉讼法、行政诉讼法、行政法、商法、国际法等）和普通法律（如商标法、文物保护法等）。行政法规，是国家行政机关（国务院）根据宪法和法律，制定的行政规范的总称。",
+                "excerpt": "法律，是国家的产物，是指统治阶级（泛指政治、经济、思想形态上占支配地位的阶级），为了实现统治并管理国家的目的，经过一定立法程序，所颁布的基本法律和普通法律。法律是统治阶级意志的体现，国家的统治工具。法律是由享有立法权的立法机关（全国人民代表大会和全国人民代表大会常务委员会）行使国家立法权，依照法定程序制定、修改并颁布，并由国家强制力保证实施的基本法律和普通法律总称。包括基本法律、普通法律。法，可…",
+                "type": "topic",
+                "url": "https://api.zhihu.com/topics/19550874",
+                "avatar_url": "https://pica.zhimg.com/50/f126e096216e4554289b0996539b79b5_l.jpg?source=4e949a73"
+              },
+              {
+                "id": "19591312",
+                "name": "刑法",
+                "introduction": "刑法是规定犯罪、刑事责任和刑罚的法律，是掌握政权的统治阶级为了维护本阶级政治上的统治和各阶级经济上的利益，根据自己的意志，规定哪些行为是犯罪并且应当负何种刑事责任 ，并给予犯罪嫌疑人何种刑事处罚的法律规范的总称。刑法有广义与狭义之分。广义刑法是一切刑事法律规范的总称，狭义刑法仅指刑法典，在我国即《中华人民共和国刑法》。与广义刑法、狭义刑法相联系的，刑法还可区分为普通刑法和特别刑法。普通刑法指具有普遍使用效力的刑法，实际上即指刑法典。特别刑法指仅使用于特定的人、时、地、事（犯罪）的刑法。在我国，也叫单行刑法和附属刑法。2015年8月29日，十二届全国人大常委会十六次会议表决通过刑法修正案（九）。修改后的刑法自2015年11月1日开始施行。这也是继1997年全面修订刑法后通过的第九个刑法修正案。",
+                "excerpt": "刑法是规定犯罪、刑事责任和刑罚的法律，是掌握政权的统治阶级为了维护本阶级政治上的统治和各阶级经济上的利益，根据自己的意志，规定哪些行为是犯罪并且应当负何种刑事责任 ，并给予犯罪嫌疑人何种刑事处罚的法律规范的总称。刑法有广义与狭义之分。广义刑法是一切刑事法律规范的总称，狭义刑法仅指刑法典，在我国即《中华人民共和国刑法》。与广义刑法、狭义刑法相联系的，刑法还可区分为普通刑法和特别刑法。普通刑法指具有…",
+                "type": "topic",
+                "url": "https://api.zhihu.com/topics/19591312",
+                "avatar_url": "https://pica.zhimg.com/50/v2-05cb3f9aab9edf724d0f5f4133960fbf_l.jpg?source=4e949a73"
+              }
+            ]
+          },
+          {
+            "type": "identity",
+            "description": "已认证的机构",
+            "topics": []
+          }
+        ],
+        "badge_v2": {
+          "title": "刑法等 2 个话题下的优秀答主",
+          "merged_badges": [
+            {
+              "type": "best",
+              "detail_type": "best",
+              "title": "优秀答主",
+              "description": "刑法等 2 个话题下的优秀答主",
+              "url": "https://www.zhihu.com/question/48509984",
+              "sources": [
+                {
+                  "id": "19591312",
+                  "token": "19591312",
+                  "type": "topic",
+                  "url": "https://www.zhihu.com/topic/19591312",
+                  "name": "刑法",
+                  "avatar_path": "v2-55d224ff5842c8b46295025812e25082",
+                  "avatar_url": "https://pic1.zhimg.com/v2-55d224ff5842c8b46295025812e25082_720w.jpg?source=32738c0c",
+                  "description": "",
+                  "priority": 0
+                },
+                {
+                  "id": "19550874",
+                  "token": "19550874",
+                  "type": "topic",
+                  "url": "https://www.zhihu.com/topic/19550874",
+                  "name": "法律",
+                  "avatar_path": "v2-1c3d24e50e3430ab16548e812e6a11d8",
+                  "avatar_url": "https://picx.zhimg.com/v2-1c3d24e50e3430ab16548e812e6a11d8_720w.jpg?source=32738c0c",
+                  "description": "",
+                  "priority": 0
+                }
+              ],
+              "icon": "",
+              "night_icon": ""
+            },
+            {
+              "type": "identity",
+              "detail_type": "identity_people",
+              "title": "认证",
+              "description": "已认证的个人",
+              "url": "https://zhuanlan.zhihu.com/p/96956163",
+              "sources": [],
+              "icon": "",
+              "night_icon": ""
+            }
+          ],
+          "detail_badges": [
+            {
+              "type": "best",
+              "detail_type": "best_answerer",
+              "title": "优秀答主",
+              "description": "刑法等 2 个话题下的优秀答主",
+              "url": "https://www.zhihu.com/question/48509984",
+              "sources": [
+                {
+                  "id": "19591312",
+                  "token": "19591312",
+                  "type": "topic",
+                  "url": "https://www.zhihu.com/topic/19591312",
+                  "name": "刑法",
+                  "avatar_path": "v2-55d224ff5842c8b46295025812e25082",
+                  "avatar_url": "https://pic1.zhimg.com/v2-55d224ff5842c8b46295025812e25082_720w.jpg?source=32738c0c",
+                  "description": "",
+                  "priority": 0
+                },
+                {
+                  "id": "19550874",
+                  "token": "19550874",
+                  "type": "topic",
+                  "url": "https://www.zhihu.com/topic/19550874",
+                  "name": "法律",
+                  "avatar_path": "v2-1c3d24e50e3430ab16548e812e6a11d8",
+                  "avatar_url": "https://picx.zhimg.com/v2-1c3d24e50e3430ab16548e812e6a11d8_720w.jpg?source=32738c0c",
+                  "description": "",
+                  "priority": 0
+                }
+              ],
+              "icon": "https://pica.zhimg.com/v2-4a07bc69c4bb04444721f35b32125c75_l.png?source=32738c0c",
+              "night_icon": "https://pica.zhimg.com/v2-4a07bc69c4bb04444721f35b32125c75_l.png?source=32738c0c"
+            },
+            {
+              "type": "reward",
+              "detail_type": "super_activity",
+              "title": "社区成就",
+              "description": "知势榜法律领域影响力榜上榜答主",
+              "url": "",
+              "sources": [
+                {
+                  "id": "27",
+                  "token": "",
+                  "type": "content_potential_category",
+                  "url": "",
+                  "name": "知势榜8月",
+                  "avatar_path": "",
+                  "avatar_url": "",
+                  "description": "",
+                  "priority": 27
+                }
+              ],
+              "icon": "https://picx.zhimg.com/v2-4a07bc69c4bb04444721f35b32125c75_l.png?source=32738c0c",
+              "night_icon": "https://pic1.zhimg.com/v2-4a07bc69c4bb04444721f35b32125c75_l.png?source=32738c0c"
+            },
+            {
+              "type": "identity",
+              "detail_type": "identity_people",
+              "title": "已认证的个人",
+              "description": "已认证的个人",
+              "url": "https://zhuanlan.zhihu.com/p/96956163",
+              "sources": [],
+              "icon": "https://pic1.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c",
+              "night_icon": "https://picx.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c"
+            }
+          ],
+          "icon": "https://pic1.zhimg.com/v2-27bfcba90e66db79ce8768ab807e017e_l.png?source=32738c0c",
+          "night_icon": "https://pic1.zhimg.com/v2-27bfcba90e66db79ce8768ab807e017e_l.png?source=32738c0c"
+        },
+        "old_badges": [
+          {
+            "type": "best_answerer",
+            "description": "优秀答主",
+            "topics": [
+              {
+                "id": "19591312",
+                "type": "topic",
+                "url": "https://www.zhihu.com/topic/19591312",
+                "name": "刑法",
+                "avatar_url": "https://pic1.zhimg.com/v2-55d224ff5842c8b46295025812e25082_720w.jpg?source=32738c0c"
+              },
+              {
+                "id": "19550874",
+                "type": "topic",
+                "url": "https://www.zhihu.com/topic/19550874",
+                "name": "法律",
+                "avatar_url": "https://picx.zhimg.com/v2-1c3d24e50e3430ab16548e812e6a11d8_720w.jpg?source=32738c0c"
+              }
+            ]
+          },
+          {
+            "type": "identity",
+            "description": "已认证的个人"
+          }
+        ],
+        "badge_v2_string": "{\"title\":\"刑法等 2 个话题下的优秀答主\",\"merged_badges\":[{\"type\":\"best\",\"detail_type\":\"best\",\"title\":\"优秀答主\",\"description\":\"刑法等 2 个话题下的优秀答主\",\"url\":\"https://www.zhihu.com/question/48509984\",\"sources\":[{\"id\":\"19591312\",\"token\":\"19591312\",\"type\":\"topic\",\"url\":\"https://www.zhihu.com/topic/19591312\",\"name\":\"刑法\",\"avatar_path\":\"v2-55d224ff5842c8b46295025812e25082\",\"avatar_url\":\"https://pic1.zhimg.com/v2-55d224ff5842c8b46295025812e25082_720w.jpg?source=32738c0c\",\"description\":\"\",\"priority\":0},{\"id\":\"19550874\",\"token\":\"19550874\",\"type\":\"topic\",\"url\":\"https://www.zhihu.com/topic/19550874\",\"name\":\"法律\",\"avatar_path\":\"v2-1c3d24e50e3430ab16548e812e6a11d8\",\"avatar_url\":\"https://picx.zhimg.com/v2-1c3d24e50e3430ab16548e812e6a11d8_720w.jpg?source=32738c0c\",\"description\":\"\",\"priority\":0}],\"icon\":\"\",\"night_icon\":\"\",\"badge_status\":\"passed\"},{\"type\":\"identity\",\"detail_type\":\"identity_people\",\"title\":\"认证\",\"description\":\"已认证的个人\",\"url\":\"https://zhuanlan.zhihu.com/p/96956163\",\"sources\":[],\"icon\":\"\",\"night_icon\":\"\",\"badge_status\":\"passed\"}],\"detail_badges\":[{\"type\":\"best\",\"detail_type\":\"best_answerer\",\"title\":\"优秀答主\",\"description\":\"刑法等 2 个话题下的优秀答主\",\"url\":\"https://www.zhihu.com/question/48509984\",\"sources\":[{\"id\":\"19591312\",\"token\":\"19591312\",\"type\":\"topic\",\"url\":\"https://www.zhihu.com/topic/19591312\",\"name\":\"刑法\",\"avatar_path\":\"v2-55d224ff5842c8b46295025812e25082\",\"avatar_url\":\"https://pic1.zhimg.com/v2-55d224ff5842c8b46295025812e25082_720w.jpg?source=32738c0c\",\"description\":\"\",\"priority\":0},{\"id\":\"19550874\",\"token\":\"19550874\",\"type\":\"topic\",\"url\":\"https://www.zhihu.com/topic/19550874\",\"name\":\"法律\",\"avatar_path\":\"v2-1c3d24e50e3430ab16548e812e6a11d8\",\"avatar_url\":\"https://picx.zhimg.com/v2-1c3d24e50e3430ab16548e812e6a11d8_720w.jpg?source=32738c0c\",\"description\":\"\",\"priority\":0}],\"icon\":\"https://pica.zhimg.com/v2-4a07bc69c4bb04444721f35b32125c75_l.png?source=32738c0c\",\"night_icon\":\"https://pica.zhimg.com/v2-4a07bc69c4bb04444721f35b32125c75_l.png?source=32738c0c\",\"badge_status\":\"passed\"},{\"type\":\"reward\",\"detail_type\":\"super_activity\",\"title\":\"社区成就\",\"description\":\"知势榜法律领域影响力榜上榜答主\",\"url\":\"\",\"sources\":[{\"id\":\"27\",\"token\":\"\",\"type\":\"content_potential_category\",\"url\":\"\",\"name\":\"知势榜8月\",\"avatar_path\":\"\",\"avatar_url\":\"\",\"description\":\"\",\"priority\":27}],\"icon\":\"https://picx.zhimg.com/v2-4a07bc69c4bb04444721f35b32125c75_l.png?source=32738c0c\",\"night_icon\":\"https://pic1.zhimg.com/v2-4a07bc69c4bb04444721f35b32125c75_l.png?source=32738c0c\",\"badge_status\":\"passed\"},{\"type\":\"identity\",\"detail_type\":\"identity_people\",\"title\":\"已认证的个人\",\"description\":\"已认证的个人\",\"url\":\"https://zhuanlan.zhihu.com/p/96956163\",\"sources\":[],\"icon\":\"https://pic1.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c\",\"night_icon\":\"https://picx.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c\",\"badge_status\":\"passed\"}],\"icon\":\"https://pic1.zhimg.com/v2-27bfcba90e66db79ce8768ab807e017e_l.png?source=32738c0c\",\"night_icon\":\"https://pic1.zhimg.com/v2-27bfcba90e66db79ce8768ab807e017e_l.png?source=32738c0c\"}",
+        "is_following": false,
+        "is_followed": false,
+        "is_self": false,
+        "follower_count": 88235,
+        "voteup_count": 267514,
+        "answer_count": 1579,
+        "articles_count": 74,
+        "creation_count": 1805,
+        "last_creation_time": 1786859261,
+        "vip_info": {
+          "is_vip": false,
+          "vip_icon": {
+            "url": "",
+            "night_mode_url": ""
+          }
+        },
+        "attached_info_bytes": "ANONYMIZED"
+      },
+      "hit_labels": null,
+      "index": 3,
+      "id": 818397553
+    },
+    {
+      "type": "search_result",
+      "highlight": {
+        "description": "结婚登报以纪念收藏为主，可作为婚姻相关辅助凭证，本文梳理由来、实际用处、办理渠道、收费标准与实操注意事项。 一、结婚登报的由来、<em>法律</em>效力及用处 1、结婚登报的由来结婚登报并不是近些年才兴起的新鲜玩法，早在民国时…",
+        "title": "详解登报结婚的意义：结婚登报的由来、<em>法律</em>效力及用处"
+      },
+      "object": {
+        "id": "2070450975589110182",
+        "title": "详解登报结婚的意义：结婚登报的由来、<em>法律</em>效力及用处",
+        "type": "article",
+        "url": "https://api.zhihu.com/articles/2070450975589110182",
+        "excerpt": "结婚登报以纪念收藏为主，可作为婚姻相关辅助凭证，本文梳理由来、实际用处、办理渠道、收费标准与实操注意事项。 一、结婚登报的由来、<em>法律</em>效力及用处 1、结婚登报的由来结婚登报并不是近些年才兴起的新鲜玩法，早在民国时…",
+        "voteup_count": 1,
+        "comment_count": 0,
+        "zfav_count": 0,
+        "created_time": 1786414133,
+        "updated_time": 1786414133,
+        "content": "<p data-pid=\"v1aXVQJ9\">【办理材料】新人双方身份证件、结婚证、拟刊登的结婚启事文案；</p><p data-pid=\"-P3Zy03R\">【通用流程】准备资料，选定刊登报刊，提交文案审核，缴纳费用，等待刊发，接收纸质报纸留存。</p><figure data-size=\"normal\"><img src=\"https://pic3.zhimg.com/v2-a852f383486d38990f357e524a66897e_1440w.jpg\" data-caption=\"\" data-size=\"normal\" data-rawwidth=\"1448\" data-rawheight=\"1086\" data-original-token=\"v2-eb214a95e0c1b6408ec10262c0a5101d\" class=\"origin_image zh-lightbox-thumb\" width=\"1448\" data-original=\"https://pic3.zhimg.com/v2-a852f383486d38990f357e524a66897e_r.jpg\"/></figure><p data-pid=\"qMgBK-kZ\">结婚登报以纪念收藏为主，可作为婚姻相关辅助凭证，本文梳理由来、实际用处、办理渠道、收费标准与实操注意事项。</p><a href=\"https://xg.zhihu.com/plugin/affdfdb61c784fcb460c9a78b4d084aa?BIZ=ECOMMERCE\" data-draft-node=\"block\" data-draft-type=\"link-card\" data-draft-title=\"登报公告，24小时见报，足不出户，点击办理\" data-draft-cover=\"\" class=\"internal\">登报公告，24小时见报，足不出户，点击办理</a><p data-pid=\"zHR4BPmk\"><b>一、结婚登报的由来、法律效力及用处</b></p><p data-pid=\"Wl3yb-so\"><b>1、结婚登报的由来</b></p><p data-pid=\"Ih4GdmFt\">结婚登报并不是近些年才兴起的新鲜玩法，早在民国时期就已经十分流行海南日报。那时候婚姻登记体系还没有普及，不少新人会选择在报纸刊登结婚启事，把成婚消息告诉远方亲友。在过去，报纸属于大众公开传播载体，一纸启事相当于对外公开两个人缔结姻缘这件事。放到现在，网络朋友圈消息很容易删除、消失，报纸印刷发行之后内容无法更改，很多年轻人喜欢这种复古仪式感，把结婚登报当做一份可以长久存放的爱情纪念物。</p><p data-pid=\"ZCZwH3dL\"><b>2、结婚登报的法律效力</b></p><p data-pid=\"6vIgNzRe\">这里一定要分清，<b>登报结婚不能替代领证，只有拿到结婚证才代表婚姻关系正式确立</b>。 结婚登报属于喜事公告类刊登，它本身不能产生确立婚姻关系的效力。</p><p data-pid=\"jJl_o4kz\"><b>3、结婚登报实际用处</b></p><p data-pid=\"KbD_kzIk\"><b>纪念收藏价值</b>：纸质报纸可以妥善保存，多年之后翻看，定格新婚时刻，属于独一份的实物纪念。电子版报纸也可以留存备份。</p><p data-pid=\"rLEFs739\"><b>对外告知亲友</b>：不方便挨个通知远方亲人的情况下，登报公开喜讯，完成传统意义上昭告亲友的效果。</p><p data-pid=\"8hjrz_Ri\"><b>辅助留存凭证</b>：遇到家庭档案整理、家族资料留存场景，这份刊登过结婚启事的报纸，可以作为婚姻事实的辅助资料。</p><p data-pid=\"y7XAKXw_\"><b>仪式感体验</b>：区别普通线上朋友圈官宣，油墨印刷的公开启事，给新人增加一份庄重的官宣仪式感。</p><h2><b>二、结婚登报怎么办？线上、线下办理渠道</b></h2><p data-pid=\"sMAzwU7D\"><b>1、线上小程序</b></p><p data-pid=\"KYpaNrIq\">持有完整 ICP 备案资质，商标注册号：56497105，商标注册时间：2021 年 05 月 31 日，工信部 ICP 备案号：豫 ICP 备 2024079921 号。合作全部报刊均具备国家正规 CN 刊号，出具的结婚启事报纸具备完整公示效力，不会出现内部小报无效的情况，不管是收藏还是作为辅助凭证都完全可用。平台对接全国 1800 余家正规报社，全国、各省、地市报刊全覆盖，新人可以自由对比各家报价，不用挨个线下跑报社咨询，足不出户手机上就能完成全部操作。</p><p data-pid=\"k1MFz3Tr\"><b>2、其他线上平台</b></p><p data-pid=\"WMf58wPI\">多数平台具备线上业务资质，对接多家报社资源，可选择多地报刊，手机线上提交资料办理。平台报刊库数量各不相同，部分平台可选报纸数量偏少。审核通过后下个工作日见报，文案修改权限以平台页面规则为准，报纸支持邮寄。</p><p data-pid=\"jDgweL22\"><b>3、线下报社</b></p><p data-pid=\"CT5QN3k5\">直接去到报社线下业务窗口办理，对接的都是自有合作报刊，可以现场确认版面排版。需要新人抽出时间上门办理，只能受理自家合作报纸。仅工作日可以受理业务，周末无法提交登报申请，同等级别报纸线下报价普遍会高出 50120 元，部分报社不提供免费修改文案服务。</p><p data-pid=\"4rjxNiGG\"><b>4、线上操作步骤</b></p><p data-pid=\"DqlpeMxf\">选择你所在的城市和报纸；</p><p data-pid=\"emnccktj\">套用模板填写信息；</p><p data-pid=\"OIIfgZ-h\">在线支付，下个工作日见报，纸质报纸邮寄到家。</p><h2><b>三、结婚登报需要什么材料？</b></h2><p data-pid=\"A41HLCDY\">办理结婚登报，需要准备以下资料：</p><p data-pid=\"iASOGTiS\">l 新人双方身份证件信息，用于平台和报社核验身份。</p><p data-pid=\"qDC3lJeA\">l 结婚证，报社需要核验新人已经完成婚姻登记，才允许刊登结婚启事。</p><p data-pid=\"FI4CyIQF\">l 准备好结婚启事文案，也可以直接使用平台现成模板，文案内容要符合公序良俗，不能出现违规表述。</p><p data-pid=\"3hHvXXZE\">l 收件地址与联系电话，用于纸质报纸邮寄派送。</p><h2><b>四、结婚登报常见问题与解答</b></h2><p data-pid=\"JYlCuv8S\"><b>1：登报结婚之后，是不是就不用领结婚证了？</b></p><p data-pid=\"zII_Dqfy\">不是，结婚证才是确立婚姻关系的凭证，登报只是喜事公告，不具备婚姻登记效力。</p><p data-pid=\"NNJj4Fdu\"><b>2：结婚登报的文案可以自己随便写吗？</b></p><p data-pid=\"xvVXciVf\">可以自己撰写，但要符合公序良俗，内容需要报社审核，审核不通过需要修改之后再刊登。</p><p data-pid=\"aFnJR0MP\"><b>3：登报之后，会给我纸质报纸吗？</b></p><p data-pid=\"5geczdpA\">大多数渠道都可以邮寄纸质报纸，部分渠道需要额外加购报纸份数，看个人需求。</p>",
+        "thumbnail_info": {
+          "count": 1,
+          "thumbnails": [
+            {
+              "data_url": "",
+              "url": "https://pic1.zhimg.com/80/v2-b543c5d3c1a7ae75912d0f66b614bfb6_qhd.jpg?source=4e949a73",
+              "type": "image",
+              "width": 2000,
+              "height": 1500
+            }
+          ],
+          "type": "thumbnail_info",
+          "total_count": 1
+        },
+        "author": {
+          "id": "anon-content-author-001",
+          "url_token": "anon-content-author-001",
+          "name": "匿名作者甲",
+          "headline": "匿名作者简介",
+          "gender": 0,
+          "is_followed": false,
+          "is_following": false,
+          "user_type": "people",
+          "url": "https://www.zhihu.com/people/anon-content-author-001",
+          "type": "people",
+          "avatar_url": "https://pic.example/anon-content-author-001.png",
+          "badge": [
+            {
+              "type": "identity",
+              "description": "已认证的个人",
+              "topics": []
+            },
+            {
+              "type": "identity",
+              "description": "已认证的机构",
+              "topics": []
+            }
+          ],
+          "authority_info": [
+            {
+              "company": "",
+              "job": "",
+              "name": "",
+              "verify_info": "已认证的个人",
+              "verify_info_bayes": ""
+            }
+          ],
+          "voteup_count": 0,
+          "follower_count": 5,
+          "badge_v2": {
+            "title": "已认证的个人",
+            "merged_badges": [
+              {
+                "type": "identity",
+                "detail_type": "identity_people",
+                "title": "认证",
+                "description": "已认证的个人",
+                "url": "https://zhuanlan.zhihu.com/p/96956163",
+                "sources": [],
+                "icon": "",
+                "night_icon": ""
+              }
+            ],
+            "detail_badges": [
+              {
+                "type": "identity",
+                "detail_type": "identity_people",
+                "title": "已认证的个人",
+                "description": "已认证的个人",
+                "url": "https://zhuanlan.zhihu.com/p/96956163",
+                "sources": [],
+                "icon": "https://picx.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c",
+                "night_icon": "https://picx.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c"
+              }
+            ],
+            "icon": "https://pica.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c",
+            "night_icon": "https://pic1.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c"
+          },
+          "old_badges": [
+            {
+              "type": "identity",
+              "description": "已认证的个人"
+            }
+          ],
+          "badge_v2_string": "{\"title\":\"已认证的个人\",\"merged_badges\":[{\"type\":\"identity\",\"detail_type\":\"identity_people\",\"title\":\"认证\",\"description\":\"已认证的个人\",\"url\":\"https://zhuanlan.zhihu.com/p/96956163\",\"sources\":[],\"icon\":\"\",\"night_icon\":\"\",\"badge_status\":\"passed\"}],\"detail_badges\":[{\"type\":\"identity\",\"detail_type\":\"identity_people\",\"title\":\"已认证的个人\",\"description\":\"已认证的个人\",\"url\":\"https://zhuanlan.zhihu.com/p/96956163\",\"sources\":[],\"icon\":\"https://picx.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c\",\"night_icon\":\"https://picx.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c\",\"badge_status\":\"passed\"}],\"icon\":\"https://pica.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c\",\"night_icon\":\"https://pic1.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c\"}",
+          "topic_bayes_map": null,
+          "topic_map": {},
+          "verify_bayes": ""
+        },
+        "voting": 0,
+        "relationship": {
+          "is_voted": false,
+          "is_author": false,
+          "following_upvoter": [],
+          "following_upvoter_count": 0,
+          "following_collect": [],
+          "following_collect_count": 0,
+          "high_level_creator": [],
+          "high_level_creator_count": 0
+        },
+        "flag": {
+          "flag_type": "professional",
+          "flag_text": ""
+        },
+        "is_zhi_plus": true,
+        "is_zhi_plus_content": true,
+        "extra": "{\"is_card\":true,\"id\":\"3806942\",\"parameters\":\"plugcb=https%3A%2F%2Fsugar.zhihu.com%2Fplutus_adreaper_callback%3Fcid%3D3806942%26ccid%3D3806942%26zoneid%3D10001%26adid%3D3786428%26sid%3Dfa907d17-5760-482d-8995-c3d2df5a710d%26adsource%3Dzhi_plus%26ocpxs%3D1%26ocpxp%3D1000%26dynamictitle%3D%26mixinfo%3D__MIX__INFO__%26campaignid%3D2779089%26cbed%3DCjNQdw9zbXl7FHQEQTlxFhkgTitKJzl9aEQxE1gmJUQSLF13HiEqfX8SfFUBYnsGX3INcw1xbHl5HXQXQzl-DVtjSiMFJTt5fhI2VgZ9eQdddRR-AHE-bXYca1IcM39UWSFff1l0a3AqAzsEDGFqUQJ4Cn0AdW5ydgMxF0Ntfh1aY1YpSDs9Ly9Jb1YEdi9CAngKcgh1Y3R8AzEODGJ0AVtxCn8Od3wjIVFvUhczJFJWdR84XTQ7MipLb0FFMT9bAiEEbFklOyNzAGUlFGJ-Xwg1WhVaJX9yfABhJgB1fnNOdwsoVywuZXwXd1RwYGkCKGALeF0gKiNrF2BCAhF9FVkGHHgKLTUiJ0F3VQN1f3FbYAsJHXFoIyFWJkIDYmkDKnEceHtmaHIrRiIKbicpWQwtTW8KcX9zDxV3VXJ1fgIcIFAtUDcFIyFANEIDYmkDKnQceHtmaHIsSj0TbjYtUx8qS28KcX9zDxV3VXJ1fgIIKko-ZyU7IzpKIEIDYmkDKnEceHtmaHIvST4IRjEiUw5gC3gdcBtwaxcRQgNiLkUPIlw-ZyU7IzpKIDhHMSBFDmALeB1wG3BrFxFCA2ItXAwqSyNMKzcfOUA7AFkkaQJZYAoLCGZoA2sXYAFUNShvCCpXPkosNh86XCICFGJ-FVgECW8PB3wvLVUqFwxhfABbY1AtS35qZidMJloBdjxCAngJbFssKX1_EnxVAWJ7Bl9yDXMNcWx5eR10BkM7cQJNN0k4UX5rcXYQZ1QXIzhJByAEbw8Bf3J8TD8GVjVpAllgCgsdcWg2fAgwUgVjLwUPdlp7WXQ7JXkQa1YDNHxWXXNbfAl3OCYsE3dVA3V-c053Cz5ZJH9yfABhJhRifhVZdxx4e2Zocj1RKwtUdX4CTnZ4bwpxbmV8F3dQdXYjUxs9SncJZTY1JxhrUAFmfQJadQlsWyIzfXwSZV4BaHUWGy1adwllOScnGGJBUiRxA1N1D3MMcXwzJ0hvVxczKEQCeB8rWjNncGhGJhMMdi9cGHgfP1EtZ3F-FWJWAWF-A00hWjxKfmpufhVjXgVnewlbdgF-Cnpodn4XZ0FGIDtDVmNSPUx-fDo-SScUQSRxAE0kQyMFcmpwfhR0CFImPg1bawl7D3FqcnkTZlAFaXkCXXwOch4wLX1rYGRCc2NpCV5gfH8dAR9ldmd0E0I_cQFNLk4jXH58IypRIVoAdilTGyZKdwhlKS9zF3QERSlxQAQ2TWxbJy40cxU936Ed3KpqHQ%3D%3D%26cmixid%3D__CMIXID__%26isnative%3Dfalse%26seg%3D%E6%B3%95%E5%BE%8B%26advertiser_id%3D707951%26content_id%3D281043564%26content_type%3Dpost%26creative%3D3806942%26caid%3D%25255B%25257B%252522version%252522%25253A%252522%252522%25257D%25252C%25257B%252522version2%252522%25253A%252522%252522%25257D%25255D%26os%3D3%26imei%3D%26idfa%3D%26androidid%3D%26ip%3D182.35.111.115%26ua%3DMozilla%252F5.0%2B%2528X11%253B%2BU%253B%2BLinux%2Bx86_64%253B%2Ben-US%2529%2BAppleWebKit%252F540.0%2B%2528KHTML%252C%2Blike%2BGecko%2529%2BUbuntu%252F10.10%2BChrome%252F9.1.0.0%2BSafari%252F540.0%26oaid%3D\",\"sign\":\"635a18d9-042f-4ce1-b0e6-525e99ab1571\",\"mobile_experiment\":null,\"new_asset\":\"\",\"click_tracks\":[\"https://sugar.zhihu.com/ad-track/zplus_log?isy=4\\u0026zk=\\u0026currency=0\\u0026ar=0.008242875337600708\\u0026tev=0.732421875\\u0026ui=182.35.111.115\\u0026cv=\\u0026dts=1786864190\\u0026ri=f11ce525-27e2-4a63-9f5c-0298ea542c20\\u0026exp=zplus-search-0\\u0026cl=610100\\u0026pt=0\\u0026cla=3\\u0026octr=0.008242875337600708\\u0026mix=__MIX__INFO__\\u0026zri=588fb33259c1234f47beb434e65a778d\\u0026swi=nil\\u0026cc=370900\\u0026ed=CjNQdw9zbXl7FHQEQTlxFhkgTitKJzl9aEQxE1gmJUQSLF13HiEqfX8SfFUBYnsGX3INcw1xbHl5HXQXQzl-DVtjSiMFJTt5fhI2VgZ9eQdddRR-AHE-bXYca1IcM39UWSFff1l0a3AqAzsEDGFqUQJ4Cn0AdW5ydgMxF0Ntfh1aY1YpSDs9Ly9Jb1YEdi9CAngKcgh1Y3R8AzEODGJ0AVtxCn8Od3wjIVFvUhczJFJWdR84XTQ7MipLb0FFMT9bAiEEbFklOyNzAGUlFGJ-Xwg1WhVaJX9yfABhJgB1fnNOdwsoVywuZXwXd1RwYGkCKGALeF0gKiNrF2BCAhF9FVkGHHgKLTUiJ0F3VQN1f3FbYAsJHXFoIyFWJkIDYmkDKnEceHtmaHIrRiIKbicpWQwtTW8KcX9zDxV3VXJ1fgIcIFAtUDcFIyFANEIDYmkDKnQceHtmaHIsSj0TbjYtUx8qS28KcX9zDxV3VXJ1fgIIKko-ZyU7IzpKIEIDYmkDKnEceHtmaHIvST4IRjEiUw5gC3gdcBtwaxcRQgNiLkUPIlw-ZyU7IzpKIDhHMSBFDmALeB1wG3BrFxFCA2ItXAwqSyNMKzcfOUA7AFkkaQJZYAoLCGZoA2sXYAFUNShvCCpXPkosNh86XCICFGJ-FVgECW8PB3wvLVUqFwxhfABbY1AtS35qZidMJloBdjxCAngJbFssKX1_EnxVAWJ7Bl9yDXMNcWx5eR10BkM7cQJNN0k4UX5rcXYQZ1QXIzhJByAEbw8Bf3J8TD8GVjVpAllgCgsdcWg2fAgwUgVjLwUPdlp7WXQ7JXkQa1YDNHxWXXNbfAl3OCYsE3dVA3V-c053Cz5ZJH9yfABhJhRifhVZdxx4e2Zocj1RKwtUdX4CTnZ4bwpxbmV8F3dQdXYjUxs9SncJZTY1JxhrUAFmfQJadQlsWyIzfXwSZV4BaHUWGy1adwllOScnGGJBUiRxA1N1D3MMcXwzJ0hvVxczKEQCeB8rWjNncGhGJhMMdi9cGHgfP1EtZ3F-FWJWAWF-A00hWjxKfmpufhVjXgVnewlbdgF-Cnpodn4XZ0FGIDtDVmNSPUx-fDo-SScUQSRxAE0kQyMFcmpwfhR0CFImPg1bawl7D3FqcnkTZlAFaXkCXXwOch4wLX1rYGRCc2NpCV5gfH8dAR9ldmd0E0I_cQFNLk4jXH58IypRIVoAdilTGyZKdwhlKS9zF3QERSlxQAQ2TWxbJy40cxU936Ed3KpqHQ==\\u0026at=CjEEKVQqOSuIYIdBvEo7Wg==\"],\"view_tracks\":[\"https://sugar.zhihu.com/ad-track/zplus_log?isy=4\\u0026zk=\\u0026currency=0\\u0026ar=0.008242875337600708\\u0026tev=0.732421875\\u0026ui=182.35.111.115\\u0026cv=\\u0026dts=1786864190\\u0026ri=f11ce525-27e2-4a63-9f5c-0298ea542c20\\u0026exp=zplus-search-0\\u0026cl=610100\\u0026pt=0\\u0026cla=3\\u0026octr=0.008242875337600708\\u0026mix=__MIX__INFO__\\u0026zri=588fb33259c1234f47beb434e65a778d\\u0026swi=nil\\u0026cc=370900\\u0026ed=CjNQdw9zbXl7FHQEQTlxFhkgTitKJzl9aEQxE1gmJUQSLF13HiEqfX8SfFUBYnsGX3INcw1xbHl5HXQXQzl-DVtjSiMFJTt5fhI2VgZ9eQdddRR-AHE-bXYca1IcM39UWSFff1l0a3AqAzsEDGFqUQJ4Cn0AdW5ydgMxF0Ntfh1aY1YpSDs9Ly9Jb1YEdi9CAngKcgh1Y3R8AzEODGJ0AVtxCn8Od3wjIVFvUhczJFJWdR84XTQ7MipLb0FFMT9bAiEEbFklOyNzAGUlFGJ-Xwg1WhVaJX9yfABhJgB1fnNOdwsoVywuZXwXd1RwYGkCKGALeF0gKiNrF2BCAhF9FVkGHHgKLTUiJ0F3VQN1f3FbYAsJHXFoIyFWJkIDYmkDKnEceHtmaHIrRiIKbicpWQwtTW8KcX9zDxV3VXJ1fgIcIFAtUDcFIyFANEIDYmkDKnQceHtmaHIsSj0TbjYtUx8qS28KcX9zDxV3VXJ1fgIIKko-ZyU7IzpKIEIDYmkDKnEceHtmaHIvST4IRjEiUw5gC3gdcBtwaxcRQgNiLkUPIlw-ZyU7IzpKIDhHMSBFDmALeB1wG3BrFxFCA2ItXAwqSyNMKzcfOUA7AFkkaQJZYAoLCGZoA2sXYAFUNShvCCpXPkosNh86XCICFGJ-FVgECW8PB3wvLVUqFwxhfABbY1AtS35qZidMJloBdjxCAngJbFssKX1_EnxVAWJ7Bl9yDXMNcWx5eR10BkM7cQJNN0k4UX5rcXYQZ1QXIzhJByAEbw8Bf3J8TD8GVjVpAllgCgsdcWg2fAgwUgVjLwUPdlp7WXQ7JXkQa1YDNHxWXXNbfAl3OCYsE3dVA3V-c053Cz5ZJH9yfABhJhRifhVZdxx4e2Zocj1RKwtUdX4CTnZ4bwpxbmV8F3dQdXYjUxs9SncJZTY1JxhrUAFmfQJadQlsWyIzfXwSZV4BaHUWGy1adwllOScnGGJBUiRxA1N1D3MMcXwzJ0hvVxczKEQCeB8rWjNncGhGJhMMdi9cGHgfP1EtZ3F-FWJWAWF-A00hWjxKfmpufhVjXgVnewlbdgF-Cnpodn4XZ0FGIDtDVmNSPUx-fDo-SScUQSRxAE0kQyMFcmpwfhR0CFImPg1bawl7D3FqcnkTZlAFaXkCXXwOch4wLX1rYGRCc2NpCV5gfH8dAR9ldmd0E0I_cQFNLk4jXH58IypRIVoAdilTGyZKdwhlKS9zF3QERSlxQAQ2TWxbJy40cxU936Ed3KpqHQ==\\u0026at=CjEEPFEmLWm8-o_znDYB\"],\"view_x_tracks\":[\"https://sugar.zhihu.com/ad-track/zplus_log?isy=4\\u0026zk=\\u0026currency=0\\u0026ar=0.008242875337600708\\u0026tev=0.732421875\\u0026ui=182.35.111.115\\u0026cv=\\u0026dts=1786864190\\u0026ri=f11ce525-27e2-4a63-9f5c-0298ea542c20\\u0026exp=zplus-search-0\\u0026cl=610100\\u0026pt=0\\u0026cla=3\\u0026octr=0.008242875337600708\\u0026mix=__MIX__INFO__\\u0026zri=588fb33259c1234f47beb434e65a778d\\u0026swi=nil\\u0026cc=370900\\u0026ed=CjNQdw9zbXl7FHQEQTlxFhkgTitKJzl9aEQxE1gmJUQSLF13HiEqfX8SfFUBYnsGX3INcw1xbHl5HXQXQzl-DVtjSiMFJTt5fhI2VgZ9eQdddRR-AHE-bXYca1IcM39UWSFff1l0a3AqAzsEDGFqUQJ4Cn0AdW5ydgMxF0Ntfh1aY1YpSDs9Ly9Jb1YEdi9CAngKcgh1Y3R8AzEODGJ0AVtxCn8Od3wjIVFvUhczJFJWdR84XTQ7MipLb0FFMT9bAiEEbFklOyNzAGUlFGJ-Xwg1WhVaJX9yfABhJgB1fnNOdwsoVywuZXwXd1RwYGkCKGALeF0gKiNrF2BCAhF9FVkGHHgKLTUiJ0F3VQN1f3FbYAsJHXFoIyFWJkIDYmkDKnEceHtmaHIrRiIKbicpWQwtTW8KcX9zDxV3VXJ1fgIcIFAtUDcFIyFANEIDYmkDKnQceHtmaHIsSj0TbjYtUx8qS28KcX9zDxV3VXJ1fgIIKko-ZyU7IzpKIEIDYmkDKnEceHtmaHIvST4IRjEiUw5gC3gdcBtwaxcRQgNiLkUPIlw-ZyU7IzpKIDhHMSBFDmALeB1wG3BrFxFCA2ItXAwqSyNMKzcfOUA7AFkkaQJZYAoLCGZoA2sXYAFUNShvCCpXPkosNh86XCICFGJ-FVgECW8PB3wvLVUqFwxhfABbY1AtS35qZidMJloBdjxCAngJbFssKX1_EnxVAWJ7Bl9yDXMNcWx5eR10BkM7cQJNN0k4UX5rcXYQZ1QXIzhJByAEbw8Bf3J8TD8GVjVpAllgCgsdcWg2fAgwUgVjLwUPdlp7WXQ7JXkQa1YDNHxWXXNbfAl3OCYsE3dVA3V-c053Cz5ZJH9yfABhJhRifhVZdxx4e2Zocj1RKwtUdX4CTnZ4bwpxbmV8F3dQdXYjUxs9SncJZTY1JxhrUAFmfQJadQlsWyIzfXwSZV4BaHUWGy1adwllOScnGGJBUiRxA1N1D3MMcXwzJ0hvVxczKEQCeB8rWjNncGhGJhMMdi9cGHgfP1EtZ3F-FWJWAWF-A00hWjxKfmpufhVjXgVnewlbdgF-Cnpodn4XZ0FGIDtDVmNSPUx-fDo-SScUQSRxAE0kQyMFcmpwfhR0CFImPg1bawl7D3FqcnkTZlAFaXkCXXwOch4wLX1rYGRCc2NpCV5gfH8dAR9ldmd0E0I_cQFNLk4jXH58IypRIVoAdilTGyZKdwhlKS9zF3QERSlxQAQ2TWxbJy40cxU936Ed3KpqHQ==\\u0026at=CjEEPFEmLR820zpS4V8L1jE=\"],\"deliver_x_tracks\":[\"http://proxy-ad-track-zplus:10000/ad-track/zplus_log?isy=4\\u0026zk=\\u0026currency=0\\u0026ar=0.008242875337600708\\u0026tev=0.732421875\\u0026ui=182.35.111.115\\u0026cv=\\u0026dts=1786864190\\u0026ri=f11ce525-27e2-4a63-9f5c-0298ea542c20\\u0026exp=zplus-search-0\\u0026cl=610100\\u0026pt=0\\u0026cla=3\\u0026octr=0.008242875337600708\\u0026mix=__MIX__INFO__\\u0026zri=588fb33259c1234f47beb434e65a778d\\u0026swi=nil\\u0026cc=370900\\u0026ed=CjNQdw9zbXl7FHQEQTlxFhkgTitKJzl9aEQxE1gmJUQSLF13HiEqfX8SfFUBYnsGX3INcw1xbHl5HXQXQzl-DVtjSiMFJTt5fhI2VgZ9eQdddRR-AHE-bXYca1IcM39UWSFff1l0a3AqAzsEDGFqUQJ4Cn0AdW5ydgMxF0Ntfh1aY1YpSDs9Ly9Jb1YEdi9CAngKcgh1Y3R8AzEODGJ0AVtxCn8Od3wjIVFvUhczJFJWdR84XTQ7MipLb0FFMT9bAiEEbFklOyNzAGUlFGJ-Xwg1WhVaJX9yfABhJgB1fnNOdwsoVywuZXwXd1RwYGkCKGALeF0gKiNrF2BCAhF9FVkGHHgKLTUiJ0F3VQN1f3FbYAsJHXFoIyFWJkIDYmkDKnEceHtmaHIrRiIKbicpWQwtTW8KcX9zDxV3VXJ1fgIcIFAtUDcFIyFANEIDYmkDKnQceHtmaHIsSj0TbjYtUx8qS28KcX9zDxV3VXJ1fgIIKko-ZyU7IzpKIEIDYmkDKnEceHtmaHIvST4IRjEiUw5gC3gdcBtwaxcRQgNiLkUPIlw-ZyU7IzpKIDhHMSBFDmALeB1wG3BrFxFCA2ItXAwqSyNMKzcfOUA7AFkkaQJZYAoLCGZoA2sXYAFUNShvCCpXPkosNh86XCICFGJ-FVgECW8PB3wvLVUqFwxhfABbY1AtS35qZidMJloBdjxCAngJbFssKX1_EnxVAWJ7Bl9yDXMNcWx5eR10BkM7cQJNN0k4UX5rcXYQZ1QXIzhJByAEbw8Bf3J8TD8GVjVpAllgCgsdcWg2fAgwUgVjLwUPdlp7WXQ7JXkQa1YDNHxWXXNbfAl3OCYsE3dVA3V-c053Cz5ZJH9yfABhJhRifhVZdxx4e2Zocj1RKwtUdX4CTnZ4bwpxbmV8F3dQdXYjUxs9SncJZTY1JxhrUAFmfQJadQlsWyIzfXwSZV4BaHUWGy1adwllOScnGGJBUiRxA1N1D3MMcXwzJ0hvVxczKEQCeB8rWjNncGhGJhMMdi9cGHgfP1EtZ3F-FWJWAWF-A00hWjxKfmpufhVjXgVnewlbdgF-Cnpodn4XZ0FGIDtDVmNSPUx-fDo-SScUQSRxAE0kQyMFcmpwfhR0CFImPg1bawl7D3FqcnkTZlAFaXkCXXwOch4wLX1rYGRCc2NpCV5gfH8dAR9ldmd0E0I_cQFNLk4jXH58IypRIVoAdilTGyZKdwhlKS9zF3QERSlxQAQ2TWxbJy40cxU936Ed3KpqHQ==\\u0026at=CjEELl0vMzYrVw0fll1t8qj4XUE=\"],\"impression_tracks\":[\"https://sugar.zhihu.com/ad-track/zplus_log?isy=4\\u0026zk=\\u0026currency=0\\u0026ar=0.008242875337600708\\u0026tev=0.732421875\\u0026ui=182.35.111.115\\u0026cv=\\u0026dts=1786864190\\u0026ri=f11ce525-27e2-4a63-9f5c-0298ea542c20\\u0026exp=zplus-search-0\\u0026cl=610100\\u0026pt=0\\u0026cla=3\\u0026octr=0.008242875337600708\\u0026mix=__MIX__INFO__\\u0026zri=588fb33259c1234f47beb434e65a778d\\u0026swi=nil\\u0026cc=370900\\u0026ed=CjNQdw9zbXl7FHQEQTlxFhkgTitKJzl9aEQxE1gmJUQSLF13HiEqfX8SfFUBYnsGX3INcw1xbHl5HXQXQzl-DVtjSiMFJTt5fhI2VgZ9eQdddRR-AHE-bXYca1IcM39UWSFff1l0a3AqAzsEDGFqUQJ4Cn0AdW5ydgMxF0Ntfh1aY1YpSDs9Ly9Jb1YEdi9CAngKcgh1Y3R8AzEODGJ0AVtxCn8Od3wjIVFvUhczJFJWdR84XTQ7MipLb0FFMT9bAiEEbFklOyNzAGUlFGJ-Xwg1WhVaJX9yfABhJgB1fnNOdwsoVywuZXwXd1RwYGkCKGALeF0gKiNrF2BCAhF9FVkGHHgKLTUiJ0F3VQN1f3FbYAsJHXFoIyFWJkIDYmkDKnEceHtmaHIrRiIKbicpWQwtTW8KcX9zDxV3VXJ1fgIcIFAtUDcFIyFANEIDYmkDKnQceHtmaHIsSj0TbjYtUx8qS28KcX9zDxV3VXJ1fgIIKko-ZyU7IzpKIEIDYmkDKnEceHtmaHIvST4IRjEiUw5gC3gdcBtwaxcRQgNiLkUPIlw-ZyU7IzpKIDhHMSBFDmALeB1wG3BrFxFCA2ItXAwqSyNMKzcfOUA7AFkkaQJZYAoLCGZoA2sXYAFUNShvCCpXPkosNh86XCICFGJ-FVgECW8PB3wvLVUqFwxhfABbY1AtS35qZidMJloBdjxCAngJbFssKX1_EnxVAWJ7Bl9yDXMNcWx5eR10BkM7cQJNN0k4UX5rcXYQZ1QXIzhJByAEbw8Bf3J8TD8GVjVpAllgCgsdcWg2fAgwUgVjLwUPdlp7WXQ7JXkQa1YDNHxWXXNbfAl3OCYsE3dVA3V-c053Cz5ZJH9yfABhJhRifhVZdxx4e2Zocj1RKwtUdX4CTnZ4bwpxbmV8F3dQdXYjUxs9SncJZTY1JxhrUAFmfQJadQlsWyIzfXwSZV4BaHUWGy1adwllOScnGGJBUiRxA1N1D3MMcXwzJ0hvVxczKEQCeB8rWjNncGhGJhMMdi9cGHgfP1EtZ3F-FWJWAWF-A00hWjxKfmpufhVjXgVnewlbdgF-Cnpodn4XZ0FGIDtDVmNSPUx-fDo-SScUQSRxAE0kQyMFcmpwfhR0CFImPg1bawl7D3FqcnkTZlAFaXkCXXwOch4wLX1rYGRCc2NpCV5gfH8dAR9ldmd0E0I_cQFNLk4jXH58IypRIVoAdilTGyZKdwhlKS9zF3QERSlxQAQ2TWxbJy40cxU936Ed3KpqHQ==\\u0026at=CjEEI1UzKCU9VjsIXwyIzIulhGWC\",\"https://sugar.zhihu.com/ad-track/zplus_log?isy=4\\u0026zk=\\u0026currency=0\\u0026ar=0.008242875337600708\\u0026tev=0.732421875\\u0026ui=182.35.111.115\\u0026cv=\\u0026dts=1786864190\\u0026ri=f11ce525-27e2-4a63-9f5c-0298ea542c20\\u0026exp=zplus-search-0\\u0026cl=610100\\u0026pt=0\\u0026cla=3\\u0026octr=0.008242875337600708\\u0026mix=__MIX__INFO__\\u0026zri=588fb33259c1234f47beb434e65a778d\\u0026swi=nil\\u0026cc=370900\\u0026ed=CjNQdw9zbXl7FHQEQTlxFhkgTitKJzl9aEQxE1gmJUQSLF13HiEqfX8SfFUBYnsGX3INcw1xbHl5HXQXQzl-DVtjSiMFJTt5fhI2VgZ9eQdddRR-AHE-bXYca1IcM39UWSFff1l0a3AqAzsEDGFqUQJ4Cn0AdW5ydgMxF0Ntfh1aY1YpSDs9Ly9Jb1YEdi9CAngKcgh1Y3R8AzEODGJ0AVtxCn8Od3wjIVFvUhczJFJWdR84XTQ7MipLb0FFMT9bAiEEbFklOyNzAGUlFGJ-Xwg1WhVaJX9yfABhJgB1fnNOdwsoVywuZXwXd1RwYGkCKGALeF0gKiNrF2BCAhF9FVkGHHgKLTUiJ0F3VQN1f3FbYAsJHXFoIyFWJkIDYmkDKnEceHtmaHIrRiIKbicpWQwtTW8KcX9zDxV3VXJ1fgIcIFAtUDcFIyFANEIDYmkDKnQceHtmaHIsSj0TbjYtUx8qS28KcX9zDxV3VXJ1fgIIKko-ZyU7IzpKIEIDYmkDKnEceHtmaHIvST4IRjEiUw5gC3gdcBtwaxcRQgNiLkUPIlw-ZyU7IzpKIDhHMSBFDmALeB1wG3BrFxFCA2ItXAwqSyNMKzcfOUA7AFkkaQJZYAoLCGZoA2sXYAFUNShvCCpXPkosNh86XCICFGJ-FVgECW8PB3wvLVUqFwxhfABbY1AtS35qZidMJloBdjxCAngJbFssKX1_EnxVAWJ7Bl9yDXMNcWx5eR10BkM7cQJNN0k4UX5rcXYQZ1QXIzhJByAEbw8Bf3J8TD8GVjVpAllgCgsdcWg2fAgwUgVjLwUPdlp7WXQ7JXkQa1YDNHxWXXNbfAl3OCYsE3dVA3V-c053Cz5ZJH9yfABhJhRifhVZdxx4e2Zocj1RKwtUdX4CTnZ4bwpxbmV8F3dQdXYjUxs9SncJZTY1JxhrUAFmfQJadQlsWyIzfXwSZV4BaHUWGy1adwllOScnGGJBUiRxA1N1D3MMcXwzJ0hvVxczKEQCeB8rWjNncGhGJhMMdi9cGHgfP1EtZ3F-FWJWAWF-A00hWjxKfmpufhVjXgVnewlbdgF-Cnpodn4XZ0FGIDtDVmNSPUx-fDo-SScUQSRxAE0kQyMFcmpwfhR0CFImPg1bawl7D3FqcnkTZlAFaXkCXXwOch4wLX1rYGRCc2NpCV5gfH8dAR9ldmd0E0I_cQFNLk4jXH58IypRIVoAdilTGyZKdwhlKS9zF3QERSlxQAQ2TWxbJy40cxU936Ed3KpqHQ==\\u0026at=CjEELl0hLycRTD8XQzU_QwIqV_9hpCNYfyxv\\u0026dat=debug_beforefesend\"],\"conversion_tracks\":[\"https://sugar.zhihu.com/ad-track/zplus_log?isy=4\\u0026zk=\\u0026currency=0\\u0026ar=0.008242875337600708\\u0026tev=0.732421875\\u0026ui=182.35.111.115\\u0026cv=\\u0026dts=1786864190\\u0026ri=f11ce525-27e2-4a63-9f5c-0298ea542c20\\u0026exp=zplus-search-0\\u0026cl=610100\\u0026pt=0\\u0026cla=3\\u0026octr=0.008242875337600708\\u0026mix=__MIX__INFO__\\u0026zri=588fb33259c1234f47beb434e65a778d\\u0026swi=nil\\u0026cc=370900\\u0026ed=CjNQdw9zbXl7FHQEQTlxFhkgTitKJzl9aEQxE1gmJUQSLF13HiEqfX8SfFUBYnsGX3INcw1xbHl5HXQXQzl-DVtjSiMFJTt5fhI2VgZ9eQdddRR-AHE-bXYca1IcM39UWSFff1l0a3AqAzsEDGFqUQJ4Cn0AdW5ydgMxF0Ntfh1aY1YpSDs9Ly9Jb1YEdi9CAngKcgh1Y3R8AzEODGJ0AVtxCn8Od3wjIVFvUhczJFJWdR84XTQ7MipLb0FFMT9bAiEEbFklOyNzAGUlFGJ-Xwg1WhVaJX9yfABhJgB1fnNOdwsoVywuZXwXd1RwYGkCKGALeF0gKiNrF2BCAhF9FVkGHHgKLTUiJ0F3VQN1f3FbYAsJHXFoIyFWJkIDYmkDKnEceHtmaHIrRiIKbicpWQwtTW8KcX9zDxV3VXJ1fgIcIFAtUDcFIyFANEIDYmkDKnQceHtmaHIsSj0TbjYtUx8qS28KcX9zDxV3VXJ1fgIIKko-ZyU7IzpKIEIDYmkDKnEceHtmaHIvST4IRjEiUw5gC3gdcBtwaxcRQgNiLkUPIlw-ZyU7IzpKIDhHMSBFDmALeB1wG3BrFxFCA2ItXAwqSyNMKzcfOUA7AFkkaQJZYAoLCGZoA2sXYAFUNShvCCpXPkosNh86XCICFGJ-FVgECW8PB3wvLVUqFwxhfABbY1AtS35qZidMJloBdjxCAngJbFssKX1_EnxVAWJ7Bl9yDXMNcWx5eR10BkM7cQJNN0k4UX5rcXYQZ1QXIzhJByAEbw8Bf3J8TD8GVjVpAllgCgsdcWg2fAgwUgVjLwUPdlp7WXQ7JXkQa1YDNHxWXXNbfAl3OCYsE3dVA3V-c053Cz5ZJH9yfABhJhRifhVZdxx4e2Zocj1RKwtUdX4CTnZ4bwpxbmV8F3dQdXYjUxs9SncJZTY1JxhrUAFmfQJadQlsWyIzfXwSZV4BaHUWGy1adwllOScnGGJBUiRxA1N1D3MMcXwzJ0hvVxczKEQCeB8rWjNncGhGJhMMdi9cGHgfP1EtZ3F-FWJWAWF-A00hWjxKfmpufhVjXgVnewlbdgF-Cnpodn4XZ0FGIDtDVmNSPUx-fDo-SScUQSRxAE0kQyMFcmpwfhR0CFImPg1bawl7D3FqcnkTZlAFaXkCXXwOch4wLX1rYGRCc2NpCV5gfH8dAR9ldmd0E0I_cQFNLk4jXH58IypRIVoAdilTGyZKdwhlKS9zF3QERSlxQAQ2TWxbJy40cxU936Ed3KpqHQ==\\u0026at=CjEEKVctLCU8VjsIX1u2KBLeP1SB\"],\"close_tracks\":[\"https://sugar.zhihu.com/ad-track/zplus_log?isy=4\\u0026zk=\\u0026currency=0\\u0026ar=0.008242875337600708\\u0026tev=0.732421875\\u0026ui=182.35.111.115\\u0026cv=\\u0026dts=1786864190\\u0026ri=f11ce525-27e2-4a63-9f5c-0298ea542c20\\u0026exp=zplus-search-0\\u0026cl=610100\\u0026pt=0\\u0026cla=3\\u0026octr=0.008242875337600708\\u0026mix=__MIX__INFO__\\u0026zri=588fb33259c1234f47beb434e65a778d\\u0026swi=nil\\u0026cc=370900\\u0026ed=CjNQdw9zbXl7FHQEQTlxFhkgTitKJzl9aEQxE1gmJUQSLF13HiEqfX8SfFUBYnsGX3INcw1xbHl5HXQXQzl-DVtjSiMFJTt5fhI2VgZ9eQdddRR-AHE-bXYca1IcM39UWSFff1l0a3AqAzsEDGFqUQJ4Cn0AdW5ydgMxF0Ntfh1aY1YpSDs9Ly9Jb1YEdi9CAngKcgh1Y3R8AzEODGJ0AVtxCn8Od3wjIVFvUhczJFJWdR84XTQ7MipLb0FFMT9bAiEEbFklOyNzAGUlFGJ-Xwg1WhVaJX9yfABhJgB1fnNOdwsoVywuZXwXd1RwYGkCKGALeF0gKiNrF2BCAhF9FVkGHHgKLTUiJ0F3VQN1f3FbYAsJHXFoIyFWJkIDYmkDKnEceHtmaHIrRiIKbicpWQwtTW8KcX9zDxV3VXJ1fgIcIFAtUDcFIyFANEIDYmkDKnQceHtmaHIsSj0TbjYtUx8qS28KcX9zDxV3VXJ1fgIIKko-ZyU7IzpKIEIDYmkDKnEceHtmaHIvST4IRjEiUw5gC3gdcBtwaxcRQgNiLkUPIlw-ZyU7IzpKIDhHMSBFDmALeB1wG3BrFxFCA2ItXAwqSyNMKzcfOUA7AFkkaQJZYAoLCGZoA2sXYAFUNShvCCpXPkosNh86XCICFGJ-FVgECW8PB3wvLVUqFwxhfABbY1AtS35qZidMJloBdjxCAngJbFssKX1_EnxVAWJ7Bl9yDXMNcWx5eR10BkM7cQJNN0k4UX5rcXYQZ1QXIzhJByAEbw8Bf3J8TD8GVjVpAllgCgsdcWg2fAgwUgVjLwUPdlp7WXQ7JXkQa1YDNHxWXXNbfAl3OCYsE3dVA3V-c053Cz5ZJH9yfABhJhRifhVZdxx4e2Zocj1RKwtUdX4CTnZ4bwpxbmV8F3dQdXYjUxs9SncJZTY1JxhrUAFmfQJadQlsWyIzfXwSZV4BaHUWGy1adwllOScnGGJBUiRxA1N1D3MMcXwzJ0hvVxczKEQCeB8rWjNncGhGJhMMdi9cGHgfP1EtZ3F-FWJWAWF-A00hWjxKfmpufhVjXgVnewlbdgF-Cnpodn4XZ0FGIDtDVmNSPUx-fDo-SScUQSRxAE0kQyMFcmpwfhR0CFImPg1bawl7D3FqcnkTZlAFaXkCXXwOch4wLX1rYGRCc2NpCV5gfH8dAR9ldmd0E0I_cQFNLk4jXH58IypRIVoAdilTGyZKdwhlKS9zF3QERSlxQAQ2TWxbJy40cxU936Ed3KpqHQ==\\u0026at=CjEEKVQsKSUfy894zJfb6A==\"],\"video_tracks\":[\"https://sugar.zhihu.com/ad-track/zplus_log?isy=4\\u0026zk=\\u0026currency=0\\u0026ar=0.008242875337600708\\u0026tev=0.732421875\\u0026ui=182.35.111.115\\u0026cv=\\u0026dts=1786864190\\u0026ri=f11ce525-27e2-4a63-9f5c-0298ea542c20\\u0026exp=zplus-search-0\\u0026cl=610100\\u0026pt=0\\u0026cla=3\\u0026octr=0.008242875337600708\\u0026mix=__MIX__INFO__\\u0026zri=588fb33259c1234f47beb434e65a778d\\u0026swi=nil\\u0026cc=370900\\u0026ed=CjNQdw9zbXl7FHQEQTlxFhkgTitKJzl9aEQxE1gmJUQSLF13HiEqfX8SfFUBYnsGX3INcw1xbHl5HXQXQzl-DVtjSiMFJTt5fhI2VgZ9eQdddRR-AHE-bXYca1IcM39UWSFff1l0a3AqAzsEDGFqUQJ4Cn0AdW5ydgMxF0Ntfh1aY1YpSDs9Ly9Jb1YEdi9CAngKcgh1Y3R8AzEODGJ0AVtxCn8Od3wjIVFvUhczJFJWdR84XTQ7MipLb0FFMT9bAiEEbFklOyNzAGUlFGJ-Xwg1WhVaJX9yfABhJgB1fnNOdwsoVywuZXwXd1RwYGkCKGALeF0gKiNrF2BCAhF9FVkGHHgKLTUiJ0F3VQN1f3FbYAsJHXFoIyFWJkIDYmkDKnEceHtmaHIrRiIKbicpWQwtTW8KcX9zDxV3VXJ1fgIcIFAtUDcFIyFANEIDYmkDKnQceHtmaHIsSj0TbjYtUx8qS28KcX9zDxV3VXJ1fgIIKko-ZyU7IzpKIEIDYmkDKnEceHtmaHIvST4IRjEiUw5gC3gdcBtwaxcRQgNiLkUPIlw-ZyU7IzpKIDhHMSBFDmALeB1wG3BrFxFCA2ItXAwqSyNMKzcfOUA7AFkkaQJZYAoLCGZoA2sXYAFUNShvCCpXPkosNh86XCICFGJ-FVgECW8PB3wvLVUqFwxhfABbY1AtS35qZidMJloBdjxCAngJbFssKX1_EnxVAWJ7Bl9yDXMNcWx5eR10BkM7cQJNN0k4UX5rcXYQZ1QXIzhJByAEbw8Bf3J8TD8GVjVpAllgCgsdcWg2fAgwUgVjLwUPdlp7WXQ7JXkQa1YDNHxWXXNbfAl3OCYsE3dVA3V-c053Cz5ZJH9yfABhJhRifhVZdxx4e2Zocj1RKwtUdX4CTnZ4bwpxbmV8F3dQdXYjUxs9SncJZTY1JxhrUAFmfQJadQlsWyIzfXwSZV4BaHUWGy1adwllOScnGGJBUiRxA1N1D3MMcXwzJ0hvVxczKEQCeB8rWjNncGhGJhMMdi9cGHgfP1EtZ3F-FWJWAWF-A00hWjxKfmpufhVjXgVnewlbdgF-Cnpodn4XZ0FGIDtDVmNSPUx-fDo-SScUQSRxAE0kQyMFcmpwfhR0CFImPg1bawl7D3FqcnkTZlAFaXkCXXwOch4wLX1rYGRCc2NpCV5gfH8dAR9ldmd0E0I_cQFNLk4jXH58IypRIVoAdilTGyZKdwhlKS9zF3QERSlxQAQ2TWxbJy40cxU936Ed3KpqHQ==\\u0026at=CjEEPFEnPy8RVT4GSP2lJbJWhW_G\"],\"video_play_tracks\":null,\"debug_tracks\":[\"https://sugar.zhihu.com/ad-track/zplus_log?isy=4\\u0026zk=\\u0026currency=0\\u0026ar=0.008242875337600708\\u0026tev=0.732421875\\u0026ui=182.35.111.115\\u0026cv=\\u0026dts=1786864190\\u0026ri=f11ce525-27e2-4a63-9f5c-0298ea542c20\\u0026exp=zplus-search-0\\u0026cl=610100\\u0026pt=0\\u0026cla=3\\u0026octr=0.008242875337600708\\u0026mix=__MIX__INFO__\\u0026zri=588fb33259c1234f47beb434e65a778d\\u0026swi=nil\\u0026cc=370900\\u0026ed=CjNQdw9zbXl7FHQEQTlxFhkgTitKJzl9aEQxE1gmJUQSLF13HiEqfX8SfFUBYnsGX3INcw1xbHl5HXQXQzl-DVtjSiMFJTt5fhI2VgZ9eQdddRR-AHE-bXYca1IcM39UWSFff1l0a3AqAzsEDGFqUQJ4Cn0AdW5ydgMxF0Ntfh1aY1YpSDs9Ly9Jb1YEdi9CAngKcgh1Y3R8AzEODGJ0AVtxCn8Od3wjIVFvUhczJFJWdR84XTQ7MipLb0FFMT9bAiEEbFklOyNzAGUlFGJ-Xwg1WhVaJX9yfABhJgB1fnNOdwsoVywuZXwXd1RwYGkCKGALeF0gKiNrF2BCAhF9FVkGHHgKLTUiJ0F3VQN1f3FbYAsJHXFoIyFWJkIDYmkDKnEceHtmaHIrRiIKbicpWQwtTW8KcX9zDxV3VXJ1fgIcIFAtUDcFIyFANEIDYmkDKnQceHtmaHIsSj0TbjYtUx8qS28KcX9zDxV3VXJ1fgIIKko-ZyU7IzpKIEIDYmkDKnEceHtmaHIvST4IRjEiUw5gC3gdcBtwaxcRQgNiLkUPIlw-ZyU7IzpKIDhHMSBFDmALeB1wG3BrFxFCA2ItXAwqSyNMKzcfOUA7AFkkaQJZYAoLCGZoA2sXYAFUNShvCCpXPkosNh86XCICFGJ-FVgECW8PB3wvLVUqFwxhfABbY1AtS35qZidMJloBdjxCAngJbFssKX1_EnxVAWJ7Bl9yDXMNcWx5eR10BkM7cQJNN0k4UX5rcXYQZ1QXIzhJByAEbw8Bf3J8TD8GVjVpAllgCgsdcWg2fAgwUgVjLwUPdlp7WXQ7JXkQa1YDNHxWXXNbfAl3OCYsE3dVA3V-c053Cz5ZJH9yfABhJhRifhVZdxx4e2Zocj1RKwtUdX4CTnZ4bwpxbmV8F3dQdXYjUxs9SncJZTY1JxhrUAFmfQJadQlsWyIzfXwSZV4BaHUWGy1adwllOScnGGJBUiRxA1N1D3MMcXwzJ0hvVxczKEQCeB8rWjNncGhGJhMMdi9cGHgfP1EtZ3F-FWJWAWF-A00hWjxKfmpufhVjXgVnewlbdgF-Cnpodn4XZ0FGIDtDVmNSPUx-fDo-SScUQSRxAE0kQyMFcmpwfhR0CFImPg1bawl7D3FqcnkTZlAFaXkCXXwOch4wLX1rYGRCc2NpCV5gfH8dAR9ldmd0E0I_cQFNLk4jXH58IypRIVoAdilTGyZKdwhlKS9zF3QERSlxQAQ2TWxbJy40cxU936Ed3KpqHQ==\\u0026at=CjEELl0hLycRTD8XQzU_QwIqV_9hpCNYfyxv\"],\"view_as_click_tm\":5}",
+        "settings": {
+          "table_of_contents": {
+            "enabled": false
+          }
+        },
+        "attached_info_bytes": "ANONYMIZED",
+        "article_type": "normal",
+        "biz_encoded_params": "ctid%3Dct%3A3806942%26sw%3D%E6%B3%95%E5%BE%8B",
+        "native": 0
+      },
+      "hit_labels": null,
+      "index": 4
+    }
+  ],
+  "hit_labels": null,
+  "related_search_result": [],
+  "search_action_info": {
+    "attached_info_bytes": "ANONYMIZED",
+    "lc_idx": 20,
+    "search_hash_id": "588fb33259c1234f47beb434e65a778d",
+    "isfeed": false
+  },
+  "is_brand_word": false,
+  "pendant": null,
+  "sensitive_level": -1,
+  "warning": "",
+  "filter_items": null,
+  "ab_params": "d_new_search_h2=1;dm_preset_opt=1;dm_ai_zhiplus=0;bt_member_verify=1;dm_hotvideo=0;dm_fine_rel=2;sb_novel_member=1;dm_ai_search_safe=1;dm_l3_multi3=0;sb_sku_ui=1;sb_xg_search=1;dm_AI_hot_recall=0;dm_correct=1;dm_ai_corner=0;dm_v_member_zag=2;dm_ai_search_kl=1;sb_ecpmctcvr=1;sb_slot_domain=2;bt_holdback_2025=0;dm_DupFilter=1;dm_question_limit=2;dm_realtime=0;sb_caowei_4in10=1;sb_sku_time=1;sb_newreb=1;dm_content_quota=3;dm_rescore_v=2;dm_pre_docs=2;dm_ai_medical=1;se_koc_list_box=1;sb_vip_tag=1;sb_domain_2025=0;dm_l2_ab=1;dm_integrate=0;sb_vip_xunzhi=1;dm_kocrecommend=0;sb_sku_rel=1;dm_search_pregen=1;sb_new_guess=1;sb_story_ca=0;sb_zhiedu=1;dm_pin_card=0;dm_test=1;sb_slot_time=2;dm_pu_user_card=1;dm_center_feature=1;sb_cardfilter=1;sb_zhiad=1;dm_evaluate=0;dm_preset_migrate=2;sb_eduzhi=1;sb_storytag=1;dm_mark=0;dm_query_rewrite=0;dm_ai_card_cache=0;adflow=0;d_sr_hold_2026=0;dm_ai_rerank=0;dm_l2_snp=0;dm_ai_class=0;dm_ai_prompt=0;dm_llm_query=0;dm_ai_hot_more=0;sb_sku_kzh=1;bt_vertical_mem=1;dm_pu_sug=0;dm_hot_pin=0",
+  "item_in_view": [
+    {
+      "type": "user_survey",
+      "index": 5,
+      "token": "f789e8e4867b476c8406c1420e4e05f4"
+    },
+    {
+      "type": "ask_question",
+      "index": 9
+    }
+  ],
+  "domain_info": {
+    "first_category": "法律"
+  },
+  "is_koc_words": false,
+  "strategy_res_list": [
+    "dm_ai_class_10"
+  ]
+}

--- a/app/src/androidTest/assets/search-badge-people.json
+++ b/app/src/androidTest/assets/search-badge-people.json
@@ -1,0 +1,124 @@
+{
+  "paging": {
+    "is_end": false,
+    "next": "https://api.zhihu.com/search_v3?advert_count=0&correction=1&gk_version=gz-gaokao&include=data%5B%2A%5D.highlight%2Cobject%2Ctype&limit=20&offset=20&q=%E7%9F%A5%E4%B9%8E&search_hash_id=783ec8ea00f3133dc2344a5d33a9c40b&search_source=Normal&show_all_topics=0&t=people&vertical_info=0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0"
+  },
+  "data": [
+    {
+      "type": "search_result",
+      "highlight": {
+        "description": "",
+        "title": "<em>匿名</em>机构甲"
+      },
+      "object": {
+        "id": "anon-people-001",
+        "url_token": "anon-people-001",
+        "honor_label": "",
+        "type": "people",
+        "url": "https://www.zhihu.com/people/anon-people-001",
+        "name": "<em>匿名</em>机构甲",
+        "user_type": "organization",
+        "headline": "匿名机构简介",
+        "gender": -1,
+        "avatar_url": "https://pic.example/anon-people-001.png",
+        "badge": [
+          {
+            "type": "identity",
+            "description": "已认证账号",
+            "topics": []
+          },
+          {
+            "type": "identity",
+            "description": "已认证的机构",
+            "topics": []
+          }
+        ],
+        "badge_v2": {
+          "title": "已认证机构号",
+          "merged_badges": [
+            {
+              "type": "identity",
+              "detail_type": "identity_org",
+              "title": "认证",
+              "description": "已认证机构号",
+              "url": "https://www.zhihu.com/term/institution-settle",
+              "sources": [],
+              "icon": "",
+              "night_icon": ""
+            }
+          ],
+          "detail_badges": [
+            {
+              "type": "identity",
+              "detail_type": "identity_org",
+              "title": "已认证机构号",
+              "description": "已认证机构号",
+              "url": "https://www.zhihu.com/term/institution-settle",
+              "sources": [],
+              "icon": "https://picx.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c",
+              "night_icon": "https://picx.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c"
+            }
+          ],
+          "icon": "https://pic1.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c",
+          "night_icon": "https://picx.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c"
+        },
+        "old_badges": [
+          {
+            "type": "identity",
+            "description": "已认证机构号"
+          }
+        ],
+        "badge_v2_string": "{\"title\":\"已认证机构号\",\"merged_badges\":[{\"type\":\"identity\",\"detail_type\":\"identity_org\",\"title\":\"认证\",\"description\":\"已认证机构号\",\"url\":\"https://www.zhihu.com/term/institution-settle\",\"sources\":[],\"icon\":\"\",\"night_icon\":\"\",\"badge_status\":\"passed\"}],\"detail_badges\":[{\"type\":\"identity\",\"detail_type\":\"identity_org\",\"title\":\"已认证机构号\",\"description\":\"已认证机构号\",\"url\":\"https://www.zhihu.com/term/institution-settle\",\"sources\":[],\"icon\":\"https://picx.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c\",\"night_icon\":\"https://picx.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c\",\"badge_status\":\"passed\"}],\"icon\":\"https://pic1.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c\",\"night_icon\":\"https://picx.zhimg.com/v2-2ddc5cc683982648f6f123616fb4ec09_l.png?source=32738c0c\"}",
+        "is_following": false,
+        "is_followed": false,
+        "is_self": false,
+        "follower_count": 197287,
+        "voteup_count": 45669,
+        "answer_count": 3,
+        "articles_count": 7,
+        "creation_count": 341,
+        "last_creation_time": 1737620532,
+        "vip_info": {
+          "is_vip": false,
+          "vip_icon": {
+            "url": "",
+            "night_mode_url": ""
+          }
+        },
+        "attached_info_bytes": "ANONYMIZED"
+      },
+      "hit_labels": null,
+      "index": 13,
+      "id": 10000001
+    }
+  ],
+  "hit_labels": null,
+  "related_search_result": [],
+  "search_action_info": {
+    "attached_info_bytes": "ANONYMIZED",
+    "lc_idx": 20,
+    "search_hash_id": "anon-search-people",
+    "isfeed": false
+  },
+  "is_brand_word": false,
+  "pendant": null,
+  "sensitive_level": -1,
+  "warning": "",
+  "filter_items": null,
+  "ab_params": "sb_sku_ui=1;dm_hotvideo=0;d_new_search_h2=1;se_koc_list_box=1;dm_preset_opt=1;dm_ai_prompt=0;dm_rescore_v=2;sb_novel_member=1;sb_sku_time=1;dm_ai_class=0;dm_correct=1;dm_AI_hot_recall=0;dm_mark=0;dm_content_quota=3;sb_vip_tag=1;sb_caowei_4in10=1;dm_ai_search_kl=1;sb_slot_time=2;dm_DupFilter=1;dm_ai_corner=0;dm_pre_docs=2;sb_slot_domain=2;sb_zhiad=1;sb_storytag=1;sb_sku_rel=1;sb_vip_xunzhi=1;dm_ai_zhiplus=0;dm_kocrecommend=0;sb_story_ca=0;dm_question_limit=2;dm_center_feature=1;dm_pu_user_card=1;dm_ai_search_safe=1;dm_evaluate=0;bt_holdback_2025=0;dm_l2_snp=0;dm_pin_card=0;sb_domain_2025=0;bt_member_verify=1;dm_l3_multi3=0;dm_search_pregen=1;dm_ai_card_cache=0;dm_test=1;sb_zhiedu=1;dm_integrate=0;bt_vertical_mem=1;d_sr_hold_2026=0;dm_v_member_zag=2;adflow=0;sb_xg_search=1;dm_pu_sug=0;dm_ai_medical=1;dm_realtime=0;dm_ai_rerank=0;sb_ecpmctcvr=1;sb_newreb=1;dm_preset_migrate=2;dm_query_rewrite=0;sb_eduzhi=1;dm_fine_rel=2;dm_l2_ab=1;sb_sku_kzh=1;sb_cardfilter=1;dm_llm_query=0;dm_ai_hot_more=0;dm_hot_pin=0;sb_new_guess=1",
+  "item_in_view": [
+    {
+      "type": "user_survey",
+      "index": 5,
+      "token": "f789e8e4867b476c8406c1420e4e05f4"
+    },
+    {
+      "type": "ask_question",
+      "index": 9
+    }
+  ],
+  "domain_info": {
+    "first_category": ""
+  },
+  "is_koc_words": false
+}

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/SearchScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/SearchScreenInstrumentedTest.kt
@@ -25,13 +25,16 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.github.zly2006.zhihu.navigation.Account
 import com.github.zly2006.zhihu.navigation.Search
 import com.github.zly2006.zhihu.test.InstrumentedTestEnvironment
@@ -203,6 +206,32 @@ class SearchScreenInstrumentedTest {
     }
 
     @Test
+    fun peopleAndGeneralResultsRenderReturnedAuthorBadges() {
+        ZhihuMockApi.mockJsonPrefix(
+            method = HttpMethod.Get,
+            urlPrefix = "https://www.zhihu.com/api/v4/search_v3",
+            body = readTestAsset("search-badge-general.json"),
+        )
+        composeRule.setScreenContent { SearchScreen(search = Search(query = "徽章")) }
+
+        composeRule.onNodeWithTag("search_people_result_anon-general-people-001").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("刑法等 2 个话题下的优秀答主").assertIsDisplayed()
+        composeRule.onNodeWithTag("search_general_results").performScrollToIndex(2)
+        composeRule
+            .onNodeWithTag("search_general_content_article:2070450975589110182")
+            .assertIsDisplayed()
+
+        ZhihuMockApi.mockJsonPrefix(
+            method = HttpMethod.Get,
+            urlPrefix = "https://www.zhihu.com/api/v4/search_v3",
+            body = readTestAsset("search-badge-people.json"),
+        )
+        composeRule.onNodeWithTag("search_tab_People").performClick()
+
+        composeRule.onNodeWithContentDescription("已认证机构号").assertIsDisplayed()
+    }
+
+    @Test
     fun searchHistoryRendersRecordsSearchesAndSupportsMenuActions() {
         // This disables hot-search so the history surface can be tested without network requests.
         // Expected behavior:
@@ -336,4 +365,12 @@ class SearchScreenInstrumentedTest {
         )
         assertEquals(0, recordingNavigator.backCount)
     }
+
+    private fun readTestAsset(fileName: String): String =
+        InstrumentationRegistry
+            .getInstrumentation()
+            .context.assets
+            .open(fileName)
+            .bufferedReader()
+            .use { it.readText() }
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/SearchScreen.kt
@@ -83,7 +83,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
+import com.github.zly2006.zhihu.data.DataHolder
 import com.github.zly2006.zhihu.data.ZhihuJson
+import com.github.zly2006.zhihu.data.officialBadge
 import com.github.zly2006.zhihu.navigation.Account
 import com.github.zly2006.zhihu.navigation.LocalNavigator
 import com.github.zly2006.zhihu.navigation.Person
@@ -94,6 +96,7 @@ import com.github.zly2006.zhihu.platform.UserMessageDuration
 import com.github.zly2006.zhihu.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.platform.rememberUserMessageSink
 import com.github.zly2006.zhihu.reading.RegisterReadingQueueSource
+import com.github.zly2006.zhihu.ui.components.AuthorBadge
 import com.github.zly2006.zhihu.ui.components.DraggableRefreshButton
 import com.github.zly2006.zhihu.ui.components.FeedAuthorBlockConfirmDialog
 import com.github.zly2006.zhihu.ui.components.FeedAuthorBlockRequest
@@ -662,46 +665,11 @@ fun SearchScreen(
                             is SearchEntity.Person -> {
                                 val person = result.person
                                 val plainName = person.name.replace("<em>", "").replace("</em>", "")
-                                Row(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .clickable {
-                                            navigator.onNavigate(
-                                                Person(person.id, person.urlToken.orEmpty(), plainName),
-                                            )
-                                        }.padding(horizontal = 16.dp, vertical = 12.dp)
-                                        .testTag("search_people_result_${person.id}"),
-                                    verticalAlignment = Alignment.CenterVertically,
-                                ) {
-                                    AsyncImage(
-                                        model = person.avatarUrl,
-                                        contentDescription = "${plainName}的头像",
-                                        modifier = Modifier.size(48.dp).clip(CircleShape),
-                                    )
-                                    Column(Modifier.weight(1f).padding(start = 12.dp)) {
-                                        Text(
-                                            text = parseEmphasizedHtmlTextWithTheme(person.name),
-                                            style = MaterialTheme.typography.titleMedium,
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis,
-                                        )
-                                        person.headline.takeIf(String::isNotEmpty)?.let {
-                                            Text(
-                                                text = it,
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                maxLines = 2,
-                                                overflow = TextOverflow.Ellipsis,
-                                            )
-                                        }
-                                        Text(
-                                            text = "${person.followerCount} 粉丝 · ${person.answerCount} 回答",
-                                            style = MaterialTheme.typography.bodySmall,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        )
-                                    }
+                                PersonSearchResultRow(person) {
+                                    navigator.onNavigate(Person(person.id, person.urlToken.orEmpty(), plainName))
                                 }
                             }
+                            is SearchEntity.Content -> Unit
                         }
                     }
                     item {
@@ -721,8 +689,9 @@ fun SearchScreen(
             } else {
                 FeedPullToRefresh(viewModel, paginationEnvironment) {
                     PaginatedList(
-                        items = viewModel.displayItems,
+                        items = viewModel.entities,
                         onLoadMore = { viewModel.loadMore(paginationEnvironment) },
+                        modifier = Modifier.testTag("search_general_results"),
                         topContent = {
                             item {
                                 if (isMemberSearch) {
@@ -739,26 +708,45 @@ fun SearchScreen(
                             }
                         },
                         footer = ProgressIndicatorFooter,
-                    ) { item ->
-                        FeedCard(
-                            item = item,
-                            readingQueueSourceId = readingQueueSourceId,
-                            menuItems = { dismissMenu ->
-                                DropdownMenuItem(
-                                    text = { Text("屏蔽用户") },
-                                    onClick = {
-                                        dismissMenu()
-                                        viewModel.handleBlockUser(paginationEnvironment, userMessages, item) { authorInfo ->
-                                            feedAuthorBlockRequest = FeedAuthorBlockRequest(
-                                                FeedAuthorBlockType.CONTENT_AUTHOR,
-                                                authorInfo.first,
-                                                authorInfo.second,
-                                            )
-                                        }
-                                    },
+                        key = SearchEntity::id,
+                    ) { result ->
+                        when (result) {
+                            is SearchEntity.Content -> FeedCard(
+                                item = result.item,
+                                modifier = Modifier.testTag("search_general_content_${result.id}"),
+                                readingQueueSourceId = readingQueueSourceId,
+                                menuItems = { dismissMenu ->
+                                    DropdownMenuItem(
+                                        text = { Text("屏蔽用户") },
+                                        onClick = {
+                                            dismissMenu()
+                                            viewModel.handleBlockUser(
+                                                paginationEnvironment,
+                                                userMessages,
+                                                result.item,
+                                            ) { authorInfo ->
+                                                feedAuthorBlockRequest = FeedAuthorBlockRequest(
+                                                    FeedAuthorBlockType.CONTENT_AUTHOR,
+                                                    authorInfo.first,
+                                                    authorInfo.second,
+                                                )
+                                            }
+                                        },
+                                    )
+                                },
+                            )
+                            is SearchEntity.Person -> PersonSearchResultRow(result.person) {
+                                val person = result.person
+                                navigator.onNavigate(
+                                    Person(
+                                        person.id,
+                                        person.urlToken.orEmpty(),
+                                        person.name.replace("<em>", "").replace("</em>", ""),
+                                    ),
                                 )
-                            },
-                        )
+                            }
+                            is SearchEntity.Topic -> Unit
+                        }
                     }
 
                     val showRefreshFab = remember { settings.getBoolean("showRefreshFab", true) }
@@ -789,6 +777,58 @@ fun SearchScreen(
             feedAuthorBlockRequest = null
         },
     )
+}
+
+@Composable
+private fun PersonSearchResultRow(
+    person: DataHolder.People,
+    onClick: () -> Unit,
+) {
+    val plainName = person.name.replace("<em>", "").replace("</em>", "")
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .testTag("search_people_result_${person.id}"),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AsyncImage(
+            model = person.avatarUrl,
+            contentDescription = "${plainName}的头像",
+            modifier = Modifier.size(48.dp).clip(CircleShape),
+        )
+        Column(Modifier.weight(1f).padding(start = 12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = parseEmphasizedHtmlTextWithTheme(person.name),
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                val badge = person.badgeV2.officialBadge()
+                if (badge?.isUsefulInList == true) {
+                    Spacer(Modifier.width(4.dp))
+                    AuthorBadge(badge, compact = true)
+                }
+            }
+            person.headline.takeIf(String::isNotEmpty)?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Text(
+                text = "${person.followerCount} 粉丝 · ${person.answerCount} 回答",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/SearchViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/SearchViewModel.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.setValue
 import com.github.zly2006.zhihu.data.CommonFeed
 import com.github.zly2006.zhihu.data.DataHolder
 import com.github.zly2006.zhihu.data.Feed
+import com.github.zly2006.zhihu.data.FeedDisplayItem
 import com.github.zly2006.zhihu.data.ZhihuJson
 import com.github.zly2006.zhihu.data.target
 import com.github.zly2006.zhihu.util.raiseForStatus
@@ -44,6 +45,7 @@ open class SearchViewModel(
     private val restrictedMemberHashId: String = "",
 ) : BaseFeedViewModel() {
     val entities = mutableStateListOf<SearchEntity>()
+    private var pendingGeneralEntities = emptyList<PendingGeneralEntity>()
     val changingTopicIds = mutableStateListOf<String>()
     var filters by mutableStateOf(SearchFilters())
         private set
@@ -114,17 +116,44 @@ open class SearchViewModel(
     ): List<Feed> {
         val existingIds = entities.mapTo(mutableSetOf(), SearchEntity::id)
         var decodedTopicCount = 0
-        val feeds = rawData.mapNotNull { element ->
+        val indexedEntries = rawData.withIndex().sortedBy { (responseOrder, element) ->
+            (element as? JsonObject)
+                ?.get("index")
+                ?.jsonPrimitive
+                ?.content
+                ?.toIntOrNull() ?: responseOrder
+        }
+        if (searchTab == SearchTab.General) {
+            pendingGeneralEntities = indexedEntries.mapNotNull { (_, element) ->
+                val entry = element as? JsonObject ?: return@mapNotNull null
+                if (entry["type"]?.jsonPrimitive?.content != "search_result") return@mapNotNull null
+                val content = entry["object"] as? JsonObject ?: return@mapNotNull null
+                try {
+                    if (content["type"]?.jsonPrimitive?.content == "people") {
+                        PendingGeneralEntity.Person(ZhihuJson.decodeJson<DataHolder.People>(content))
+                    } else {
+                        PendingGeneralEntity.Content(
+                            CommonFeed(
+                                id = content["id"]?.jsonPrimitive?.content ?: return@mapNotNull null,
+                                verb = "SEARCH_RESULT",
+                                target = ZhihuJson.decodeJson<Feed.Target>(content),
+                            ),
+                        )
+                    }
+                } catch (e: Exception) {
+                    environment.logDecodeFailure("SearchViewModel", element, e)
+                    null
+                }
+            }
+            return pendingGeneralEntities.mapNotNull { (it as? PendingGeneralEntity.Content)?.feed }
+        }
+        val feeds = indexedEntries.mapNotNull { (_, element) ->
             val entry = element as? JsonObject ?: return@mapNotNull null
             if (entry["type"]?.jsonPrimitive?.content != "search_result") return@mapNotNull null
             val content = entry["object"] as? JsonObject ?: return@mapNotNull null
             try {
                 when (searchTab) {
-                    SearchTab.General -> CommonFeed(
-                        id = entry["id"]?.jsonPrimitive?.content ?: return@mapNotNull null,
-                        verb = "SEARCH_RESULT",
-                        target = ZhihuJson.decodeJson<Feed.Target>(content),
-                    )
+                    SearchTab.General -> error("General 搜索已在保序分支解码")
                     SearchTab.People -> {
                         val person = ZhihuJson.decodeJson<DataHolder.People>(content)
                         if (existingIds.add(person.id)) entities += SearchEntity.Person(person)
@@ -175,7 +204,31 @@ open class SearchViewModel(
             data.filterNot { it.target?.author?.id in blockedUserIds },
             rawData,
         )
+        if (searchTab != SearchTab.General) return
+        if (isPullToRefresh) entities.clear()
+        val loadedContent = latestLoadedDisplayItems.value.associateBy(FeedDisplayItem::stableKey)
+        val existingIds = entities.mapTo(mutableSetOf(), SearchEntity::id)
+        pendingGeneralEntities.forEach { pending ->
+            val entity = when (pending) {
+                is PendingGeneralEntity.Person -> SearchEntity.Person(pending.person)
+                is PendingGeneralEntity.Content -> createDisplayItem(environment, pending.feed)
+                    .stableKey
+                    .let(loadedContent::get)
+                    ?.let { SearchEntity.Content(it) }
+            }
+            if (entity != null && existingIds.add(entity.id)) entities += entity
+        }
     }
+}
+
+private sealed interface PendingGeneralEntity {
+    data class Person(
+        val person: DataHolder.People,
+    ) : PendingGeneralEntity
+
+    data class Content(
+        val feed: Feed,
+    ) : PendingGeneralEntity
 }
 
 sealed interface SearchEntity {
@@ -185,6 +238,12 @@ sealed interface SearchEntity {
         val person: DataHolder.People,
     ) : SearchEntity {
         override val id = person.id
+    }
+
+    data class Content(
+        val item: FeedDisplayItem,
+    ) : SearchEntity {
+        override val id = item.stableKey
     }
 
     data class Topic(


### PR DESCRIPTION
## 改动说明

- 用户搜索结果复用现有 `badge_v2 -> officialBadge() -> AuthorBadge` 语义，在用户名同行展示接口实际返回的徽章。
- 全站搜索保留内容卡与 `object.type=people` 用户条目的两种独立契约，并按服务端 `index` 混排；用户条目复用与“用户”页相同的强类型人物结果行。
- 修正全站普通内容结果取标识的位置：真实 `search_v3` 普通结果顶层没有 `id`，使用 `object.id`，避免内容卡被整体丢弃。
- 不处理无 `badge_v2` 的 KOC 卡，不添加详情兜底或逐项二次请求。

## 真实接口证据

| 来源 | 样本 | 无 include | 当前 include | 候选 include | 生产解码 |
|---|---:|---|---|---|---|
| People（“知乎”“法律”） | 每组 20 条，多组请求；另有 60 distinct 私有语料 | `object.badge_v2` 存在 | `data[*].highlight,object,type` 下存在 | 显式 `object.badge_v2` 下存在 | `ZhihuJson -> DataHolder.People.badgeV2` 保留 |
| General（“法律”“科技”） | 每组 20 条，多组请求；另有至少 60 distinct 私有语料 | 内容作者徽章与 `object.type=people.badge_v2` 可返回 | 当前 include 下可返回 | 显式作者/人物 badge 候选下可返回 | `ZhihuJson -> Feed.Target` / `DataHolder.People` 保留 |

原始响应和生产解码同时核对。回归夹具从真实响应截取最小代表项，保持原 HTML/字段结构，只对用户身份及关联嵌套字符串做一致脱敏；提交中不含 Cookie、token 或账号文件。

## 数据流与请求预算

`search_v3` 单页响应 → `ZhihuJson` 解码 → 内容卡经过现有过滤/展示模型，人物卡保留强类型 `DataHolder.People` → 按 `index` 合并 → Compose 列表。

- 首屏请求：维持现有 1 次 `search_v3`
- 分页请求：维持现有每页 1 次 `search_v3`
- 新增详情请求：0
- N+1 / fallback：0

## 验证

- `GRADLE_USER_HOME=/tmp/search-badge-gradle-home ./gradlew :app:assembleLiteDebug :app:assembleLiteDebugAndroidTest ktlintCheck --no-daemon -Dkotlin.compiler.execution.strategy=in-process`：通过
- `adb shell am instrument -w -r -e class com.github.zly2006.zhihu.SearchScreenInstrumentedTest#peopleAndGeneralResultsRenderReturnedAuthorBadges com.github.zly2006.zhplus.lite.test/com.github.zly2006.zhihu.ZhihuInstrumentedTestRunner`：通过，`OK (1 test)`
- 删除测试内无效截图 I/O 后，`ktlintCheck` 与 `git diff --check`：通过

定向用例覆盖真实脱敏 General 响应中的人物徽章、`index=3` 人物在 `index=4` 内容之前的顺序，以及 People 响应中的机构徽章。

## 截图

已在 API 31 隔离 AVD 上安装 Lite APK，并使用真实线上搜索响应验证：

| 全站结果作者徽章 | 用户结果徽章 |
|---|---|
| ![全站结果作者徽章](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-673/search-general-author-badges.png) | ![用户结果徽章](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-673/search-people-badges.png) |

截图已持久化在 `zly2006/agent-image` 的 `zhihu-plus-plus/pr-673/` 目录；资产提交为 `99ed059`。
