### PR TITLE
fix: 让信息流标题跟随字号设置

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
@@ -148,7 +148,7 @@ fun FeedCard(
         Column(
             modifier = modifier
                 .fillMaxWidth()
-                .then(if (showPinImages) Modifier else Modifier.heightIn(max = maxHeight)),
+                .then(if (showPinImages || duo3CardLayout) Modifier else Modifier.heightIn(max = maxHeight)),
         ) {
             Column(
                 modifier = Modifier
@@ -175,7 +175,7 @@ fun FeedCard(
         Box(
             modifier = modifier
                 .fillMaxWidth()
-                .then(if (showPinImages) Modifier else Modifier.heightIn(max = maxHeight))
+                .then(if (showPinImages || duo3CardLayout) Modifier else Modifier.heightIn(max = maxHeight))
                 .padding(horizontal = horizontalPadding, vertical = 8.dp),
         ) {
             Card(

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/components/FeedCard.kt
@@ -303,14 +303,18 @@ private fun FeedCardContent(
             FeedCardSourceLabel(sourceLabel)
         }
         if (!item.title.isEmpty()) {
+            val titleStyle = if (duo3CardLargeTitle) {
+                MaterialTheme.typography.titleLarge
+            } else {
+                MaterialTheme.typography.titleMedium
+            }
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = parseEmphasizedHtmlTextWithTheme(item.title),
-                    style = if (duo3CardLargeTitle) {
-                        MaterialTheme.typography.titleLarge
-                    } else {
-                        MaterialTheme.typography.titleMedium
-                    },
+                    style = titleStyle.copy(
+                        fontSize = titleStyle.fontSize * fontSizePercent / 100,
+                        lineHeight = titleStyle.lineHeight * fontSizePercent / 100,
+                    ),
                     maxLines = 2,
                     color = MaterialTheme.colorScheme.onSurface,
                     overflow = TextOverflow.Ellipsis,
@@ -419,7 +423,7 @@ private fun FeedCardContent(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = parseEmphasizedHtmlTextWithTheme(item.title),
-                    fontSize = 16.sp,
+                    fontSize = 16.sp * fontSizePercent / 100,
                     fontWeight = FontWeight.Bold,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,


### PR DESCRIPTION
## 问题

信息流摘要已经会随内容字号设置缩放，但 legacy 与 Duo3 排版的标题仍使用固定字号，导致调整内容字号后标题与摘要的比例不一致。

## 修改

- 让 legacy 与 Duo3 信息流标题的 `fontSize` 随 `contentFontSize` 同比例缩放。
- Duo3 标题的 `lineHeight` 同步按相同比例缩放，保持排版关系。
- Duo3 排版不再套用 legacy 的固定卡片最大高度，避免放大字号后底部作者/详情行被裁切。
- 保持 100% 默认显示、最多 2 行及省略号行为不变。
- 保持原有间距与颜色不变。

## 验证

- `./gradlew assembleLiteDebug`
- `./gradlew ktlintFormat`
- `git diff --check`
- 初版字号缩放已通过独立代码 review
- 裁切修复已通过包含最新提交的 API 35 AVD 复验

## 截图

截图来自 API 35 AVD 实际运行的 Lite APK，设置 `contentFontSize=130`，UI dump 确认存在真实信息流卡片标题与摘要。

### Legacy（130%）

`duo3_card_appearance=false`，`duo3_card_layout=false`。

![Legacy 信息流标题随字号缩放](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-687/legacy-130.png)

### Duo3（130%）

`duo3_card_appearance=true`，`duo3_card_layout=true`。修复后的截图与 UI dump 均确认首两张卡片的作者/详情行完整可见，没有底部裁切。

![Duo3 信息流标题随字号缩放且卡片内容完整](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-687/duo3-130.png)

Resolves #619
