### PR TITLE
feat: 支持推荐卡片先展示并按需加载正文过滤

### DIFF
--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
@@ -421,7 +421,10 @@ open class SharedAndroidPaginationEnvironment(
             onDetailsKeywordFiltered = { item, keyword ->
                 Log.e("ContentFilterExtensions", "Filtered item '${item.title}' due to keyword '$keyword' in details: ${item.content}")
             },
-        ).filter(foregroundItems)
+        ).filter(
+            foregroundItems,
+            loadFullContent = filterSettings.loadFullContentForRecommendationFiltering,
+        )
         return HomeFeedFilterResult(
             foregroundItems = foregroundItems,
             filteredItems = filteredItems,

--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
@@ -288,6 +288,10 @@ open class SharedAndroidPaginationEnvironment(
             it.name == settingsStore.getString(QUALITY_FILTER_MODE_PREFERENCE_KEY, QualityFilterMode.RULES.name)
         } ?: QualityFilterMode.RULES,
         reverseBlock = settingsStore.getBoolean("reverseBlock", false),
+        loadFullContentForRecommendationFiltering = settingsStore.getBoolean(
+            LOAD_FULL_CONTENT_FOR_RECOMMENDATION_FILTERING_PREFERENCE_KEY,
+            false,
+        ),
     )
 
     override fun localHistory(): List<NavDestination> = HistoryStorage(context).history
@@ -383,15 +387,23 @@ open class SharedAndroidPaginationEnvironment(
         recordContentOpenEvent(destination, questionId)
     }
 
-    override suspend fun applyHomeFeedFilters(items: List<FeedDisplayItem>): HomeFeedFilterResult {
+    override suspend fun applyHomeFeedFilters(
+        items: List<FeedDisplayItem>,
+        loadFullContent: Boolean,
+        applyForegroundFilter: Boolean,
+    ): HomeFeedFilterResult {
         val settings = feedDisplaySettings()
         val filterSettings = context.contentFilterSettings()
         val filterDatabase = getContentFilterDatabase(context)
-        val foregroundItems = ForegroundReadFilterPipeline(
-            settings = filterSettings,
-            contentFilterManager = ContentFilterManager(filterDatabase.contentFilterDao()),
-            blockedFeedRecordDao = filterDatabase.blockedFeedRecordDao(),
-        ).filter(items)
+        val foregroundItems = if (applyForegroundFilter) {
+            ForegroundReadFilterPipeline(
+                settings = filterSettings,
+                contentFilterManager = ContentFilterManager(filterDatabase.contentFilterDao()),
+                blockedFeedRecordDao = filterDatabase.blockedFeedRecordDao(),
+            ).filter(items)
+        } else {
+            items
+        }
         val filteredItems = FeedDisplayFilterPipeline(
             settings = filterSettings,
             contentDetailProvider = this::getOrFetchContentDetail,
@@ -423,7 +435,7 @@ open class SharedAndroidPaginationEnvironment(
             },
         ).filter(
             foregroundItems,
-            loadFullContent = filterSettings.loadFullContentForRecommendationFiltering,
+            loadFullContent = loadFullContent,
         )
         return HomeFeedFilterResult(
             foregroundItems = foregroundItems,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/data/ZhihuDataCore.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/data/ZhihuDataCore.kt
@@ -128,6 +128,13 @@ private fun Feed.toTargetDisplayItem(
             authorName = target.author?.name,
             authorBadgeV2 = target.author?.badgeV2,
             feed = this,
+            content = when (target) {
+                is Feed.AnswerTarget -> target.content
+                is Feed.ArticleTarget -> target.content
+                is Feed.QuestionTarget -> target.detail
+                is Feed.PinTarget -> target.contentHtml
+                is Feed.VideoTarget -> target.description
+            },
         )
 
         is Feed.PinTarget -> {
@@ -152,6 +159,7 @@ private fun Feed.toTargetDisplayItem(
                 authorName = target.author.name,
                 authorBadgeV2 = target.author.badgeV2,
                 feed = this,
+                content = target.contentHtml,
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/ContentFilterSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/ContentFilterSettingsScreen.kt
@@ -75,6 +75,7 @@ import com.github.zly2006.zhihu.ui.components.SettingItem
 import com.github.zly2006.zhihu.ui.components.SettingItemGroup
 import com.github.zly2006.zhihu.ui.components.SettingItemWithSwitch
 import com.github.zly2006.zhihu.util.Log
+import com.github.zly2006.zhihu.viewmodel.LOAD_FULL_CONTENT_FOR_RECOMMENDATION_FILTERING_PREFERENCE_KEY
 import com.github.zly2006.zhihu.viewmodel.QUALITY_FILTER_MODE_PREFERENCE_KEY
 import com.github.zly2006.zhihu.viewmodel.QualityFilterMode
 import com.github.zly2006.zhihu.viewmodel.filter.getContentFilterDatabase
@@ -299,6 +300,29 @@ fun ContentFilterSettingsScreen(
                         settings.putBoolean("enableContentFilter", it)
                     },
                     settingKey = "enableContentFilter",
+                    highlightedKey = highlightedSetting,
+                )
+
+                val loadFullContentForRecommendationFiltering = remember {
+                    mutableStateOf(
+                        settings.getBoolean(
+                            LOAD_FULL_CONTENT_FOR_RECOMMENDATION_FILTERING_PREFERENCE_KEY,
+                            false,
+                        ),
+                    )
+                }
+                SettingItemWithSwitch(
+                    modifier = Modifier.testTag("contentFilterSettings:loadFullContentForRecommendationFiltering"),
+                    title = { Text("加载完整正文进行推荐过滤") },
+                    description = {
+                        Text("开启后会在后台加载推荐内容正文，以执行更严格的过滤，可能增加流量和加载时间")
+                    },
+                    checked = loadFullContentForRecommendationFiltering.value,
+                    onCheckedChange = {
+                        loadFullContentForRecommendationFiltering.value = it
+                        settings.putBoolean(LOAD_FULL_CONTENT_FOR_RECOMMENDATION_FILTERING_PREFERENCE_KEY, it)
+                    },
+                    settingKey = LOAD_FULL_CONTENT_FOR_RECOMMENDATION_FILTERING_PREFERENCE_KEY,
                     highlightedKey = highlightedSetting,
                 )
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/subscreens/SettingsSearchScreen.kt
@@ -60,6 +60,7 @@ import com.github.zly2006.zhihu.ui.ARTICLE_USE_WEBVIEW_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.components.DISABLE_BOTTOM_SHEET_ROUNDED_CORNERS_PREFERENCE_KEY
 import com.github.zly2006.zhihu.ui.components.SettingItem
 import com.github.zly2006.zhihu.ui.components.SettingItemGroup
+import com.github.zly2006.zhihu.viewmodel.LOAD_FULL_CONTENT_FOR_RECOMMENDATION_FILTERING_PREFERENCE_KEY
 import com.github.zly2006.zhihu.viewmodel.QUALITY_FILTER_MODE_PREFERENCE_KEY
 
 const val SETTINGS_SEARCH_INPUT_TAG = "settingsSearch.input"
@@ -206,6 +207,15 @@ private val settingsSearchEntries = buildList {
     add(recommendEntry("recommend.loginForRecommendation", "推荐内容时登录", "获取推荐内容时是否带登录凭证。", "loginForRecommendation"))
     add(recommendEntry("recommend.qualityFilterMode", "质量屏蔽", "选择不屏蔽、显示屏蔽规则或直接隐藏低质量内容。", QUALITY_FILTER_MODE_PREFERENCE_KEY, listOf("低质量", "屏蔽规则", "隐藏")))
     add(recommendEntry("recommend.enableContentFilter", "启用智能内容过滤", "过滤重复出现但未点击内容。", "enableContentFilter"))
+    add(
+        recommendEntry(
+            "recommend.loadFullContentForRecommendationFiltering",
+            "加载完整正文进行推荐过滤",
+            "加载推荐内容正文，以执行更严格的过滤，可能增加流量和加载时间。",
+            LOAD_FULL_CONTENT_FOR_RECOMMENDATION_FILTERING_PREFERENCE_KEY,
+            listOf("完整正文", "正文过滤", "推荐过滤"),
+        ),
+    )
     add(recommendEntry("recommend.filterFollowedUserContent", "过滤已关注用户内容", "控制是否过滤已关注用户的内容。", "filterFollowedUserContent"))
     add(recommendEntry("recommend.enableKeywordBlocking", "启用关键词屏蔽", "按关键词过滤内容。", "enableKeywordBlocking", listOf("关键词", "屏蔽词")))
     add(recommendEntry("recommend.enableUserBlocking", "启用用户屏蔽", "按用户过滤内容。", "enableUserBlocking", listOf("作者屏蔽", "屏蔽用户")))

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -573,6 +573,7 @@ enum class QualityFilterMode {
 }
 
 const val QUALITY_FILTER_MODE_PREFERENCE_KEY = "qualityFilterMode"
+const val LOAD_FULL_CONTENT_FOR_RECOMMENDATION_FILTERING_PREFERENCE_KEY = "loadFullContentForRecommendationFiltering"
 
 data class HomeFeedFilterResult(
     val foregroundItems: List<FeedDisplayItem>,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -100,7 +100,7 @@ abstract class PaginationViewModel<T : Any>(
      */
     open val include = "data[*].content,excerpt,headline,target.author.badge_v2"
 
-    open fun refresh(environment: PaginationEnvironment) {
+    internal fun resetPaginationState() {
         currentJob?.cancel()
         currentJob = null
         isLoading = false
@@ -108,6 +108,10 @@ abstract class PaginationViewModel<T : Any>(
         debugData.clear()
         allData.clear()
         lastPaging = null // 重置 lastPaging
+    }
+
+    open fun refresh(environment: PaginationEnvironment) {
+        resetPaginationState()
         loadMore(environment)
     }
 
@@ -150,10 +154,11 @@ abstract class PaginationViewModel<T : Any>(
 
             val jsonArray = json["data"] as? JsonArray
                 ?: throw RuntimeException("您可能已被风控，请重新登录。", Exception("cause: no $.data"))
-            processResponse(environment, decodePage(environment, jsonArray), jsonArray)
             if ("paging" in json) {
+                // 先保存分页游标，部分信息流会在 processResponse 中异步处理过滤。
                 lastPaging = decodeJson(json["paging"]!!)
             }
+            processResponse(environment, decodePage(environment, jsonArray), jsonArray)
         } catch (e: Exception) {
             if (e is kotlin.coroutines.cancellation.CancellationException) throw e
             environment.handleFetchFailure(this::class.simpleName, e)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -410,7 +410,17 @@ interface MobileHomeFeedEnvironment : ZhihuApiEnvironment {
 interface FeedDisplayEnvironment {
     fun feedDisplaySettings(): FeedDisplaySettings = FeedDisplaySettings()
 
-    suspend fun applyHomeFeedFilters(items: List<FeedDisplayItem>): HomeFeedFilterResult =
+    /**
+     * 分一到两次执行推荐过滤。
+     *
+     * 第二次过滤必须关闭前台过滤，因为前台过滤会记录已展示内容；重复执行会让刚展示的页面
+     * 在正文详情过滤前就被已读规则移除。
+     */
+    suspend fun applyHomeFeedFilters(
+        items: List<FeedDisplayItem>,
+        loadFullContent: Boolean = feedDisplaySettings().loadFullContentForRecommendationFiltering,
+        applyForegroundFilter: Boolean = true,
+    ): HomeFeedFilterResult =
         HomeFeedFilterResult(
             foregroundItems = items,
             filteredItems = items,
@@ -564,6 +574,8 @@ interface PaginationEnvironment :
 data class FeedDisplaySettings(
     val qualityFilterMode: QualityFilterMode = QualityFilterMode.RULES,
     val reverseBlock: Boolean = false,
+    /** 在推荐卡片展示后，是否继续执行可选的详情正文过滤。 */
+    val loadFullContentForRecommendationFiltering: Boolean = false,
 )
 
 enum class QualityFilterMode {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/BaseFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/BaseFeedViewModel.kt
@@ -45,6 +45,9 @@ abstract class BaseFeedViewModel : PaginationViewModel<Feed>(typeOf<Feed>()) {
     var displayItems = mutableStateListOf<FeedDisplayItem>()
     internal var latestLoadedDisplayItems = mutableStateOf<List<FeedDisplayItem>>(emptyList())
     internal var completedPageCount by mutableIntStateOf(0)
+
+    // 刷新时使后台详情过滤失效，避免旧页面重新插入过期卡片。
+    protected var filterGeneration = 0
     var isPullToRefresh by mutableStateOf(false)
         protected set
 
@@ -56,11 +59,13 @@ abstract class BaseFeedViewModel : PaginationViewModel<Feed>(typeOf<Feed>()) {
     }
 
     override fun refresh(environment: PaginationEnvironment) {
+        filterGeneration++
         displayItems.clear()
         super.refresh(environment)
     }
 
     suspend fun pullToRefresh(environment: PaginationEnvironment) {
+        filterGeneration++
         isPullToRefresh = true
         displayItems.clear()
         if (isLoading) return
@@ -85,6 +90,8 @@ abstract class BaseFeedViewModel : PaginationViewModel<Feed>(typeOf<Feed>()) {
             reverseBlock = settings.reverseBlock,
         )
     }
+
+    protected fun isCurrentFilterGeneration(generation: Int): Boolean = generation == filterGeneration
 
     fun addDisplayItems(newItems: List<FeedDisplayItem>) {
         newItems.forEach {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/BaseFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/BaseFeedViewModel.kt
@@ -59,13 +59,13 @@ abstract class BaseFeedViewModel : PaginationViewModel<Feed>(typeOf<Feed>()) {
     }
 
     override fun refresh(environment: PaginationEnvironment) {
-        filterGeneration++
+        invalidateFilterProcessing()
         displayItems.clear()
         super.refresh(environment)
     }
 
-    suspend fun pullToRefresh(environment: PaginationEnvironment) {
-        filterGeneration++
+    open suspend fun pullToRefresh(environment: PaginationEnvironment) {
+        invalidateFilterProcessing()
         isPullToRefresh = true
         displayItems.clear()
         if (isLoading) return
@@ -89,6 +89,10 @@ abstract class BaseFeedViewModel : PaginationViewModel<Feed>(typeOf<Feed>()) {
             enableQualityFilter = settings.qualityFilterMode != QualityFilterMode.OFF,
             reverseBlock = settings.reverseBlock,
         )
+    }
+
+    internal fun invalidateFilterProcessing() {
+        filterGeneration++
     }
 
     protected fun isCurrentFilterGeneration(generation: Int): Boolean = generation == filterGeneration

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
@@ -209,7 +209,7 @@ class HomeFeedViewModel :
                 val filterResult = if (loadFullContent) {
                     try {
                         environment.applyHomeFeedFilters(
-                            newItems,
+                            foregroundResult.foregroundItems,
                             loadFullContent = true,
                             applyForegroundFilter = false,
                         )
@@ -240,7 +240,7 @@ class HomeFeedViewModel :
             val filterResult = if (loadFullContent) {
                 try {
                     environment.applyHomeFeedFilters(
-                        newItems,
+                        foregroundResult.foregroundItems,
                         loadFullContent = true,
                         applyForegroundFilter = false,
                     )

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
@@ -223,9 +223,11 @@ class HomeFeedViewModel :
                 }
                 if (!isCurrentFilterGeneration(generation)) return@launch
                 withContext(Dispatchers.Main) {
-                    addDisplayItems(filterResult.filteredItems)
-                    latestLoadedDisplayItems.value = filterResult.filteredItems
-                    completedPageCount++
+                    if (isCurrentFilterGeneration(generation)) {
+                        addDisplayItems(filterResult.filteredItems)
+                        latestLoadedDisplayItems.value = filterResult.filteredItems
+                        completedPageCount++
+                    }
                 }
                 return@launch
             }
@@ -256,9 +258,11 @@ class HomeFeedViewModel :
 
             // 移除被过滤的条目，并更新已保留条目的 raw 内容
             withContext(Dispatchers.Main) {
-                displayItems.replaceHomeFeedItemsWithFilteredResult(filterResult)
-                latestLoadedDisplayItems.value = filterResult.filteredItems
-                completedPageCount++
+                if (isCurrentFilterGeneration(generation)) {
+                    displayItems.replaceHomeFeedItemsWithFilteredResult(filterResult)
+                    latestLoadedDisplayItems.value = filterResult.filteredItems
+                    completedPageCount++
+                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
@@ -29,6 +29,7 @@ import com.github.zly2006.zhihu.data.target
 import com.github.zly2006.zhihu.navigation.Question
 import com.github.zly2006.zhihu.util.Log
 import com.github.zly2006.zhihu.viewmodel.ContentInteractionEnvironment
+import com.github.zly2006.zhihu.viewmodel.HomeFeedFilterResult
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.QualityFilterMode
 import com.github.zly2006.zhihu.viewmodel.filter.ContentDetailProvider
@@ -174,6 +175,7 @@ class HomeFeedViewModel :
         allData.addAll(data)
         debugData.addAll(rawData)
 
+        val generation = filterGeneration
         viewModelScope.launch {
             val loadedItems = data
                 .flattenFeeds()
@@ -184,21 +186,78 @@ class HomeFeedViewModel :
                 loadedItems
             }
 
-            val filterResult = environment.applyHomeFeedFilters(newItems)
-            if (!filterResult.reverseBlock) {
+            val settings = environment.feedDisplaySettings()
+            val loadFullContent = settings.loadFullContentForRecommendationFiltering
+            // 前台过滤只能执行一次，因为它会把新展示的内容记录为已读。
+            val foregroundResult = try {
+                environment.applyHomeFeedFilters(
+                    newItems,
+                    loadFullContent = false,
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                HomeFeedFilterResult(
+                    foregroundItems = newItems,
+                    filteredItems = newItems,
+                    reverseBlock = settings.reverseBlock,
+                )
+            }
+            if (!isCurrentFilterGeneration(generation)) return@launch
+
+            if (foregroundResult.reverseBlock) {
+                val result = if (loadFullContent) {
+                    try {
+                        environment.applyHomeFeedFilters(
+                            newItems,
+                            loadFullContent = true,
+                            applyForegroundFilter = false,
+                        )
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Exception) {
+                        foregroundResult
+                    }
+                } else {
+                    foregroundResult
+                }
+                if (!isCurrentFilterGeneration(generation)) return@launch
                 withContext(Dispatchers.Main) {
-                    addDisplayItems(filterResult.foregroundItems)
+                    addDisplayItems(result.filteredItems)
+                    latestLoadedDisplayItems.value = result.filteredItems
+                    completedPageCount++
+                }
+                return@launch
+            }
+
+            withContext(Dispatchers.Main) {
+                if (isCurrentFilterGeneration(generation)) {
+                    addDisplayItems(foregroundResult.foregroundItems)
                 }
             }
 
-            if (filterResult.reverseBlock) {
-                addDisplayItems(filterResult.filteredItems)
+            // 卡片展示后再执行完整正文过滤；详情失败时保留轻量过滤结果。
+            val result = if (loadFullContent) {
+                try {
+                    environment.applyHomeFeedFilters(
+                        newItems,
+                        loadFullContent = true,
+                        applyForegroundFilter = false,
+                    )
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: Exception) {
+                    foregroundResult
+                }
+            } else {
+                foregroundResult
             }
+            if (!isCurrentFilterGeneration(generation)) return@launch
 
             // 移除被过滤的条目，并更新已保留条目的 raw 内容
             withContext(Dispatchers.Main) {
-                displayItems.replaceHomeFeedItemsWithFilteredResult(filterResult)
-                latestLoadedDisplayItems.value = filterResult.filteredItems
+                displayItems.replaceHomeFeedItemsWithFilteredResult(result)
+                latestLoadedDisplayItems.value = result.filteredItems
                 completedPageCount++
             }
         }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
@@ -206,7 +206,7 @@ class HomeFeedViewModel :
             if (!isCurrentFilterGeneration(generation)) return@launch
 
             if (foregroundResult.reverseBlock) {
-                val result = if (loadFullContent) {
+                val filterResult = if (loadFullContent) {
                     try {
                         environment.applyHomeFeedFilters(
                             newItems,
@@ -223,8 +223,8 @@ class HomeFeedViewModel :
                 }
                 if (!isCurrentFilterGeneration(generation)) return@launch
                 withContext(Dispatchers.Main) {
-                    addDisplayItems(result.filteredItems)
-                    latestLoadedDisplayItems.value = result.filteredItems
+                    addDisplayItems(filterResult.filteredItems)
+                    latestLoadedDisplayItems.value = filterResult.filteredItems
                     completedPageCount++
                 }
                 return@launch
@@ -237,7 +237,7 @@ class HomeFeedViewModel :
             }
 
             // 卡片展示后再执行完整正文过滤；详情失败时保留轻量过滤结果。
-            val result = if (loadFullContent) {
+            val filterResult = if (loadFullContent) {
                 try {
                     environment.applyHomeFeedFilters(
                         newItems,
@@ -256,8 +256,8 @@ class HomeFeedViewModel :
 
             // 移除被过滤的条目，并更新已保留条目的 raw 内容
             withContext(Dispatchers.Main) {
-                displayItems.replaceHomeFeedItemsWithFilteredResult(result)
-                latestLoadedDisplayItems.value = result.filteredItems
+                displayItems.replaceHomeFeedItemsWithFilteredResult(filterResult)
+                latestLoadedDisplayItems.value = filterResult.filteredItems
                 completedPageCount++
             }
         }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
@@ -30,6 +30,7 @@ import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.navigation.Pin
 import com.github.zly2006.zhihu.platform.SettingsStore
+import com.github.zly2006.zhihu.viewmodel.LOAD_FULL_CONTENT_FOR_RECOMMENDATION_FILTERING_PREFERENCE_KEY
 import kotlinx.serialization.json.Json
 
 class ForegroundReadFilterPipeline(
@@ -505,6 +506,7 @@ private fun getLinkBasedAdReason(
 
 data class FeedFilterSettings(
     val enableContentFilter: Boolean = true,
+    val loadFullContentForRecommendationFiltering: Boolean = false,
     val reverseBlock: Boolean = false,
     val filterFollowedUserContent: Boolean = false,
     val enableKeywordBlocking: Boolean = true,
@@ -518,6 +520,10 @@ data class FeedFilterSettings(
 
 fun SettingsStore.toFeedFilterSettings(): FeedFilterSettings = FeedFilterSettings(
     enableContentFilter = getBoolean("enableContentFilter", true),
+    loadFullContentForRecommendationFiltering = getBoolean(
+        LOAD_FULL_CONTENT_FOR_RECOMMENDATION_FILTERING_PREFERENCE_KEY,
+        false,
+    ),
     reverseBlock = getBoolean("reverseBlock", false),
     filterFollowedUserContent = getBoolean("filterFollowedUserContent", false),
     enableKeywordBlocking = getBoolean("enableKeywordBlocking", true),

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
@@ -20,6 +20,7 @@ package com.github.zly2006.zhihu.viewmodel.filter
 import com.fleeksoft.ksoup.Ksoup
 import com.github.zly2006.zhihu.data.AdvertisementFeed
 import com.github.zly2006.zhihu.data.DataHolder
+import com.github.zly2006.zhihu.data.Feed
 import com.github.zly2006.zhihu.data.FeedDisplayItem
 import com.github.zly2006.zhihu.data.navDestination
 import com.github.zly2006.zhihu.data.questionAuthor
@@ -167,7 +168,7 @@ class FeedContentFilterPipeline(
 
         if (settings.enableTopicBlocking) {
             filteredContents = filteredContents.filter { content ->
-                val topicIds = extractTopicIds(content.raw)
+                val topicIds = content.topicIds ?: extractTopicIds(content.raw)
                 val blockedTopicIds = topicIds
                     ?.takeIf { it.isNotEmpty() }
                     ?.let { blockedTopicDao.getBlockedTopicIds(it) }
@@ -223,7 +224,10 @@ class FeedDisplayFilterPipeline(
     private val onDetailFetchFailed: (FeedDisplayItem) -> Unit = {},
     private val onDetailsKeywordFiltered: (FeedDisplayItem, String) -> Unit = { _, _ -> },
 ) {
-    suspend fun filter(items: List<FeedDisplayItem>): List<FeedDisplayItem> {
+    suspend fun filter(
+        items: List<FeedDisplayItem>,
+        loadFullContent: Boolean = true,
+    ): List<FeedDisplayItem> {
         val (followedUserItems, otherItems) = if (!settings.filterFollowedUserContent) {
             items.partition { item ->
                 item.feed
@@ -239,9 +243,9 @@ class FeedDisplayFilterPipeline(
 
         otherItems.forEach { item ->
             val identity = item.resolveContentIdentity()
-            val rawContent = resolveRawContent(item)
+            val rawContent = resolveRawContent(item, loadFullContent)
 
-            if (rawContent is DataHolder.DummyContent) {
+            if (loadFullContent && rawContent is DataHolder.DummyContent) {
                 onDetailFetchFailed(item)
             }
 
@@ -292,10 +296,17 @@ class FeedDisplayFilterPipeline(
         return (followedUserItems + filteredOtherItems).filterDetailsKeywords()
     }
 
-    private suspend fun resolveRawContent(item: FeedDisplayItem): DataHolder.Content = when (val dest = item.navDestination) {
-        is Article -> contentDetailProvider.get(dest) ?: DataHolder.DummyContent
-        is Pin -> contentDetailProvider.get(dest) ?: DataHolder.DummyContent
-        else -> DataHolder.DummyContent
+    private suspend fun resolveRawContent(
+        item: FeedDisplayItem,
+        loadFullContent: Boolean,
+    ): DataHolder.Content = if (!loadFullContent) {
+        DataHolder.DummyContent
+    } else {
+        when (val dest = item.navDestination) {
+            is Article -> contentDetailProvider.get(dest) ?: DataHolder.DummyContent
+            is Pin -> contentDetailProvider.get(dest) ?: DataHolder.DummyContent
+            else -> DataHolder.DummyContent
+        }
     }
 
     private fun List<FeedDisplayItem>.filterDetailsKeywords(): List<FeedDisplayItem> = filter { item ->
@@ -360,6 +371,7 @@ data class FilterableContent(
     val contentId: String,
     val contentType: String,
     val raw: DataHolder.Content,
+    val topicIds: List<String>? = null,
     val isFollowing: Boolean = false,
     val questionId: Long? = null,
     val url: String? = null,
@@ -396,12 +408,24 @@ fun FeedDisplayItem.toFilterableContent(
         else -> null
     } ?: content ?: summary,
     authorName = authorName,
-    authorId = rawContent.author?.id,
+    authorId = rawContent.author?.id ?: feed?.target?.author?.id,
     contentId = identity.id,
     contentType = identity.type,
     raw = rawContent,
-    isFollowing = rawContent.author?.isFollowing ?: false,
-    questionId = (rawContent as? DataHolder.Answer)?.question?.id,
+    topicIds = when (val target = feed?.target) {
+        is Feed.AnswerTarget ->
+            target.question.boundTopicIds
+                .map(Long::toString)
+                .takeIf { it.isNotEmpty() }
+        is Feed.QuestionTarget ->
+            target.boundTopicIds
+                .map(Long::toString)
+                .takeIf { it.isNotEmpty() }
+        else -> null
+    },
+    isFollowing = rawContent.author?.isFollowing ?: feed?.target?.author?.isFollowing ?: false,
+    questionId = (rawContent as? DataHolder.Answer)?.question?.id
+        ?: (feed?.target as? Feed.AnswerTarget)?.question?.id,
     questionAuthorName = feed?.target?.questionAuthor?.name ?: when (rawContent) {
         is DataHolder.Answer -> rawContent.question.author?.name
         is DataHolder.Question -> rawContent.author.name
@@ -466,7 +490,7 @@ fun getFeedAdBlockReason(
         }
     }
     is DataHolder.Pin -> getLinkBasedAdReason(raw.contentHtml, settings)
-    else -> null
+    else -> getLinkBasedAdReason(content.content.orEmpty(), settings)
 }
 
 private fun getLinkBasedAdReason(

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/AndroidHomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/AndroidHomeFeedViewModel.kt
@@ -72,6 +72,12 @@ class AndroidHomeFeedViewModel :
                 val jojo = response.body<JsonObject>()
                 val data = jojo["data"]?.jsonArray ?: throw IllegalStateException("No data found in response")
 
+                lastPaging = if ("paging" in jojo) {
+                    ZhihuJson.decodeJson(jojo["paging"]!!)
+                } else {
+                    null
+                }
+
                 // 收集所有待显示的项目
                 val itemsToDisplay = mutableListOf<FeedDisplayItem>()
 
@@ -124,8 +130,10 @@ class AndroidHomeFeedViewModel :
                     }
                     if (isCurrentFilterGeneration(generation)) {
                         withContext(Dispatchers.Main) {
-                            addDisplayItems(filterResult.filteredItems)
-                            latestLoadedDisplayItems.value = filterResult.filteredItems
+                            if (isCurrentFilterGeneration(generation)) {
+                                addDisplayItems(filterResult.filteredItems)
+                                latestLoadedDisplayItems.value = filterResult.filteredItems
+                            }
                         }
                     }
                 } else {
@@ -151,22 +159,20 @@ class AndroidHomeFeedViewModel :
                             }
                             if (!isCurrentFilterGeneration(generation)) return@launch
                             withContext(Dispatchers.Main) {
-                                displayItems.replaceHomeFeedItemsWithFilteredResult(filterResult)
-                                latestLoadedDisplayItems.value = filterResult.filteredItems
+                                if (isCurrentFilterGeneration(generation)) {
+                                    displayItems.replaceHomeFeedItemsWithFilteredResult(filterResult)
+                                    latestLoadedDisplayItems.value = filterResult.filteredItems
+                                }
                             }
                         }
                     } else {
                         withContext(Dispatchers.Main) {
-                            displayItems.replaceHomeFeedItemsWithFilteredResult(foregroundResult)
-                            latestLoadedDisplayItems.value = foregroundResult.filteredItems
+                            if (isCurrentFilterGeneration(generation)) {
+                                displayItems.replaceHomeFeedItemsWithFilteredResult(foregroundResult)
+                                latestLoadedDisplayItems.value = foregroundResult.filteredItems
+                            }
                         }
                     }
-                }
-
-                lastPaging = if ("paging" in jojo) {
-                    ZhihuJson.decodeJson(jojo["paging"]!!)
-                } else {
-                    null
                 }
             }
         } catch (e: Exception) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/AndroidHomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/AndroidHomeFeedViewModel.kt
@@ -30,6 +30,7 @@ import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.Pin
 import com.github.zly2006.zhihu.navigation.resolveContent
 import com.github.zly2006.zhihu.viewmodel.ContentInteractionEnvironment
+import com.github.zly2006.zhihu.viewmodel.HomeFeedFilterResult
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.feed.BaseFeedViewModel
 import com.github.zly2006.zhihu.viewmodel.feed.HomeFeedInteractionViewModel
@@ -64,6 +65,7 @@ class AndroidHomeFeedViewModel :
         get() = "https://api.zhihu.com/topstory/recommend"
 
     public override suspend fun fetchFeeds(environment: PaginationEnvironment) {
+        val generation = filterGeneration
         try {
             val response = environment.mobileHomeFeedHttpClient().get(lastPaging?.next ?: initialUrl)
             if (response.status.isSuccess()) {
@@ -84,22 +86,81 @@ class AndroidHomeFeedViewModel :
                         }
                     }
 
-                // 前台先做本地已读过滤，再立即展示
-                val filterResult = environment.applyHomeFeedFilters(itemsToDisplay)
-                if (!filterResult.reverseBlock) {
-                    withContext(Dispatchers.Main) {
-                        addDisplayItems(filterResult.foregroundItems)
+                // 先执行不需要详情正文的过滤，避免推荐卡片被冷缓存详情请求阻塞。
+                val settings = environment.feedDisplaySettings()
+                val loadFullContent = settings.loadFullContentForRecommendationFiltering
+                // 前台过滤只能执行一次，因为它会把新展示的内容记录为已读。
+                val foregroundResult = try {
+                    environment.applyHomeFeedFilters(
+                        itemsToDisplay,
+                        loadFullContent = false,
+                    )
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: Exception) {
+                    HomeFeedFilterResult(
+                        foregroundItems = itemsToDisplay,
+                        filteredItems = itemsToDisplay,
+                        reverseBlock = settings.reverseBlock,
+                    )
+                }
+                if (!isCurrentFilterGeneration(generation)) return
+
+                if (foregroundResult.reverseBlock) {
+                    val result = if (loadFullContent) {
+                        try {
+                            environment.applyHomeFeedFilters(
+                                itemsToDisplay,
+                                loadFullContent = true,
+                                applyForegroundFilter = false,
+                            )
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (_: Exception) {
+                            foregroundResult
+                        }
+                    } else {
+                        foregroundResult
                     }
-                }
+                    if (isCurrentFilterGeneration(generation)) {
+                        withContext(Dispatchers.Main) {
+                            addDisplayItems(result.filteredItems)
+                            latestLoadedDisplayItems.value = result.filteredItems
+                        }
+                    }
+                } else {
+                    withContext(Dispatchers.Main) {
+                        if (isCurrentFilterGeneration(generation)) {
+                            addDisplayItems(foregroundResult.foregroundItems)
+                        }
+                    }
 
-                if (filterResult.reverseBlock) {
-                    addDisplayItems(filterResult.filteredItems)
-                }
-
-                // 移除被过滤的条目，并更新已保留条目的 raw 内容
-                withContext(Dispatchers.Main) {
-                    displayItems.replaceHomeFeedItemsWithFilteredResult(filterResult)
-                    latestLoadedDisplayItems.value = filterResult.filteredItems
+                    if (loadFullContent) {
+                        // 让分页保持响应，详情请求在后台完成。
+                        viewModelScope.launch {
+                            val result = try {
+                                environment.applyHomeFeedFilters(
+                                    itemsToDisplay,
+                                    loadFullContent = true,
+                                    applyForegroundFilter = false,
+                                )
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (_: Exception) {
+                                foregroundResult
+                            }
+                            if (!isCurrentFilterGeneration(generation)) return@launch
+                            withContext(Dispatchers.Main) {
+                                displayItems.replaceHomeFeedItemsWithFilteredResult(result)
+                                latestLoadedDisplayItems.value = result.filteredItems
+                            }
+                        }
+                    } else {
+                        withContext(Dispatchers.Main) {
+                            displayItems.replaceHomeFeedItemsWithFilteredResult(foregroundResult)
+                            latestLoadedDisplayItems.value = foregroundResult.filteredItems
+                        }
+                    }
                 }
 
                 lastPaging = if ("paging" in jojo) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/AndroidHomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/AndroidHomeFeedViewModel.kt
@@ -110,7 +110,7 @@ class AndroidHomeFeedViewModel :
                     val filterResult = if (loadFullContent) {
                         try {
                             environment.applyHomeFeedFilters(
-                                itemsToDisplay,
+                                foregroundResult.foregroundItems,
                                 loadFullContent = true,
                                 applyForegroundFilter = false,
                             )
@@ -140,7 +140,7 @@ class AndroidHomeFeedViewModel :
                         viewModelScope.launch {
                             val filterResult = try {
                                 environment.applyHomeFeedFilters(
-                                    itemsToDisplay,
+                                    foregroundResult.foregroundItems,
                                     loadFullContent = true,
                                     applyForegroundFilter = false,
                                 )

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/AndroidHomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/AndroidHomeFeedViewModel.kt
@@ -107,7 +107,7 @@ class AndroidHomeFeedViewModel :
                 if (!isCurrentFilterGeneration(generation)) return
 
                 if (foregroundResult.reverseBlock) {
-                    val result = if (loadFullContent) {
+                    val filterResult = if (loadFullContent) {
                         try {
                             environment.applyHomeFeedFilters(
                                 itemsToDisplay,
@@ -124,8 +124,8 @@ class AndroidHomeFeedViewModel :
                     }
                     if (isCurrentFilterGeneration(generation)) {
                         withContext(Dispatchers.Main) {
-                            addDisplayItems(result.filteredItems)
-                            latestLoadedDisplayItems.value = result.filteredItems
+                            addDisplayItems(filterResult.filteredItems)
+                            latestLoadedDisplayItems.value = filterResult.filteredItems
                         }
                     }
                 } else {
@@ -138,7 +138,7 @@ class AndroidHomeFeedViewModel :
                     if (loadFullContent) {
                         // 让分页保持响应，详情请求在后台完成。
                         viewModelScope.launch {
-                            val result = try {
+                            val filterResult = try {
                                 environment.applyHomeFeedFilters(
                                     itemsToDisplay,
                                     loadFullContent = true,
@@ -151,8 +151,8 @@ class AndroidHomeFeedViewModel :
                             }
                             if (!isCurrentFilterGeneration(generation)) return@launch
                             withContext(Dispatchers.Main) {
-                                displayItems.replaceHomeFeedItemsWithFilteredResult(result)
-                                latestLoadedDisplayItems.value = result.filteredItems
+                                displayItems.replaceHomeFeedItemsWithFilteredResult(filterResult)
+                                latestLoadedDisplayItems.value = filterResult.filteredItems
                             }
                         }
                     } else {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/MixedHomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/MixedHomeFeedViewModel.kt
@@ -43,6 +43,22 @@ class MixedHomeFeedViewModel :
         web.latestLoadedDisplayItems = this.latestLoadedDisplayItems
     }
 
+    override fun refresh(environment: PaginationEnvironment) {
+        android.invalidateFilterProcessing()
+        android.resetPaginationState()
+        web.invalidateFilterProcessing()
+        web.resetPaginationState()
+        super.refresh(environment)
+    }
+
+    override suspend fun pullToRefresh(environment: PaginationEnvironment) {
+        android.invalidateFilterProcessing()
+        android.resetPaginationState()
+        web.invalidateFilterProcessing()
+        web.resetPaginationState()
+        super.pullToRefresh(environment)
+    }
+
     override suspend fun fetchFeeds(environment: PaginationEnvironment) {
         coroutineScope {
             listOf(

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
@@ -176,13 +176,14 @@ class DesktopPaginationEnvironment(
         showFetchFailureMessage?.invoke("加载失败: ${error.message}")
     }
 
-    override fun feedDisplaySettings(): FeedDisplaySettings = FeedDisplaySettings(
-        qualityFilterMode = QualityFilterMode.OFF,
-        reverseBlock = settingsStore.toFeedFilterSettings().reverseBlock,
-        loadFullContentForRecommendationFiltering = settingsStore
-            .toFeedFilterSettings()
-            .loadFullContentForRecommendationFiltering,
-    )
+    override fun feedDisplaySettings(): FeedDisplaySettings {
+        val filterSettings = settingsStore.toFeedFilterSettings()
+        return FeedDisplaySettings(
+            qualityFilterMode = QualityFilterMode.OFF,
+            reverseBlock = filterSettings.reverseBlock,
+            loadFullContentForRecommendationFiltering = filterSettings.loadFullContentForRecommendationFiltering,
+        )
+    }
 
     override fun localHistory(): List<NavDestination> =
         historyStorage.history

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
@@ -179,6 +179,9 @@ class DesktopPaginationEnvironment(
     override fun feedDisplaySettings(): FeedDisplaySettings = FeedDisplaySettings(
         qualityFilterMode = QualityFilterMode.OFF,
         reverseBlock = settingsStore.toFeedFilterSettings().reverseBlock,
+        loadFullContentForRecommendationFiltering = settingsStore
+            .toFeedFilterSettings()
+            .loadFullContentForRecommendationFiltering,
     )
 
     override fun localHistory(): List<NavDestination> =
@@ -275,13 +278,21 @@ class DesktopPaginationEnvironment(
         recordContentOpenEvent(destination, questionId)
     }
 
-    override suspend fun applyHomeFeedFilters(items: List<FeedDisplayItem>): HomeFeedFilterResult {
+    override suspend fun applyHomeFeedFilters(
+        items: List<FeedDisplayItem>,
+        loadFullContent: Boolean,
+        applyForegroundFilter: Boolean,
+    ): HomeFeedFilterResult {
         val settings = settingsStore.toFeedFilterSettings()
-        val foregroundItems = ForegroundReadFilterPipeline(
-            settings = settings,
-            contentFilterManager = ContentFilterManager(contentFilterDb.contentFilterDao()),
-            blockedFeedRecordDao = contentFilterDb.blockedFeedRecordDao(),
-        ).filter(items)
+        val foregroundItems = if (applyForegroundFilter) {
+            ForegroundReadFilterPipeline(
+                settings = settings,
+                contentFilterManager = ContentFilterManager(contentFilterDb.contentFilterDao()),
+                blockedFeedRecordDao = contentFilterDb.blockedFeedRecordDao(),
+            ).filter(items)
+        } else {
+            items
+        }
         val filteredItems = FeedDisplayFilterPipeline(
             settings = settings,
             contentDetailProvider = ContentDetailProvider(::getOrFetchContentDetail),
@@ -300,7 +311,7 @@ class DesktopPaginationEnvironment(
             blockedFeedRecordDao = contentFilterDb.blockedFeedRecordDao(),
         ).filter(
             foregroundItems,
-            loadFullContent = settings.loadFullContentForRecommendationFiltering,
+            loadFullContent = loadFullContent,
         )
         return HomeFeedFilterResult(
             foregroundItems = foregroundItems,

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
@@ -298,7 +298,10 @@ class DesktopPaginationEnvironment(
                 ),
             ),
             blockedFeedRecordDao = contentFilterDb.blockedFeedRecordDao(),
-        ).filter(foregroundItems)
+        ).filter(
+            foregroundItems,
+            loadFullContent = settings.loadFullContentForRecommendationFiltering,
+        )
         return HomeFeedFilterResult(
             foregroundItems = foregroundItems,
             filteredItems = filteredItems,

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedContentFilterPipelineTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedContentFilterPipelineTest.kt
@@ -67,7 +67,11 @@ class FeedContentFilterPipelineTest {
                 filterable("by question author", authorId = "ok-user", questionAuthorId = "blocked-asker"),
                 filterable("blocked keyword title", authorId = "ok-user"),
                 filterable("nlp hit", authorId = "ok-user"),
-                filterable("topic", authorId = "ok-user", topicId = "blocked-topic"),
+                filterable(
+                    "topic",
+                    authorId = "ok-user",
+                    topicIds = listOf("blocked-topic"),
+                ),
             ),
         )
 
@@ -135,6 +139,7 @@ class FeedContentFilterPipelineTest {
         authorId: String,
         questionAuthorId: String? = null,
         topicId: String? = null,
+        topicIds: List<String>? = null,
     ): FilterableContent = FilterableContent(
         title = title,
         summary = null,
@@ -144,6 +149,7 @@ class FeedContentFilterPipelineTest {
         contentId = title,
         contentType = "article",
         raw = article(title, content, topicId),
+        topicIds = topicIds,
         questionAuthorName = questionAuthorId?.let { "asker" },
         questionAuthorId = questionAuthorId,
     )

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedDisplayFilterPipelineTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedDisplayFilterPipelineTest.kt
@@ -23,6 +23,7 @@ import com.github.zly2006.zhihu.data.DataHolder
 import com.github.zly2006.zhihu.data.Feed
 import com.github.zly2006.zhihu.data.FeedDisplayItem
 import com.github.zly2006.zhihu.data.Person
+import com.github.zly2006.zhihu.data.toDisplayItem
 import com.github.zly2006.zhihu.data.toFeedDisplayItemNavDestinationJson
 import com.github.zly2006.zhihu.data.zhihuContentDetailInclude
 import com.github.zly2006.zhihu.navigation.Article
@@ -61,6 +62,63 @@ class FeedDisplayFilterPipelineTest {
                 .observeAll()
                 .first()
                 .map { it.blockedReason },
+        )
+        fixture.database.close()
+    }
+
+    @Test
+    fun usesFeedSnapshotWithoutFetchingDetailsWhenFullContentIsDisabled() = runTest {
+        val fixture = fixture()
+        fixture.database.blockedKeywordDao().insertKeyword(BlockedKeyword(keyword = "blocked"))
+        var fetchCount = 0
+        var failureCount = 0
+        val snapshotContent = "<p>blocked body</p>"
+        val snapshotItem = CommonFeed(
+            target = Feed.ArticleTarget(
+                id = 1,
+                url = "https://www.zhihu.com/p/snapshot",
+                author = person(),
+                title = "snapshot",
+                content = snapshotContent,
+            ),
+        ).toDisplayItem(enableQualityFilter = false)
+        assertEquals(snapshotContent, snapshotItem.content)
+
+        val result = fixture
+            .pipeline(
+                detailProvider = ContentDetailProvider {
+                    fetchCount++
+                    article("detail")
+                },
+                onDetailFetchFailed = { failureCount++ },
+            ).filter(listOf(snapshotItem), loadFullContent = false)
+
+        assertEquals(emptyList(), result)
+        assertEquals(0, fetchCount)
+        assertEquals(0, failureCount)
+        fixture.database.close()
+    }
+
+    @Test
+    fun keepsQuestionIdFromFeedSnapshotWhenFullContentIsDisabled() = runTest {
+        val fixture = fixture()
+        fixture.database.blockedKeywordDao().insertKeyword(BlockedKeyword(keyword = "blocked"))
+        val snapshotItem = answerItem(questionId = 20, questionTitle = "snapshot")
+            .copy(content = "<p>blocked body</p>")
+
+        val result = fixture
+            .pipeline(detailProvider = ContentDetailProvider { error("详情不应被请求") })
+            .filter(listOf(snapshotItem), loadFullContent = false)
+
+        assertEquals(emptyList(), result)
+        assertEquals(
+            20L,
+            fixture.database
+                .blockedFeedRecordDao()
+                .observeAll()
+                .first()
+                .single()
+                .questionId,
         )
         fixture.database.close()
     }
@@ -395,6 +453,7 @@ class FeedDisplayFilterPipelineTest {
     ) {
         fun pipeline(
             detailProvider: ContentDetailProvider,
+            onDetailFetchFailed: (FeedDisplayItem) -> Unit = {},
         ): FeedDisplayFilterPipeline = FeedDisplayFilterPipeline(
             settings = settings,
             contentDetailProvider = detailProvider,
@@ -411,6 +470,7 @@ class FeedDisplayFilterPipelineTest {
                 ),
             ),
             blockedFeedRecordDao = database.blockedFeedRecordDao(),
+            onDetailFetchFailed = onDetailFetchFailed,
         )
     }
 

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedFilterSettingsTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedFilterSettingsTest.kt
@@ -26,6 +26,7 @@ class FeedFilterSettingsTest {
     fun readsFeedFilterSettingsFromSettingsStore() {
         val settings = mapBackedSettingsStore(
             "enableContentFilter" to false,
+            "loadFullContentForRecommendationFiltering" to true,
             "reverseBlock" to true,
             "filterFollowedUserContent" to true,
             "enableKeywordBlocking" to false,
@@ -41,6 +42,7 @@ class FeedFilterSettingsTest {
         ).toFeedFilterSettings()
 
         assertEquals(false, settings.enableContentFilter)
+        assertEquals(true, settings.loadFullContentForRecommendationFiltering)
         assertEquals(true, settings.reverseBlock)
         assertEquals(true, settings.filterFollowedUserContent)
         assertEquals(false, settings.enableKeywordBlocking)

--- a/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.native.kt
+++ b/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.native.kt
@@ -159,6 +159,9 @@ internal class NativePaginationEnvironment(
     override fun feedDisplaySettings(): FeedDisplaySettings = FeedDisplaySettings(
         qualityFilterMode = QualityFilterMode.OFF,
         reverseBlock = settingsStore.toFeedFilterSettings().reverseBlock,
+        loadFullContentForRecommendationFiltering = settingsStore
+            .toFeedFilterSettings()
+            .loadFullContentForRecommendationFiltering,
     )
 
     override fun localHistory(): List<NavDestination> = historyStorage.history
@@ -240,13 +243,21 @@ internal class NativePaginationEnvironment(
     override suspend fun recordOpenEvent(destination: Article, questionId: Long?) =
         recordContentOpenEvent(destination, questionId)
 
-    override suspend fun applyHomeFeedFilters(items: List<FeedDisplayItem>): HomeFeedFilterResult {
+    override suspend fun applyHomeFeedFilters(
+        items: List<FeedDisplayItem>,
+        loadFullContent: Boolean,
+        applyForegroundFilter: Boolean,
+    ): HomeFeedFilterResult {
         val settings = settingsStore.toFeedFilterSettings()
-        val foregroundItems = ForegroundReadFilterPipeline(
-            settings = settings,
-            contentFilterManager = ContentFilterManager(contentFilterDatabase.contentFilterDao()),
-            blockedFeedRecordDao = contentFilterDatabase.blockedFeedRecordDao(),
-        ).filter(items)
+        val foregroundItems = if (applyForegroundFilter) {
+            ForegroundReadFilterPipeline(
+                settings = settings,
+                contentFilterManager = ContentFilterManager(contentFilterDatabase.contentFilterDao()),
+                blockedFeedRecordDao = contentFilterDatabase.blockedFeedRecordDao(),
+            ).filter(items)
+        } else {
+            items
+        }
         val filteredItems = FeedDisplayFilterPipeline(
             settings = settings,
             contentDetailProvider = ContentDetailProvider(::getOrFetchContentDetail),
@@ -265,7 +276,7 @@ internal class NativePaginationEnvironment(
             blockedFeedRecordDao = contentFilterDatabase.blockedFeedRecordDao(),
         ).filter(
             foregroundItems,
-            loadFullContent = settings.loadFullContentForRecommendationFiltering,
+            loadFullContent = loadFullContent,
         )
         return HomeFeedFilterResult(
             foregroundItems = foregroundItems,

--- a/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.native.kt
+++ b/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.native.kt
@@ -156,13 +156,14 @@ internal class NativePaginationEnvironment(
 
     override fun logout() = clearAccountSession()
 
-    override fun feedDisplaySettings(): FeedDisplaySettings = FeedDisplaySettings(
-        qualityFilterMode = QualityFilterMode.OFF,
-        reverseBlock = settingsStore.toFeedFilterSettings().reverseBlock,
-        loadFullContentForRecommendationFiltering = settingsStore
-            .toFeedFilterSettings()
-            .loadFullContentForRecommendationFiltering,
-    )
+    override fun feedDisplaySettings(): FeedDisplaySettings {
+        val filterSettings = settingsStore.toFeedFilterSettings()
+        return FeedDisplaySettings(
+            qualityFilterMode = QualityFilterMode.OFF,
+            reverseBlock = filterSettings.reverseBlock,
+            loadFullContentForRecommendationFiltering = filterSettings.loadFullContentForRecommendationFiltering,
+        )
+    }
 
     override fun localHistory(): List<NavDestination> = historyStorage.history
 

--- a/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.native.kt
+++ b/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.native.kt
@@ -263,7 +263,10 @@ internal class NativePaginationEnvironment(
                 ),
             ),
             blockedFeedRecordDao = contentFilterDatabase.blockedFeedRecordDao(),
-        ).filter(foregroundItems)
+        ).filter(
+            foregroundItems,
+            loadFullContent = settings.loadFullContentForRecommendationFiltering,
+        )
         return HomeFeedFilterResult(
             foregroundItems = foregroundItems,
             filteredItems = filteredItems,


### PR DESCRIPTION
## 关联问题

- #568：希望优化首页加载时间
- #450：提升主页和评论的加载速度

以上问题仅作为背景关联，不自动关闭。

## 必填：AI 使用与验证材料

- [ ] 未使用 AI 编写、改写或批量生成代码
- [x] 使用了 AI 编写、改写或批量生成代码

若使用了 AI，本 PR 已经过人工代码审查、定向测试和真实设备验证。

- [x] 已上传测试截图
- [x] 已上传测试录屏

## 变更说明

- 推荐卡片先执行不依赖详情正文的轻量过滤并立即展示。
- 新增“加载完整正文进行推荐过滤”开关，默认关闭。
- 开启开关后，在卡片展示后后台加载完整正文并执行更严格的过滤。
- 后台过滤不重复执行会记录已读的前台过滤，并在刷新后丢弃过期结果。
- 详情过滤失败时保留已经展示的轻量过滤结果。

## 行为边界

- 不改变推荐接口的单页数量；当前接口实测忽略自定义 `limit`。
- 不增加评论预加载。
- 不修改废弃的 WebView 正文路径。
- 默认关闭完整正文过滤，保持现有默认请求和展示策略。

与 #515 的关系：本 PR 仅处理主页推荐信息流，不修改回答详情页 Pager 或预加载逻辑，也不依赖 #515；两者仅可能在 `PaginationViewModel.kt` 合并时存在文本重叠。

## 验证与取证

- `./gradlew assembleLiteDebug`
- `./gradlew :shared:ktlintFormat`
- `./gradlew :shared:jvmTest --tests com.github.zly2006.zhihu.viewmodel.filter.FeedDisplayFilterPipelineTest --tests com.github.zly2006.zhihu.viewmodel.filter.FeedContentFilterPipelineTest --tests com.github.zly2006.zhihu.viewmodel.feed.HomeFeedFilterResultMergeTest --tests com.github.zly2006.zhihu.viewmodel.filter.FeedFilterSettingsTest`
- `git diff --check`
- 独立只读静态复审：无阻塞问题。
- 真实 Android 手机 Lite Debug 验证：默认关闭；开启后观察到推荐卡片先展示，随后被完整正文过滤移除。

## 截图
<img width="1272" height="2800" alt="Screenshot_20260822_200452_com_github_zly2006_zhplus_lite_MainActivity_edit_286338369787748" src="https://github.com/user-attachments/assets/9f332d65-6a09-43c7-9a97-fab94759edc7" />



## 录屏

https://github.com/user-attachments/assets/f69e6d05-9c00-4dec-a80f-9450d57ef8d4




