### PR TITLE
feat: 接入可选的提椠 Markdown 正文渲染

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -138,8 +138,8 @@ kotlin {
         androidMain {
             kotlin.srcDir("src/tiqianMarkdownMain/kotlin")
             dependencies {
-                implementation("org.tiqian:markdown-compose:0.1.0-alpha03")
-                implementation("org.tiqian:math-font-stix:0.1.0-alpha03")
+                implementation("org.tiqian:markdown-compose:0.1.0-alpha04")
+                implementation("org.tiqian:math-font-stix:0.1.0-alpha04")
                 implementation("androidx.activity:activity-compose:1.13.0")
                 implementation("androidx.browser:browser:1.10.0")
                 implementation("androidx.core:core-ktx:1.19.0")
@@ -159,8 +159,8 @@ kotlin {
             kotlin.srcDir("src/tiqianMarkdownMain/kotlin")
         }
         jvmMain.dependencies {
-            implementation("org.tiqian:markdown-compose:0.1.0-alpha03")
-            implementation("org.tiqian:math-font-stix:0.1.0-alpha03")
+            implementation("org.tiqian:markdown-compose:0.1.0-alpha04")
+            implementation("org.tiqian:math-font-stix:0.1.0-alpha04")
             implementation("io.coil-kt.coil3:coil-network-ktor3:3.5.0")
             implementation("androidx.sqlite:sqlite-bundled:2.6.2")
             implementation(compose.desktop.currentOs)

--- a/shared/src/tiqianMarkdownMain/kotlin/com/github/zly2006/zhihu/markdown/TiqianMarkdownRenderer.kt
+++ b/shared/src/tiqianMarkdownMain/kotlin/com/github/zly2006/zhihu/markdown/TiqianMarkdownRenderer.kt
@@ -19,7 +19,6 @@ import androidx.compose.material.icons.outlined.FileDownload
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -46,9 +45,8 @@ import com.hrm.markdown.parser.ast.NativeBlock
 import com.hrm.markdown.parser.ast.SegmentHighlight
 import com.hrm.markdown.renderer.LocalOnSegmentHighlightClick
 import com.hrm.markdown.renderer.MarkdownImageData
-import org.tiqian.compose.CjkText
+import org.tiqian.compose.material3.CjkText
 import org.tiqian.compose.ruby
-import org.tiqian.compose.toCjkTextStyle
 import org.tiqian.markdown.MarkdownCustomBlock
 import org.tiqian.markdown.MarkdownImageBlock
 import org.tiqian.markdown.MarkdownNodeKey
@@ -335,6 +333,5 @@ internal actual fun TiqianBrandTitle(prefix: String, suffix: String) {
             ruby("椠", "qiàn")
             append(suffix)
         },
-        textStyle = LocalTextStyle.current.toCjkTextStyle(),
     )
 }


### PR DESCRIPTION
## 必填：AI 使用与验证材料

- [ ] 未使用 AI 编写、改写或批量生成代码
- [x] 使用了 AI 编写、改写或批量生成代码
- [ ] 已上传测试截图
- [ ] 已上传测试录屏

## 变更说明

- 将 Android 与桌面端的提椠 Markdown、STIX 数学字体依赖升级到 Maven Central 上的 `0.1.0-alpha04`。
- 设置页的提椠标题直接使用官方 Material 3 `CjkText` adapter，继承 `LocalTextStyle`、`LocalContentColor` 和 Material 链接样式，不再由知乎++手工转换样式。

## 测试与验证

- `./gradlew :app:assembleLiteDebug --no-daemon`
- `./gradlew ktlintCheck --no-daemon`
- Gradle 依赖报告确认 Android classpath 上的 `markdown-compose`、`tiqian-compose-material3`、提椠核心模块与 `math-font-stix` 均解析为 `0.1.0-alpha04`。
