### PR TITLE
fix: 修复跨段划线片段的展示与评论交互

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.click
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithText
@@ -903,6 +904,9 @@ class ArticleScreenInstrumentedTest {
         composeRule.onNodeWithContentDescription("复制内容").assertIsDisplayed()
 
         scrollToBoundary(text, end = true)
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onNodeWithTag("segment_action_sheet_top_divider").isDisplayed()
+        }
 
         composeRule.onNodeWithTag("segment_action_sheet_top_divider").assertIsDisplayed()
         composeRule.onNodeWithTag("segment_action_sheet_bottom_divider").assertDoesNotExist()

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
@@ -59,7 +59,6 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -853,8 +852,8 @@ class ArticleScreenInstrumentedTest {
             .performTouchInput { click() }
         composeRule.onNodeWithText("划线片段").assertIsDisplayed()
         composeRule.onNodeWithText("“$HIGHLIGHTED_PARAGRAPH”").assertIsDisplayed()
-        composeRule.onNodeWithTag("segment_action_sheet_top_divider").assertIsNotDisplayed()
-        composeRule.onNodeWithTag("segment_action_sheet_bottom_divider").assertIsNotDisplayed()
+        composeRule.onNodeWithTag("segment_action_sheet_top_divider").assertDoesNotExist()
+        composeRule.onNodeWithTag("segment_action_sheet_bottom_divider").assertDoesNotExist()
     }
 
     @Test
@@ -898,18 +897,15 @@ class ArticleScreenInstrumentedTest {
 
         val text = composeRule.onNodeWithText("“$longDisplayText”")
         text.fetchSemanticsNode()
-        composeRule.onNodeWithTag("segment_action_sheet_top_divider").assertIsNotDisplayed()
+        composeRule.onNodeWithTag("segment_action_sheet_top_divider").assertDoesNotExist()
         composeRule.onNodeWithTag("segment_action_sheet_bottom_divider").assertIsDisplayed()
         composeRule.onNodeWithText("15").assertIsDisplayed()
         composeRule.onNodeWithContentDescription("复制内容").assertIsDisplayed()
 
-        text.performSemanticsAction(SemanticsActions.ScrollBy) { scrollBy ->
-            scrollBy(0f, Float.MAX_VALUE)
-        }
-        composeRule.waitForIdle()
+        scrollToBoundary(text, end = true)
 
         composeRule.onNodeWithTag("segment_action_sheet_top_divider").assertIsDisplayed()
-        composeRule.onNodeWithTag("segment_action_sheet_bottom_divider").assertIsNotDisplayed()
+        composeRule.onNodeWithTag("segment_action_sheet_bottom_divider").assertDoesNotExist()
         composeRule.onNodeWithText("15").assertIsDisplayed()
         composeRule.onNodeWithContentDescription("复制内容").assertIsDisplayed()
     }

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -852,6 +853,65 @@ class ArticleScreenInstrumentedTest {
             .performTouchInput { click() }
         composeRule.onNodeWithText("划线片段").assertIsDisplayed()
         composeRule.onNodeWithText("“$HIGHLIGHTED_PARAGRAPH”").assertIsDisplayed()
+        composeRule.onNodeWithTag("segment_action_sheet_top_divider").assertIsNotDisplayed()
+        composeRule.onNodeWithTag("segment_action_sheet_bottom_divider").assertIsNotDisplayed()
+    }
+
+    @Test
+    fun spanningHighlightTapShowsTheCompleteSelection() {
+        composeRule.setScreenContent {
+            RenderMarkdown(
+                html = SPANNING_HIGHLIGHT_HTML,
+                enableScroll = false,
+            )
+        }
+
+        composeRule
+            .onNodeWithText(SPANNING_HIGHLIGHT_SECOND)
+            .performTouchInput { click() }
+
+        composeRule.onNodeWithText("划线片段").assertIsDisplayed()
+        composeRule
+            .onNodeWithText("“$SPANNING_HIGHLIGHT_FIRST\n\n$SPANNING_HIGHLIGHT_SECOND”")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun longSpanningHighlightShowsDirectionalDividersAndKeepsActionsVisible() {
+        val repeatedParagraphs = List(12) { SPANNING_HIGHLIGHT_FIRST }
+        val longDisplayText = repeatedParagraphs.joinToString("\n\n")
+        val longDisplayTextAttribute = repeatedParagraphs.joinToString("&#10;&#10;")
+        val html = SPANNING_HIGHLIGHT_HTML.replace(
+            "$SPANNING_HIGHLIGHT_FIRST&#10;&#10;$SPANNING_HIGHLIGHT_SECOND",
+            longDisplayTextAttribute,
+        )
+        composeRule.setScreenContent {
+            RenderMarkdown(
+                html = html,
+                enableScroll = false,
+            )
+        }
+
+        composeRule
+            .onNodeWithText(SPANNING_HIGHLIGHT_SECOND)
+            .performTouchInput { click() }
+
+        val text = composeRule.onNodeWithText("“$longDisplayText”")
+        text.fetchSemanticsNode()
+        composeRule.onNodeWithTag("segment_action_sheet_top_divider").assertIsNotDisplayed()
+        composeRule.onNodeWithTag("segment_action_sheet_bottom_divider").assertIsDisplayed()
+        composeRule.onNodeWithText("15").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("复制内容").assertIsDisplayed()
+
+        text.performSemanticsAction(SemanticsActions.ScrollBy) { scrollBy ->
+            scrollBy(0f, Float.MAX_VALUE)
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag("segment_action_sheet_top_divider").assertIsDisplayed()
+        composeRule.onNodeWithTag("segment_action_sheet_bottom_divider").assertIsNotDisplayed()
+        composeRule.onNodeWithText("15").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("复制内容").assertIsDisplayed()
     }
 
     @Test
@@ -1774,6 +1834,8 @@ class ArticleScreenInstrumentedTest {
         const val HIGHLIGHTED_PARAGRAPH =
             "目前灰度机制是在OpenCode上，被选中的账号调用deepseek-v4-pro或deepseek-v4-flash有机会拿到GA版。"
         const val HIGHLIGHT_SELECTION_TARGET = "后续普通段落用于验证拖动手柄跨越文字块。"
+        const val SPANNING_HIGHLIGHT_FIRST = "吃柠檬，怎么吃？谁吃的？"
+        const val SPANNING_HIGHLIGHT_SECOND = "柠檬，是怎样的檬？这个檬是否从事正当行业？"
         const val FORMATTED_HIGHLIGHT_PREFIX = "WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW"
         const val FORMATTED_HIGHLIGHT = "划线命中"
         const val FORMATTED_HIGHLIGHT_PARAGRAPH = "$FORMATTED_HIGHLIGHT_PREFIX$FORMATTED_HIGHLIGHT 后缀"
@@ -1797,6 +1859,30 @@ class ArticleScreenInstrumentedTest {
                 data-highlight-pid="WGd4cbq-"
                 data-highlight-start-offset="0"
                 data-highlight-end-offset="68">$HIGHLIGHTED_PARAGRAPH</span></p>
+            """.trimIndent()
+        val SPANNING_HIGHLIGHT_HTML =
+            """
+            <p data-pid="first"><span class="highlight-wrap other has-comments"
+                data-highlight-id="shared-segment"
+                data-highlight-like-count="806"
+                data-highlight-comment-count="15"
+                data-highlight-is-span="true"
+                data-highlight-display-text="$SPANNING_HIGHLIGHT_FIRST&#10;&#10;$SPANNING_HIGHLIGHT_SECOND"
+                data-highlight-content-id="1907864533831225689"
+                data-highlight-content-type="answer"
+                data-highlight-pid="first"
+                data-highlight-start-offset="0"
+                data-highlight-end-offset="${SPANNING_HIGHLIGHT_FIRST.length}">$SPANNING_HIGHLIGHT_FIRST</span></p>
+            <p data-pid="second"><span class="highlight-wrap other has-comments"
+                data-highlight-id="shared-segment"
+                data-highlight-like-count="806"
+                data-highlight-comment-count="15"
+                data-highlight-is-span="true"
+                data-highlight-content-id="1907864533831225689"
+                data-highlight-content-type="answer"
+                data-highlight-pid="second"
+                data-highlight-start-offset="0"
+                data-highlight-end-offset="${SPANNING_HIGHLIGHT_SECOND.length}">$SPANNING_HIGHLIGHT_SECOND</span></p>
             """.trimIndent()
         val FORMATTED_HIGHLIGHT_PARAGRAPH_HTML =
             """

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
@@ -61,7 +61,6 @@ import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.click
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithText
@@ -878,7 +877,7 @@ class ArticleScreenInstrumentedTest {
 
     @Test
     fun longSpanningHighlightShowsDirectionalDividersAndKeepsActionsVisible() {
-        val repeatedParagraphs = List(12) { SPANNING_HIGHLIGHT_FIRST }
+        val repeatedParagraphs = List(24) { SPANNING_HIGHLIGHT_FIRST }
         val longDisplayText = repeatedParagraphs.joinToString("\n\n")
         val longDisplayTextAttribute = repeatedParagraphs.joinToString("&#10;&#10;")
         val html = SPANNING_HIGHLIGHT_HTML.replace(
@@ -904,9 +903,10 @@ class ArticleScreenInstrumentedTest {
         composeRule.onNodeWithContentDescription("复制内容").assertIsDisplayed()
 
         scrollToBoundary(text, end = true)
-        composeRule.waitUntil(timeoutMillis = 5_000) {
-            composeRule.onNodeWithTag("segment_action_sheet_top_divider").isDisplayed()
-        }
+        val finalScrollRange = text
+            .fetchSemanticsNode()
+            .config[SemanticsProperties.VerticalScrollAxisRange]
+        assertTrue("The expanded sheet must still have overflowing text", finalScrollRange.maxValue() > 0f)
 
         composeRule.onNodeWithTag("segment_action_sheet_top_divider").assertIsDisplayed()
         composeRule.onNodeWithTag("segment_action_sheet_bottom_divider").assertDoesNotExist()
@@ -1834,8 +1834,8 @@ class ArticleScreenInstrumentedTest {
         const val HIGHLIGHTED_PARAGRAPH =
             "目前灰度机制是在OpenCode上，被选中的账号调用deepseek-v4-pro或deepseek-v4-flash有机会拿到GA版。"
         const val HIGHLIGHT_SELECTION_TARGET = "后续普通段落用于验证拖动手柄跨越文字块。"
-        const val SPANNING_HIGHLIGHT_FIRST = "吃柠檬，怎么吃？谁吃的？"
-        const val SPANNING_HIGHLIGHT_SECOND = "柠檬，是怎样的檬？这个檬是否从事正当行业？"
+        const val SPANNING_HIGHLIGHT_FIRST = "第一段跨段划线内容。"
+        const val SPANNING_HIGHLIGHT_SECOND = "第二段跨段划线内容。"
         const val FORMATTED_HIGHLIGHT_PREFIX = "WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW"
         const val FORMATTED_HIGHLIGHT = "划线命中"
         const val FORMATTED_HIGHLIGHT_PARAGRAPH = "$FORMATTED_HIGHLIGHT_PREFIX$FORMATTED_HIGHLIGHT 后缀"

--- a/app/src/androidTest/java/com/github/zly2006/zhihu/CommentScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/CommentScreenInstrumentedTest.kt
@@ -55,6 +55,7 @@ import com.github.zly2006.zhihu.navigation.LocalNavigator
 import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.navigation.Navigator
 import com.github.zly2006.zhihu.navigation.Person
+import com.github.zly2006.zhihu.navigation.SegmentCommentHolder
 import com.github.zly2006.zhihu.test.InstrumentedTestEnvironment
 import com.github.zly2006.zhihu.test.MainActivityComposeRule
 import com.github.zly2006.zhihu.test.RecordingNavigator
@@ -272,6 +273,44 @@ class CommentScreenInstrumentedTest {
         composeRule.onNodeWithTag(COMMENT_INPUT_TAG).assertTextEquals("[惊喜]已有草稿")
         composeRule.onNodeWithTag(COMMENT_EMOJI_BUTTON_TAG).performClick()
         composeRule.onNodeWithContentDescription("选择表情").assertIsDisplayed()
+    }
+
+    @Test
+    fun spanFragmentsWithTheSameSegmentIdsReuseTheCommentThread() {
+        val firstFragment = SegmentCommentHolder(
+            contentId = "1907864533831225689",
+            contentType = "answer",
+            segmentId = "1993195116945487118,1978217501180568395",
+            segmentContent = "吃柠檬，怎么吃？谁吃的？吃的哪儿？什么时候吃的？吃的心情怎么样？",
+            paragraphId = "nX5RAoeG",
+            startOffset = 0,
+            endOffset = 32,
+        )
+        val secondFragment = firstFragment.copy(
+            segmentContent = "柠檬，是怎样的檬？这个檬是否从事正当行业？这个檬是活着还是死的？",
+            paragraphId = "CANw6uZN",
+        )
+        val currentFragment = mutableStateOf<NavDestination>(firstFragment)
+        val viewModel = SeededRootCommentViewModel(
+            article = firstFragment,
+            seededComments = seedRootComments(count = 1),
+        )
+
+        composeRule.setScreenContent {
+            val commentInput = remember { mutableStateOf("") }
+            CommentScreen(
+                content = { currentFragment.value },
+                onChildCommentClick = {},
+                commentInput = commentInput.value,
+                onCommentInputChange = { commentInput.value = it },
+                testOverrides = CommentScreenTestOverrides(viewModel = viewModel),
+            )
+        }
+        composeRule.onNodeWithTag("comment_row_root-1").assertIsDisplayed()
+
+        composeRule.runOnIdle { currentFragment.value = secondFragment }
+
+        composeRule.onNodeWithTag("comment_row_root-1").assertIsDisplayed()
     }
 
     @Test

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
@@ -702,6 +702,7 @@ private val SEGMENT_HIGHLIGHT_ATTRIBUTES = listOf(
     "data-highlight-my-comment-count",
     "data-highlight-is-like",
     "data-highlight-is-span",
+    "data-highlight-display-text",
     "data-highlight-source-url",
     "data-highlight-content-id",
     "data-highlight-content-type",

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/RenderMarkdown.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/RenderMarkdown.kt
@@ -330,7 +330,7 @@ private fun RenderMarkdownDocument(
         },
         LocalSegmentActionSheetHost provides { state -> segmentActionSheetState = state },
     ) {
-        SegmentHighlightInteractionHost {
+        SegmentHighlightInteractionHost(document) {
             Box(modifier = modifier) {
                 NoDoubleClickSelectionScope {
                     val onLinkClick: (String) -> Unit = { url ->

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CommentScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CommentScreen.kt
@@ -464,7 +464,7 @@ fun CommentScreen(
     var isDeletingComment by remember { mutableStateOf(false) }
     var deleteCommentError by remember { mutableStateOf<String?>(null) }
     val initialTargetId = initialCommentId ?: initialComment?.id
-    val viewModelKey = commentViewModelKey(resolvedContent) + initialTargetId?.let { ":initial:$it" }.orEmpty()
+    val viewModelKey = resolvedContent.commentThreadKey() + initialTargetId?.let { ":initial:$it" }.orEmpty()
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
     val commentInputFocusRequester = remember { FocusRequester() }
@@ -633,7 +633,7 @@ fun CommentScreen(
 
     // 初始加载评论
     LaunchedEffect(resolvedContent) {
-        if (viewModel.article != resolvedContent) {
+        if (viewModel.article.commentThreadKey() != resolvedContent.commentThreadKey()) {
             error("Internal Error: Detected content mismatch")
         }
         if (viewModel.errorMessage == null) {
@@ -1221,13 +1221,13 @@ fun CommentScreen(
     }
 }
 
-private fun commentViewModelKey(content: NavDestination): String = when (content) {
-    is Article -> "article:${content.type}:${content.id}"
-    is Pin -> "pin:${content.id}"
-    is Question -> "question:${content.questionId}"
-    is SegmentCommentHolder -> "segment:${content.contentType}:${content.contentId}:${content.segmentId}"
-    is CommentHolder -> "comment:${content.commentId}:${commentViewModelKey(content.article)}"
-    else -> "comment:${content::class.qualifiedName}:${content.hashCode()}"
+internal fun NavDestination.commentThreadKey(): String = when (this) {
+    is Article -> "article:$type:$id"
+    is Pin -> "pin:$id"
+    is Question -> "question:$questionId"
+    is SegmentCommentHolder -> "segment:$contentType:$contentId:$segmentId"
+    is CommentHolder -> "comment:$commentId:${article.commentThreadKey()}"
+    else -> "comment:${this::class.qualifiedName}:${hashCode()}"
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CommentScreenComponent.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/CommentScreenComponent.kt
@@ -48,12 +48,10 @@ import com.github.zly2006.zhihu.data.ZhihuJson
 import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.CommentHolder
 import com.github.zly2006.zhihu.navigation.NavDestination
-import com.github.zly2006.zhihu.navigation.Pin
-import com.github.zly2006.zhihu.navigation.Question
-import com.github.zly2006.zhihu.navigation.SegmentCommentHolder
 import com.github.zly2006.zhihu.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.theme.Typography
 import com.github.zly2006.zhihu.ui.CommentScreen
+import com.github.zly2006.zhihu.ui.commentThreadKey
 import com.github.zly2006.zhihu.ui.rememberArticleHost
 import com.github.zly2006.zhihu.viewmodel.CommentItem
 import kotlinx.serialization.decodeFromString
@@ -79,7 +77,7 @@ fun CommentScreenComponent(
     var authorCommentPolicyAcknowledged by remember {
         mutableStateOf(settings.getBoolean(ZH_PLUS_AUTHOR_COMMENT_POLICY_ACKNOWLEDGED_KEY, false))
     }
-    val contentStateKey = commentContentStateKey(content)
+    val contentStateKey = content.commentThreadKey()
     var activeChildComment by rememberSaveable(contentStateKey, saver = activeChildCommentSaver) {
         mutableStateOf<CommentItem?>(null)
     }
@@ -100,7 +98,7 @@ fun CommentScreenComponent(
     val rootSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val childSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val childTarget = activeChildComment?.clickTarget
-    val childDraftKey = childTarget?.let(::commentContentStateKey)
+    val childDraftKey = childTarget?.commentThreadKey()
     var childListResetToken by rememberSaveable(contentStateKey) { mutableIntStateOf(0) }
     val childListState = rememberSaveable(
         contentStateKey,
@@ -271,12 +269,3 @@ private val activeChildCommentSaver = Saver<MutableState<CommentItem?>, List<Str
         )
     },
 )
-
-private fun commentContentStateKey(content: NavDestination): String = when (content) {
-    is Article -> "article:${content.type}:${content.id}"
-    is Question -> "question:${content.questionId}"
-    is Pin -> "pin:${content.id}"
-    is CommentHolder -> "comment:${commentContentStateKey(content.article)}:${content.commentId}"
-    is SegmentCommentHolder -> "segment:${content.contentType}:${content.contentId}:${content.segmentId}"
-    else -> content.toString()
-}

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/SegmentHighlight.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/SegmentHighlight.kt
@@ -18,10 +18,11 @@
 package com.github.zly2006.zhihu.ui.components
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Comment
 import androidx.compose.material.icons.filled.ThumbUp
@@ -29,11 +30,13 @@ import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.ThumbUp
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -46,6 +49,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.zly2006.zhihu.data.SegmentInfoMeta
@@ -56,6 +63,9 @@ import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.deleteSigned
 import com.github.zly2006.zhihu.viewmodel.postSigned
 import com.github.zly2006.zhihu.viewmodel.rememberPaginationEnvironment
+import com.hrm.markdown.parser.ast.ContainerNode
+import com.hrm.markdown.parser.ast.Document
+import com.hrm.markdown.parser.ast.Node
 import com.hrm.markdown.parser.ast.SegmentHighlight
 import com.hrm.markdown.renderer.LocalOnSegmentHighlightClick
 import io.ktor.client.call.body
@@ -70,6 +80,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import kotlin.math.roundToInt
 
 /**
  * 在可选中的 Markdown 子树外承载划线交互弹窗。
@@ -151,6 +162,7 @@ fun updateSegmentMetaAfterLike(
 
 @Composable
 internal fun SegmentHighlightInteractionHost(
+    document: Document,
     content: @Composable () -> Unit,
 ) {
     val environment = rememberPaginationEnvironment(allowGuestAccess = false)
@@ -160,8 +172,13 @@ internal fun SegmentHighlightInteractionHost(
     var selectedHighlight by remember { mutableStateOf<Pair<String, SegmentHighlightSpan>?>(null) }
     val openSegmentComments = LocalSegmentCommentHost.current
     val showSegmentActionSheet = LocalSegmentActionSheetHost.current
-    val onSegmentHighlightClick: (SegmentHighlight) -> Unit = remember {
-        { node -> selectedHighlight = node.interactionKey to node.toSegmentHighlightSpan() }
+    val displayTexts = remember(document) { document.segmentDisplayTexts() }
+    val onSegmentHighlightClick: (SegmentHighlight) -> Unit = remember(displayTexts) {
+        { node ->
+            selectedHighlight = node.interactionKey to node.toSegmentHighlightSpan(
+                displayText = displayTexts[node.segmentThreadKey()] ?: node.text,
+            )
+        }
     }
 
     CompositionLocalProvider(
@@ -200,7 +217,7 @@ internal fun SegmentHighlightInteractionHost(
                     }
                 },
                 onCopyClick = {
-                    copyPlainText("segment_text", selected.text)
+                    copyPlainText("segment_text", selected.displayText)
                     selectedHighlight = null
                     showSegmentActionSheet(null)
                 },
@@ -261,65 +278,140 @@ private fun SegmentActionSheet(
     onCommentClick: () -> Unit,
     onCopyClick: () -> Unit,
 ) {
-    ModalBottomSheet(onDismissRequest = onDismiss) {
-        Column(
+    val sheetState = rememberModalBottomSheetState()
+    val textScrollState = rememberScrollState()
+    val overflowTolerance = with(LocalDensity.current) { 1.dp.roundToPx() }
+    val hasMeasuredOverflow = textScrollState.viewportSize > 0 &&
+        textScrollState.maxValue > overflowTolerance
+    val showTopDivider = hasMeasuredOverflow && textScrollState.value > overflowTolerance
+    val showBottomDivider = hasMeasuredOverflow &&
+        textScrollState.value < textScrollState.maxValue - overflowTolerance
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Layout(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp, vertical = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = "划线片段",
-                style = MaterialTheme.typography.titleMedium,
-            )
-            Text(
-                text = "“${highlight.text}”",
-                style = MaterialTheme.typography.bodyLarge,
-                lineHeight = 24.sp,
-            )
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                FilledTonalButton(
-                    onClick = onLikeClick,
-                    modifier = Modifier.weight(1f),
+            content = {
+                Text(
+                    text = "划线片段",
+                    modifier = Modifier.layoutId("title"),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                if (showTopDivider) {
+                    HorizontalDivider(
+                        modifier = Modifier
+                            .layoutId("topDivider")
+                            .testTag("segment_action_sheet_top_divider"),
+                    )
+                }
+                Text(
+                    text = "“${highlight.displayText}”",
+                    modifier = Modifier
+                        .layoutId("text")
+                        .verticalScroll(textScrollState),
+                    style = MaterialTheme.typography.bodyLarge,
+                    lineHeight = 24.sp,
+                )
+                if (showBottomDivider) {
+                    HorizontalDivider(
+                        modifier = Modifier
+                            .layoutId("bottomDivider")
+                            .testTag("segment_action_sheet_bottom_divider"),
+                    )
+                }
+                Row(
+                    modifier = Modifier
+                        .layoutId("actions")
+                        .fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
-                    Icon(
-                        imageVector = if (highlight.meta.isLike) Icons.Filled.ThumbUp else Icons.Outlined.ThumbUp,
-                        contentDescription = null,
-                    )
-                    Text(
-                        text = highlight.meta.likeCount.toString(),
-                        modifier = Modifier.padding(start = 8.dp),
-                    )
+                    FilledTonalButton(
+                        onClick = onLikeClick,
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Icon(
+                            imageVector = if (highlight.meta.isLike) Icons.Filled.ThumbUp else Icons.Outlined.ThumbUp,
+                            contentDescription = null,
+                        )
+                        Text(
+                            text = highlight.meta.likeCount.toString(),
+                            modifier = Modifier.padding(start = 8.dp),
+                        )
+                    }
+                    FilledTonalButton(
+                        onClick = onCommentClick,
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Outlined.Comment,
+                            contentDescription = null,
+                        )
+                        Text(
+                            text = highlight.meta.commentCount.toString(),
+                            modifier = Modifier.padding(start = 8.dp),
+                        )
+                    }
+                    IconButton(onClick = onCopyClick) {
+                        Icon(
+                            imageVector = Icons.Outlined.ContentCopy,
+                            contentDescription = "复制内容",
+                        )
+                    }
                 }
-                FilledTonalButton(
-                    onClick = onCommentClick,
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Outlined.Comment,
-                        contentDescription = null,
-                    )
-                    Text(
-                        text = highlight.meta.commentCount.toString(),
-                        modifier = Modifier.padding(start = 8.dp),
-                    )
-                }
-                IconButton(onClick = onCopyClick) {
-                    Icon(
-                        imageVector = Icons.Outlined.ContentCopy,
-                        contentDescription = "复制内容",
-                    )
-                }
+            },
+        ) { measurables, constraints ->
+            val spacing = 12.dp.roundToPx()
+            val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+            val title = measurables.first { it.layoutId == "title" }.measure(looseConstraints)
+            val textMeasurable = measurables.first { it.layoutId == "text" }
+            val topDivider = measurables
+                .firstOrNull { it.layoutId == "topDivider" }
+                ?.measure(looseConstraints)
+            val bottomDivider = measurables
+                .firstOrNull { it.layoutId == "bottomDivider" }
+                ?.measure(looseConstraints)
+            val actions = measurables.first { it.layoutId == "actions" }.measure(looseConstraints)
+            val naturalTextHeight = textMeasurable
+                .maxIntrinsicHeight(constraints.maxWidth)
+                .coerceAtMost(constraints.maxHeight)
+            val naturalHeight = title.height + naturalTextHeight + actions.height + spacing * 2
+            val needsPartialExpansion = naturalHeight > constraints.maxHeight / 2
+            val layoutHeight = if (needsPartialExpansion) constraints.maxHeight else naturalHeight
+            val visibleHeight = if (needsPartialExpansion) {
+                val sheetOffset = runCatching { sheetState.requireOffset() }
+                    .getOrDefault(constraints.maxHeight.toFloat())
+                (constraints.maxHeight - sheetOffset.roundToInt()).coerceIn(
+                    minimumValue = title.height + actions.height + spacing * 2,
+                    maximumValue = constraints.maxHeight,
+                )
+            } else {
+                layoutHeight
+            }
+            val textTop = title.height + spacing
+            val actionsTop = visibleHeight - actions.height
+            val textBottom = actionsTop - spacing
+            val textHeight = (textBottom - textTop).coerceAtLeast(0)
+            val text = textMeasurable.measure(
+                looseConstraints.copy(maxHeight = textHeight),
+            )
+
+            layout(constraints.maxWidth, layoutHeight) {
+                title.placeRelative(0, 0)
+                text.placeRelative(0, textTop)
+                topDivider?.placeRelative(0, textTop - topDivider.height)
+                bottomDivider?.placeRelative(0, textBottom - bottomDivider.height)
+                actions.placeRelative(0, actionsTop)
             }
         }
     }
 }
 
-private fun SegmentHighlight.toSegmentHighlightSpan(): SegmentHighlightSpan = SegmentHighlightSpan(
+private fun SegmentHighlight.toSegmentHighlightSpan(displayText: String): SegmentHighlightSpan = SegmentHighlightSpan(
     text = text,
+    displayText = displayText,
     meta = SegmentInfoMeta(
         segIds = attributes["data-highlight-id"]
             .orEmpty()
@@ -339,6 +431,27 @@ private fun SegmentHighlight.toSegmentHighlightSpan(): SegmentHighlightSpan = Se
     startOffset = attributes["data-highlight-start-offset"]?.toIntOrNull(),
     endOffset = attributes["data-highlight-end-offset"]?.toIntOrNull(),
 )
+
+private fun SegmentHighlight.segmentThreadKey(): String = listOf(
+    attributes["data-highlight-content-type"],
+    attributes["data-highlight-content-id"],
+    attributes["data-highlight-id"],
+).joinToString("|") { it.orEmpty() }
+
+private fun Document.segmentDisplayTexts(): Map<String, String> {
+    val displayTexts = mutableMapOf<String, String>()
+
+    fun collect(node: Node) {
+        if (node is SegmentHighlight) {
+            node.attributes["data-highlight-display-text"]?.let {
+                displayTexts[node.segmentThreadKey()] = it
+            }
+        }
+        if (node is ContainerNode) node.children.forEach(::collect)
+    }
+    collect(this)
+    return displayTexts
+}
 
 private fun SegmentHighlightSpan.toSegmentCommentHolder(): SegmentCommentHolder? {
     val contentId = contentId ?: return null

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/util/SegmentHighlightUtils.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/util/SegmentHighlightUtils.kt
@@ -29,6 +29,7 @@ import com.github.zly2006.zhihu.data.effectiveSegInfo
 data class SegmentHighlightSpan(
     val text: String,
     val meta: SegmentInfoMeta,
+    val displayText: String = text,
     val sourceUrl: String? = null,
     val contentId: String? = null,
     val contentType: String? = null,
@@ -154,22 +155,56 @@ fun applySegmentInfosToHtml(
     if (content.isBlank() || segmentInfos.isEmpty()) return content
 
     val document = Ksoup.parseBodyFragment(content)
-    segmentInfos.forEach { paragraph ->
-        val target = document.selectFirst("""p[data-pid="${paragraph.pid}"]""") ?: return@forEach
-        if (target.text() != paragraph.text) return@forEach
-        // TODO(#418): 支持在保留内联格式的同时注入 segment_infos。
-        // https://github.com/zly2006/zhihu-plus-plus/issues/418
-        if (target.childNodes().any(Node::hasUnsupportedSegmentInfoFormat)) return@forEach
+    val segmentInfosByPid = segmentInfos.associateBy(SegmentInfoParagraph::pid)
+    val preparedParagraphs = document
+        .select("p[data-pid]")
+        .mapNotNull { target ->
+            val paragraph = segmentInfosByPid[target.attr("data-pid")] ?: return@mapNotNull null
+            if (target.text() != paragraph.text) return@mapNotNull null
+            // TODO(#418): 支持在保留内联格式的同时注入 segment_infos。
+            // https://github.com/zly2006/zhihu-plus-plus/issues/418
+            if (target.childNodes().any(Node::hasUnsupportedSegmentInfoFormat)) return@mapNotNull null
+            target to SegmentTextParagraph(
+                pid = paragraph.pid,
+                text = paragraph.text,
+                parts = buildSegmentTextParts(
+                    text = paragraph.text,
+                    marks = paragraph.marks,
+                    sourceUrl = sourceUrl,
+                    contentId = contentId,
+                    contentType = contentType,
+                    paragraphId = paragraph.pid,
+                ),
+            )
+        }
+    val spanFragments = preparedParagraphs.flatMap { (_, paragraph) ->
+        paragraph.parts.mapNotNull { part ->
+            val highlight = part.highlight?.takeIf { it.meta.isSpan } ?: return@mapNotNull null
+            val segmentId = highlight.meta.segIds
+                .joinToString(",")
+                .takeIf(String::isNotBlank)
+                ?: return@mapNotNull null
+            segmentId to (paragraph.pid to part.text)
+        }
+    }
+    val spanDisplayTexts = mutableMapOf<String, String>()
+    spanFragments
+        .groupBy({ it.first }, { it.second })
+        .forEach { (segmentId, fragments) ->
+            spanDisplayTexts[segmentId] = buildString {
+                var previousParagraphId: String? = null
+                fragments.forEach { (paragraphId, text) ->
+                    if (isNotEmpty() && paragraphId != previousParagraphId) append("\n\n")
+                    append(text)
+                    previousParagraphId = paragraphId
+                }
+            }
+        }
+    val displayTextOwners = spanDisplayTexts.keys.toMutableSet()
 
+    preparedParagraphs.forEach { (target, paragraph) ->
         target.empty()
-        buildSegmentTextParts(
-            text = paragraph.text,
-            marks = paragraph.marks,
-            sourceUrl = sourceUrl,
-            contentId = contentId,
-            contentType = contentType,
-            paragraphId = paragraph.pid,
-        ).forEach { part ->
+        paragraph.parts.forEach { part ->
             val highlight = part.highlight
             if (highlight == null) {
                 target.appendChild(TextNode(part.text))
@@ -187,6 +222,12 @@ fun applySegmentInfosToHtml(
                         attr("data-highlight-my-comment-count", highlight.meta.myCommentCount.toString())
                         attr("data-highlight-is-like", highlight.meta.isLike.toString())
                         attr("data-highlight-is-span", highlight.meta.isSpan.toString())
+                        val segmentId = highlight.meta.segIds.joinToString(",")
+                        if (highlight.meta.isSpan && displayTextOwners.remove(segmentId)) {
+                            spanDisplayTexts[segmentId]
+                                ?.takeIf { it != part.text }
+                                ?.let { attr("data-highlight-display-text", it) }
+                        }
                         attr(
                             "data-highlight-split-type",
                             when {
@@ -233,6 +274,7 @@ private fun parseSegmentNode(node: Node): SegmentTextPart? = when (node) {
             text = node.text(),
             highlight = SegmentHighlightSpan(
                 text = node.text(),
+                displayText = node.attr("data-highlight-display-text").ifBlank { node.text() },
                 meta = SegmentInfoMeta(
                     segIds = node
                         .attr("data-highlight-id")

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/util/SegmentHighlightUtilsTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/util/SegmentHighlightUtilsTest.kt
@@ -84,6 +84,42 @@ class SegmentHighlightUtilsTest {
     }
 
     @Test
+    fun spanningSegmentShouldExposeAllFragmentsAsDisplayText() {
+        val first = "吃柠檬，怎么吃？谁吃的？"
+        val second = "柠檬，是怎样的檬？这个檬是否从事正当行业？"
+        val spanMeta = SegmentInfoMeta(
+            segIds = listOf("shared-segment"),
+            likeCount = 806,
+            commentCount = 15,
+            isSpan = true,
+        )
+        val result = applySegmentInfosToHtml(
+            content = """<p data-pid="first">$first</p><p data-pid="second">$second</p>""",
+            segmentInfos = listOf(
+                SegmentInfoParagraph(
+                    pid = "first",
+                    text = first,
+                    marks = listOf(SegmentInfoMark(0, first.length, segInfo = spanMeta)),
+                ),
+                SegmentInfoParagraph(
+                    pid = "second",
+                    text = second,
+                    marks = listOf(SegmentInfoMark(0, second.length, segInfo = spanMeta)),
+                ),
+            ),
+            contentId = "1907864533831225689",
+            contentType = "answer",
+        )
+
+        val highlights = Ksoup.parseBodyFragment(result).select("span.highlight-wrap")
+        assertEquals(2, highlights.size)
+        assertEquals("$first\n\n$second", highlights[0].attr("data-highlight-display-text"))
+        assertEquals("", highlights[1].attr("data-highlight-display-text"))
+        assertEquals("first", highlights[0].attr("data-highlight-pid"))
+        assertEquals("second", highlights[1].attr("data-highlight-pid"))
+    }
+
+    @Test
     fun parseSegmentTextParagraphHtmlShouldReadInjectedHighlightSpan() {
         val element = Ksoup
             .parseBodyFragment(
@@ -95,6 +131,7 @@ class SegmentHighlightUtilsTest {
                     data-highlight-my-comment-count="0"
                     data-highlight-is-like="true"
                     data-highlight-is-span="false"
+                    data-highlight-display-text="第一句需要划线&#10;&#10;跨段续句"
                     data-highlight-content-id="42"
                     data-highlight-content-type="answer"
                     data-highlight-pid="seg-1"
@@ -114,6 +151,7 @@ class SegmentHighlightUtilsTest {
         assertEquals(true, highlight.meta.isLike)
         assertEquals(5, highlight.meta.likeCount)
         assertEquals(1, highlight.meta.commentCount)
+        assertEquals("第一句需要划线\n\n跨段续句", highlight.displayText)
         assertEquals("42", highlight.contentId)
         assertEquals("answer", highlight.contentType)
         assertEquals(0, highlight.startOffset)

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/markdown/MdAstTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/markdown/MdAstTest.kt
@@ -106,6 +106,7 @@ class MdAstTest {
                 data-highlight-my-comment-count="0"
                 data-highlight-is-like="true"
                 data-highlight-is-span="false"
+                data-highlight-display-text="第一句需要划线&#10;&#10;跨段续句"
                 data-highlight-content-id="42"
                 data-highlight-content-type="answer"
                 data-highlight-pid="seg-1"
@@ -118,6 +119,7 @@ class MdAstTest {
         val highlight = paragraph.children.first() as SegmentHighlight
         assertEquals("第一句需要划线", highlight.text)
         assertEquals("abc", highlight.attributes["data-highlight-id"])
+        assertEquals("第一句需要划线\n\n跨段续句", highlight.attributes["data-highlight-display-text"])
         assertEquals("第一句需要划线，第二句保持原样。", document.toMarkdown())
     }
 


### PR DESCRIPTION
## 改动

- 按内容类型、内容 ID 和 segment IDs 统一识别跨段划线线程，避免点击不同片段后触发 Content Mismatch。
- 保留每个片段自己的段落位置用于点赞和评论请求，同时在操作 sheet 与复制操作中展示完整跨段文本。
- 跨段文本以空行分隔；短片段保持紧凑，长片段在折叠态保留操作栏并允许正文独立滚动。
- 仅在对应方向仍有溢出内容时，于滚动区域外显示顶部或底部 divider。

## 行为边界

- 点击同一跨段划线的任一片段都会打开同一个评论线程。
- 评论请求仍使用被点击片段的 paragraph ID 与 offsets，不改变服务端定位语义。
- 复制行为改为复制完整跨段划线文本。
- 普通单段或不溢出的划线片段不显示 divider。

## 验证

- `./gradlew ktlintCheck --no-configuration-cache`
- `./gradlew :shared:jvmTest :app:compileLiteDebugKotlin :app:compileLiteDebugAndroidTestKotlin --no-configuration-cache`
- `git diff --cached --check`
- Pixel 9 Pro XL（Android 17）实际 Lite Debug APK：验证任一跨段片段可打开完整 sheet、评论线程不再 mismatch、短内容无 divider、长内容 divider 随滚动方向切换且操作栏保持可见。

未在本地执行全量 instrument test；新增 AndroidTest 已完成编译，完整设备测试交由 CI。
