### PR TITLE
fix: 修复分式渲染

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -191,7 +191,7 @@ dependencies {
 
     implementation(project(":markdown-parser"))
     implementation(project(":markdown-renderer"))
-    implementation("io.github.zly2006:latex-renderer-android:0.0.1-alpha5")
+    implementation("io.github.zly2006:latex-renderer-android:0.0.1-alpha6")
 
     implementation("io.coil-kt.coil3:coil-compose:$coil")
     implementation("io.coil-kt.coil3:coil-network-ktor3-android:$coil")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -119,7 +119,7 @@ kotlin {
             implementation("io.ktor:ktor-serialization-kotlinx-json:3.5.0")
             implementation("com.materialkolor:material-kolor:4.1.1")
             implementation("com.fleeksoft.ksoup:ksoup:0.2.6")
-            implementation("io.github.zly2006:latex-renderer:0.0.1-alpha5")
+            implementation("io.github.zly2006:latex-renderer:0.0.1-alpha6")
             implementation(project(":markdown-parser"))
             implementation(project(":markdown-renderer"))
             implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0")

--- a/third_party/markdown/markdown-renderer/build.gradle.kts
+++ b/third_party/markdown/markdown-renderer/build.gradle.kts
@@ -49,9 +49,9 @@ kotlin {
             implementation("org.jetbrains.compose.ui:ui:1.11.1")
             implementation("org.jetbrains.compose.components:components-resources:1.11.1")
 
-            implementation("io.github.zly2006:latex-base:0.0.1-alpha5")
-            implementation("io.github.zly2006:latex-parser:0.0.1-alpha5")
-            implementation("io.github.zly2006:latex-renderer:0.0.1-alpha5")
+            implementation("io.github.zly2006:latex-base:0.0.1-alpha6")
+            implementation("io.github.zly2006:latex-parser:0.0.1-alpha6")
+            implementation("io.github.zly2006:latex-renderer:0.0.1-alpha6")
             implementation("io.github.huarangmeng:codehighlight-parser:1.1.1")
             implementation("io.github.huarangmeng:codehighlight-render:1.1.1")
 


### PR DESCRIPTION
## 改动

- 将 LaTeX fork 从 `0.0.1-alpha5` 升级到 `0.0.1-alpha6`，同步更新 app、shared 与内置 Markdown renderer 的全部消费点。
- `alpha6` 基于上游 `1.5.3` 重建；无花括号命令参数现在只消费一个 TeX 原子，因此 `\frac12` 会解析为分子 `1`、分母 `2`，不会再把后续内容吞入分式。

## 原因

旧 parser 会把连续普通文本合并成一个 token，解析无花括号参数时又一次消费整个 token。于是 `2\pi \cdot \frac12 =` 被错误解析为分子 `12`、分母 `=`。上游 `1.5.3` 已修正通用参数边界并补充覆盖分式、二项式、根式、控制序列和 Unicode 的回归测试，本 PR 通过项目 fork 发布链引入该正式修复，不在 Zhihu++ 内增加重复 workaround。

Fixes #669

## 验证

- LaTeX fork `:latex-parser:jvmTest --tests '*ArgumentAtomTest*'`：6 个用例通过。
- LaTeX fork `:latex-renderer:jvmTest`：通过。
- Maven Central：`latex-base`、`latex-parser`、`latex-renderer`、`latex-renderer-android` 的 `0.0.1-alpha6` POM 均返回 HTTP 200。
- `GRADLE_USER_HOME=/tmp/zhihu-issue-669-gradle-home ./gradlew --no-daemon assembleLiteDebug`：通过。
- `GRADLE_USER_HOME=/tmp/zhihu-issue-669-gradle-home ./gradlew --no-daemon --no-configuration-cache ktlintFormat`：通过。
