### PR TITLE
feat: 解析私信链接并支持选择和复制

### DIFF
--- a/.agents/skills/github-pr-assets/SKILL.md
+++ b/.agents/skills/github-pr-assets/SKILL.md
@@ -28,6 +28,8 @@ Core rule: PR descriptions must contain durable, publicly accessible Markdown li
 6. Update the PR body with `gh pr edit <number> --body-file -`.
 7. Re-read the PR body and re-check `git status --short --branch`.
 
+PR 正文必须先写入临时 Markdown 文件，再通过 `--body-file` 传给 `gh`；不要把包含 `\\n` 的字符串直接作为 `--body` 参数，否则 GitHub 会把转义符原样显示，Markdown 不会解析。
+
 ## GitHub Upload Boundary
 
 Do not claim that GitHub's web drag-and-drop attachment upload can be reproduced with ordinary `gh api` unless a real endpoint has been verified in the current environment.

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PrivateMessageContent.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PrivateMessageContent.kt
@@ -1,0 +1,71 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.ui
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withLink
+import com.fleeksoft.ksoup.Ksoup
+import com.github.zly2006.zhihu.data.ZhihuPrivateMessage
+import io.ktor.http.Url
+
+internal fun ZhihuPrivateMessage.displayContent(
+    linkColor: Color,
+    onLinkClick: (String) -> Unit,
+): AnnotatedString {
+    val source = plugin?.excerpt?.takeIf(String::isNotBlank)
+        ?: content.takeIf(String::isNotBlank)
+        ?: return AnnotatedString("暂不支持显示这条消息")
+    val document = Ksoup.parseBodyFragment(source)
+    val text = document.text()
+
+    return buildAnnotatedString {
+        var cursor = 0
+        var anchorSearchStart = 0
+        document.select("a[href]").forEach { anchor ->
+            val linkText = anchor.text()
+            val start = text.indexOf(linkText, anchorSearchStart).takeIf { it >= 0 }
+                ?: return@forEach
+            val end = start + linkText.length
+            anchorSearchStart = end
+            val url = anchor.attr("href").safeHttpUrl() ?: return@forEach
+            if (linkText.isEmpty() || start < cursor) return@forEach
+            append(text.substring(cursor, start))
+            withLink(
+                LinkAnnotation.Clickable(
+                    tag = url,
+                    styles = TextLinkStyles(style = SpanStyle(color = linkColor)),
+                ) { onLinkClick(url) },
+            ) {
+                append(text.substring(start, end))
+            }
+            cursor = end
+        }
+        append(text.substring(cursor))
+    }
+}
+
+private fun String.safeHttpUrl(): String? = runCatching { Url(trim()) }
+    .getOrNull()
+    ?.takeIf { it.protocol.name == "http" || it.protocol.name == "https" }
+    ?.takeIf { it.host.isNotBlank() }
+    ?.toString()

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PrivateMessageScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PrivateMessageScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.Send
@@ -51,6 +52,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -62,12 +64,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
-import com.fleeksoft.ksoup.Ksoup
 import com.github.zly2006.zhihu.data.ZhihuPrivateMessage
 import com.github.zly2006.zhihu.navigation.LocalNavigator
 import com.github.zly2006.zhihu.navigation.Notification
+import com.github.zly2006.zhihu.navigation.resolveContent
 import com.github.zly2006.zhihu.notification.rememberNotificationSettingsStore
 import com.github.zly2006.zhihu.platform.rememberUserMessageSink
+import com.github.zly2006.zhihu.platform.rememberZhihuWebUrlOpener
 import com.github.zly2006.zhihu.ui.components.PaginatedList
 import com.github.zly2006.zhihu.ui.components.ProgressIndicatorFooter
 import com.github.zly2006.zhihu.util.formatRelativeTime
@@ -212,11 +215,14 @@ private fun PrivateMessageBubble(
     message: ZhihuPrivateMessage,
     incoming: Boolean,
 ) {
-    val displayText = (
-        message.plugin?.excerpt?.takeIf { it.isNotBlank() }
-            ?: message.content.takeIf { it.isNotBlank() }
-    )?.let { Ksoup.parse(it).text() }
-        ?: "暂不支持显示这条消息"
+    val navigator = LocalNavigator.current
+    val openWebUrl = rememberZhihuWebUrlOpener()
+    val linkColor = MaterialTheme.colorScheme.primary
+    val displayText = remember(message.content, message.plugin, linkColor, navigator, openWebUrl) {
+        message.displayContent(linkColor) { url ->
+            resolveContent(url)?.let(navigator.onNavigate) ?: openWebUrl(url)
+        }
+    }
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -254,11 +260,15 @@ private fun PrivateMessageBubble(
                     MaterialTheme.colorScheme.primaryContainer
                 },
             ) {
-                Text(
-                    text = displayText,
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
-                )
+                SelectionContainer {
+                    Text(
+                        text = displayText,
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier
+                            .commentSelectionWorkaround()
+                            .padding(horizontal = 14.dp, vertical = 10.dp),
+                    )
+                }
             }
             Text(
                 text = formatRelativeTime(message.createdTime),

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/ui/PrivateMessageContentTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/ui/PrivateMessageContentTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Zhihu++ - Free & Ad-Free Zhihu client for all platforms.
+ * Copyright (C) 2024-2026, zly2006 <i@zly2006.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation (version 3 only).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.zly2006.zhihu.ui
+
+import androidx.compose.ui.graphics.Color
+import com.github.zly2006.zhihu.data.ZhihuPrivateMessage
+import com.github.zly2006.zhihu.data.ZhihuPrivateMessagePlugin
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PrivateMessageContentTest {
+    @Test
+    fun parsesVisibleHtmlAnchorsOnly() {
+        val content = ZhihuPrivateMessage(
+            content = "周报已生成，<a href=\"https://www.zhihu.com/creator/weekly\">查看周报</a>；活动地址见下方。",
+        ).displayContent(Color.Blue) {}
+
+        assertEquals("周报已生成，查看周报；活动地址见下方。", content.text)
+        assertEquals(1, content.getLinkAnnotations(0, content.length).size)
+    }
+
+    @Test
+    fun parsesPluginExcerptButIgnoresPluginResourceUrls() {
+        val content = ZhihuPrivateMessage(
+            plugin = ZhihuPrivateMessagePlugin(
+                excerpt = "咨询详情：<a href=\"https://www.zhihu.com/question/123\">打开</a>",
+                pluginContent =
+                    """{"card":{"title":"咨询"},"tabs":[{"title":"分类","icon":"https://static.example/icon.png"}]}""",
+            ),
+        ).displayContent(Color.Blue) {}
+
+        assertEquals("咨询详情：打开", content.text)
+    }
+
+    @Test
+    fun keepsDangerousAndRelativeTargetsAsPlainText() {
+        val content = ZhihuPrivateMessage(
+            content =
+                "<a href=\"javascript:alert(1)\">危险链接</a> " +
+                    "<a href=\"/question/123\">相对链接</a>",
+        ).displayContent(Color.Blue) {}
+
+        assertEquals("危险链接 相对链接", content.text)
+    }
+}


### PR DESCRIPTION
## 变更

- 解析私信正文和插件摘要中的 HTML anchor，生成可点击的 Compose 链接标注。
- 站内链接沿用现有导航，其他安全 `http(s)` 链接打开现有 WebView。
- 保留私信文本选择、复制和全选；忽略插件 JSON 中的图标资源 URL。

## 原因

当前私信把 HTML 转成纯文本，真实创作周报和官方活动中的链接无法点击或复制。

## 验证

- `./gradlew :shared:jvmTest --tests com.github.zly2006.zhihu.ui.PrivateMessageContentTest`：通过。
- `./gradlew assembleLiteDebug`：通过。
- 使用真实账号数据在 off Android 15 AVD 验证：活动消息中的链接显示为蓝色、点击打开站内内容，长按出现 Translate/Copy/Select all/Read aloud。
- 真实 116 条私信语料解析：133 个 anchor 中 132 个安全链接可用；1 个相对/无 scheme 链接拒绝；8 个插件图标 URL 均未变成可点击链接。

截图来自真实账号、真实私信和 off Android 15 AVD：

![off AVD 私信链接与复制验证](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-690/private-message-links-off-avd.png)

Resolves #666
