### PR TITLE
feat: 增加 popup 直角选项

### DIFF
--- a/docs/ai-ui-design-guide.md
+++ b/docs/ai-ui-design-guide.md
@@ -65,6 +65,7 @@ URL 解析集中在 `resolveContent()`。支持知乎问题、回答、文章、
 | `useDynamicColor` | Material You 动态取色 | Android 12+ 取系统壁纸色 | 关闭后自定义主题色才明显生效 |
 | `customThemeColor` | 自定义主题色 | Material 3 主色 | 不要和动态取色同时假设生效 |
 | `backgroundColorLight`, `backgroundColorDark` | 自定义背景颜色 | 明暗模式背景 | 按当前明暗模式写入不同 key |
+| `disableBottomSheetRoundedCorners` | 禁用 popup 圆角 | `MyModalBottomSheet` 顶部改为直角 | 默认关闭，统一影响评论等复用 popup |
 | `contentFontSize`, `contentLineHeight`, `contentBlockSpacing` | 字号、行高、段间距 | 正文字号/行高、分段文本样式和 Markdown 正文块间距 | 查 `SegmentedText` 和 Markdown 渲染路径 |
 | `showFeedThumbnail` | Feed 卡片缩略图 | 信息流卡片是否显示图 | 由复用 `FeedCard` 的页面读取 |
 | `showRefreshFab` | 刷新 FAB | 首页/列表可拖动刷新按钮显示 | 123Duo3 总开关会关闭它 |

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/MyModalBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/MyModalBottomSheet.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.GraphicsLayerScope
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
@@ -87,10 +88,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import com.github.zly2006.zhihu.platform.PlatformPredictiveBackHandler
 import com.github.zly2006.zhihu.platform.exportTestTagsForUiAutomation
+import com.github.zly2006.zhihu.platform.rememberSettingsStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlin.math.max
 import kotlin.math.min
+
+const val DISABLE_BOTTOM_SHEET_ROUNDED_CORNERS_PREFERENCE_KEY = "disableBottomSheetRoundedCorners"
 
 @Composable
 @ExperimentalMaterial3Api
@@ -111,6 +115,12 @@ fun MyModalBottomSheet(
     usePlatformWindow: Boolean = true,
     content: @Composable ColumnScope.() -> Unit,
 ) {
+    val settings = rememberSettingsStore()
+    val bottomSheetShape = if (settings.getBoolean(DISABLE_BOTTOM_SHEET_ROUNDED_CORNERS_PREFERENCE_KEY, false)) {
+        RectangleShape
+    } else {
+        shape
+    }
     val scope = rememberCoroutineScope()
     val animateToDismiss: () -> Unit = {
         // 绕过 SheetState.confirmValueChange 不可见的问题，直接调用内部 anchoredDraggableState。
@@ -156,7 +166,7 @@ fun MyModalBottomSheet(
                 state = sheetState,
                 maxWidth = sheetMaxWidth,
                 gesturesEnabled = sheetGesturesEnabled,
-                shape = shape,
+                shape = bottomSheetShape,
                 containerColor = containerColor,
                 contentColor = contentColor,
                 tonalElevation = tonalElevation,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/AppearanceSettingsScreen.kt
@@ -105,6 +105,7 @@ import com.github.zly2006.zhihu.ui.AnswerDoubleTapAction
 import com.github.zly2006.zhihu.ui.components.ANSWER_SWITCH_SENSITIVITY_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.components.ColorPickerDialog
 import com.github.zly2006.zhihu.ui.components.DEFAULT_ANSWER_SWITCH_SENSITIVITY
+import com.github.zly2006.zhihu.ui.components.DISABLE_BOTTOM_SHEET_ROUNDED_CORNERS_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.components.MAX_ANSWER_SWITCH_SENSITIVITY
 import com.github.zly2006.zhihu.ui.components.MIN_ANSWER_SWITCH_SENSITIVITY
 import com.github.zly2006.zhihu.ui.components.SettingItem
@@ -134,6 +135,7 @@ const val APPEARANCE_SETTINGS_WEBVIEW_FONT_TAG = "appearanceSettings.webViewFont
 const val APPEARANCE_SETTINGS_WEBVIEW_OPTIONS_TAG = "appearanceSettings.webViewOptions"
 const val APPEARANCE_SETTINGS_BOTTOM_BAR_SECTION_KEY = "appearanceSettings.bottomBarSection"
 const val APPEARANCE_SETTINGS_COLLECTION_DIRECT_BROWSE_TAG = "appearanceSettings.collectionDirectBrowse"
+const val APPEARANCE_SETTINGS_DISABLE_BOTTOM_SHEET_ROUNDED_CORNERS_TAG = "appearanceSettings.disableBottomSheetRoundedCorners"
 
 const val START_DESTINATION_PREFERENCE_KEY = "startDestination"
 const val BOTTOM_BAR_ITEMS_PREFERENCE_KEY = "bottom_bar_items"
@@ -542,6 +544,23 @@ fun AppearanceSettingsScreen(
                         },
                     )
                 }
+
+                val disableBottomSheetRoundedCorners = remember {
+                    mutableStateOf(settings.getBoolean(DISABLE_BOTTOM_SHEET_ROUNDED_CORNERS_PREFERENCE_KEY, false))
+                }
+                SettingItemWithSwitch(
+                    modifier = Modifier.testTag(APPEARANCE_SETTINGS_DISABLE_BOTTOM_SHEET_ROUNDED_CORNERS_TAG),
+                    title = { Text("禁用 popup 圆角") },
+                    description = { Text("开启后，评论等 popup 顶部不再显示圆角。") },
+                    checked = disableBottomSheetRoundedCorners.value,
+                    onCheckedChange = {
+                        disableBottomSheetRoundedCorners.value = it
+                        settings.putBoolean(DISABLE_BOTTOM_SHEET_ROUNDED_CORNERS_PREFERENCE_KEY, it)
+                    },
+                    settingKey = DISABLE_BOTTOM_SHEET_ROUNDED_CORNERS_PREFERENCE_KEY,
+                    highlightedKey = settingKey,
+                    bringIntoViewRequester = requesterFor(DISABLE_BOTTOM_SHEET_ROUNDED_CORNERS_PREFERENCE_KEY),
+                )
 
                 var fabOpacity by remember {
                     mutableIntStateOf(settings.getInt(PREF_FAB_OPACITY, DEFAULT_FAB_OPACITY))

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
@@ -57,6 +57,7 @@ import com.github.zly2006.zhihu.notification.NotificationType
 import com.github.zly2006.zhihu.platform.rememberSettingsStore
 import com.github.zly2006.zhihu.ui.ANSWER_DOUBLE_TAP_ACTION_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.ARTICLE_USE_WEBVIEW_PREFERENCE_KEY
+import com.github.zly2006.zhihu.ui.components.DISABLE_BOTTOM_SHEET_ROUNDED_CORNERS_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.components.SettingItem
 import com.github.zly2006.zhihu.ui.components.SettingItemGroup
 import com.github.zly2006.zhihu.viewmodel.QUALITY_FILTER_MODE_PREFERENCE_KEY
@@ -157,6 +158,7 @@ private fun notificationEntry(
 private val settingsSearchEntries = buildList {
     add(appearanceEntry("appearance.nightMode", "主题模式", "切换浅色、深色或跟随系统。", "nightMode", listOf("夜间模式", "深色模式", "暗色模式", "浅色模式", "跟随系统")))
     add(appearanceEntry("appearance.dynamicColor", "使用 Material You 动态取色", "Android 12+ 根据系统壁纸取色。", "dynamicColor", listOf("动态颜色", "壁纸取色", "主题色")))
+    add(appearanceEntry("appearance.bottomSheetCorners", "禁用 popup 圆角", "评论等 popup 顶部改为直角。", DISABLE_BOTTOM_SHEET_ROUNDED_CORNERS_PREFERENCE_KEY, listOf("评论圆角", "popup", "直角")))
     add(appearanceEntry("appearance.fontScale", "字号与行高", "调整正文阅读字号和行距。", "fontScale", listOf("字体大小", "内容字体", "正文字号", "行距")))
     add(appearanceEntry("appearance.showFeedThumbnail", "显示 Feed 卡片缩略图", "控制信息流卡片图片显示。", "showFeedThumbnail", listOf("图片", "封面")))
     add(appearanceEntry("appearance.showRefreshFab", "显示刷新 FAB 按钮", "控制首页和列表的浮动刷新按钮。", "showRefreshFab", listOf("刷新按钮", "浮动按钮")))


### PR DESCRIPTION
## 改动

- 在“外观与阅读体验”中新增“禁用 popup 圆角”开关，默认关闭。
- 在 `MyModalBottomSheet` 内集中读取设置；开启后所有复用 popup 使用直角外形，无需逐个修改调用点。
- 补充设置搜索入口和 UI 设计文档。

## 原因

为偏好直角界面的用户提供统一选项，同时保持现有圆角样式为默认行为。

## 截图

以下截图来自同一份 Lite Debug APK、同一台 API 35 AVD、同一个账号 popup：

| 默认关闭（圆角） | 开启（直角） |
| --- | --- |
| ![默认关闭时的圆角 popup](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-684/popup-rounded-default.png) | ![开启后的直角 popup](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-684/popup-square-enabled.png) |

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- 在同一台 API 35 AVD 上分别以默认关闭和开启状态打开同一个账号 popup，人工确认顶部圆角切换为直角，内容与交互保持不变。
- 最终只读复审：0 个问题。

Resolves #682