### PR TITLE
fix: 将公式的 Inline/Display 判定对齐知乎官方

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
@@ -113,11 +113,21 @@ private fun MarkdownNode.collectPreviewImageUrls(): List<String> = when (this) {
 private fun List<HtmlNode>.convertNodesToBlocks(noNativeBlock: Boolean): List<MarkdownNode> {
     val blocks = mutableListOf<MarkdownNode>()
     var currentParagraph: Paragraph? = null
+    // 公式 img 的判定在预扫描与主循环各触发一次；按 Element 缓存避免重复解析。
+    // null（普通图片）也要缓存，不能用 getOrPut。
+    val equationNodeCache = HashMap<Element, MarkdownNode?>()
+
+    fun Element.cachedEquationNode(): MarkdownNode? =
+        if (equationNodeCache.containsKey(this)) {
+            equationNodeCache[this]
+        } else {
+            extractEquationNode().also { equationNodeCache[this] = it }
+        }
     val hasNextInlineContent = BooleanArray(size + 1)
     for (index in lastIndex downTo 0) {
         val node = this[index]
         hasNextInlineContent[index] = when {
-            node is Element && node.isBlockBoundary() -> false
+            node is Element && node.isBlockBoundary { it.cachedEquationNode() } -> false
             node.hasInlineContent() -> true
             else -> hasNextInlineContent[index + 1]
         }
@@ -144,7 +154,7 @@ private fun List<HtmlNode>.convertNodesToBlocks(noNativeBlock: Boolean): List<Ma
 
             is Element -> {
                 if (node.tagName().equals("img", ignoreCase = true)) {
-                    node.extractEquationNode()?.let { equation ->
+                    node.cachedEquationNode()?.let { equation ->
                         if (equation is MathBlock) {
                             blocks.add(equation)
                             currentParagraph = null
@@ -192,7 +202,9 @@ private fun String.trimInlineBoundary(
     else -> trim()
 }
 
-private fun Element.isBlockBoundary(): Boolean = when (tagName().lowercase()) {
+private fun Element.isBlockBoundary(
+    equationNode: (Element) -> MarkdownNode? = { it.extractEquationNode() },
+): Boolean = when (tagName().lowercase()) {
     "br",
     "h1",
     "h2",
@@ -210,7 +222,7 @@ private fun Element.isBlockBoundary(): Boolean = when (tagName().lowercase()) {
     "table",
     "div",
     -> true
-    "img" -> extractEquationNode() is MathBlock
+    "img" -> equationNode(this) is MathBlock
     "a" -> attr("class").contains("video-box")
     else -> false
 }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/markdown/MdAst.kt
@@ -143,9 +143,14 @@ private fun List<HtmlNode>.convertNodesToBlocks(noNativeBlock: Boolean): List<Ma
             }
 
             is Element -> {
-                if (node.tagName().equals("img", ignoreCase = true) && node.attr("eeimg") != "2") {
-                    extractEquationTex(node)?.let { formula ->
-                        paragraph().appendChild(InlineMath(formula))
+                if (node.tagName().equals("img", ignoreCase = true)) {
+                    node.extractEquationNode()?.let { equation ->
+                        if (equation is MathBlock) {
+                            blocks.add(equation)
+                            currentParagraph = null
+                        } else {
+                            paragraph().appendChild(equation)
+                        }
                         continue
                     }
                 }
@@ -205,7 +210,7 @@ private fun Element.isBlockBoundary(): Boolean = when (tagName().lowercase()) {
     "table",
     "div",
     -> true
-    "img" -> attr("eeimg") == "2"
+    "img" -> extractEquationNode() is MathBlock
     "a" -> attr("class").contains("video-box")
     else -> false
 }
@@ -230,12 +235,6 @@ private fun convertElementToBlock(
         } else if (element.childrenSize() == 1 && element.textWithOnlyWhitespace() && element.child(0).tagName() == "br") {
             // single <br> as paragraph, treat it as empty to avoid extra spacing
             emptyList()
-        } else if (element.childrenSize() == 1 && element.textWithOnlyWhitespace() && element.child(0).tagName() == "img" && element.child(0).attr("eeimg") == "1") {
-            // eeimg == "1" is inline math
-            val image = element.child(0)
-            extractEquationTex(image)
-                ?.let { formula -> listOf(MathBlock(formula)) }
-                ?: listOfNotNull(createBlockImage(image))
         } else {
             // 特殊处理<p>里面包含的MathBlock
             val list = mutableListOf<MarkdownNode>()
@@ -359,12 +358,6 @@ private fun createListBlock(
 }
 
 private fun createBlockImage(element: Element): MarkdownNode? {
-    if (element.attr("eeimg") == "2") {
-        extractEquationTex(element)?.let { formula ->
-            return MathBlock(formula)
-        }
-    }
-
     val src = extractImageUrl(element::attr) ?: return null
     val caption = element.attr("data-caption").ifBlank { element.attr("alt") }
     return Figure(
@@ -536,6 +529,118 @@ private fun extractEquationTex(imgElement: Element): String? = extractImageUrl(i
     ?.let { Url(it).parameters["tex"].orEmpty() }
     ?.takeIf { it.isNotBlank() }
 
+private fun Element.extractEquationNode(): MarkdownNode? = extractEquationTex(this)?.let { formula ->
+    if (attr("eeimg") == "2" || formula.zhihuEquationSemantics().isDisplay) {
+        MathBlock(formula)
+    } else {
+        InlineMath(formula)
+    }
+}
+
+internal data class ZhihuEquationSemantics(
+    val isDisplay: Boolean,
+    val hasEquationTag: Boolean,
+)
+
+/**
+ * Zhihu's MathJax promotes some `eeimg=1` equations to display math. A top-level row separator, a
+ * `\\tag` command, and a top-level align environment are display structures, while a row separator
+ * inside a matrix-like environment remains inline. The source is inspected only and is kept
+ * byte-for-byte on the resulting AST node.
+ */
+internal fun String.zhihuEquationSemantics(): ZhihuEquationSemantics {
+    var index = 0
+    var groupDepth = 0
+    var isDisplay = false
+    var hasEquationTag = false
+    val environments = mutableListOf<String>()
+
+    fun skipIgnorable(start: Int): Int {
+        var cursor = start
+        while (cursor < length) {
+            when {
+                this[cursor].isWhitespace() -> cursor++
+                this[cursor] == '%' -> {
+                    cursor++
+                    while (cursor < length && this[cursor] != '\n' && this[cursor] != '\r') cursor++
+                }
+                else -> return cursor
+            }
+        }
+        return cursor
+    }
+
+    fun readEnvironmentName(start: Int): Pair<String, Int>? {
+        var cursor = skipIgnorable(start)
+        if (cursor >= length || this[cursor] != '{') return null
+        val nameStart = ++cursor
+        while (cursor < length && this[cursor] != '}') {
+            if (this[cursor] == '{') return null
+            cursor++
+        }
+        if (cursor >= length || cursor == nameStart) return null
+        return substring(nameStart, cursor) to cursor + 1
+    }
+
+    while (index < length) {
+        when (this[index]) {
+            '%' -> index = skipIgnorable(index)
+            '{' -> {
+                groupDepth++
+                index++
+            }
+            '}' -> {
+                if (groupDepth > 0) groupDepth--
+                index++
+            }
+            '\\' -> {
+                if (index + 1 < length && this[index + 1] == '\\') {
+                    val afterSeparator = index + 2
+                    if (groupDepth == 0 && environments.isEmpty()) {
+                        isDisplay = true
+                    }
+                    index = afterSeparator
+                    continue
+                }
+
+                var commandEnd = index + 1
+                if (commandEnd < length && this[commandEnd].isLetter()) {
+                    while (commandEnd < length && this[commandEnd].isLetter()) commandEnd++
+                } else if (commandEnd < length) {
+                    commandEnd++
+                }
+                val command = substring(index + 1, commandEnd)
+                if (command == "tag") {
+                    isDisplay = true
+                    hasEquationTag = true
+                }
+                if (command == "begin" || command == "end") {
+                    readEnvironmentName(commandEnd)?.let { (environment, afterEnvironment) ->
+                        if (
+                            command == "begin" &&
+                            groupDepth == 0 &&
+                            environments.isEmpty() &&
+                            (environment == "align" || environment == "align*")
+                        ) {
+                            isDisplay = true
+                        }
+                        if (command == "begin") {
+                            environments.add(environment)
+                        } else if (environments.lastOrNull() == environment) {
+                            environments.removeAt(environments.lastIndex)
+                        }
+                        index = afterEnvironment
+                        continue
+                    }
+                }
+                index = commandEnd
+            }
+            else -> index++
+        }
+    }
+    return ZhihuEquationSemantics(isDisplay, hasEquationTag)
+}
+
 /**
  * 将一个 HTML 节点转换为 Markdown 内联节点列表
  *
@@ -636,13 +741,9 @@ private fun extractInlineNode(
         "br" -> listOf(HardLineBreak())
 
         "img" -> {
-            val formula = extractEquationTex(node)
-            if (formula != null) {
-                if (node.attr("eeimg") == "2") {
-                    listOf(MathBlock(formula))
-                } else {
-                    listOf(InlineMath(formula))
-                }
+            val equation = node.extractEquationNode()
+            if (equation != null) {
+                listOf(equation)
             } else {
                 extractImageUrl(node::attr)
                     ?.let { url ->

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/markdown/MdAstTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/markdown/MdAstTest.kt
@@ -35,6 +35,8 @@ import com.hrm.markdown.parser.ast.StrongEmphasis
 import com.hrm.markdown.parser.ast.Text
 import org.jsoup.Jsoup
 import java.io.File
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -168,7 +170,7 @@ class MdAstTest {
     }
 
     @Test
-    fun paragraph_with_only_inline_equation_with_space_should_convert_to_math_block() {
+    fun paragraph_with_only_inline_equation_with_space_should_stay_inline() {
         val document = htmlToMdAst(
             """
             <p>  <img eeimg="1" src="https://www.zhihu.com/equation?tex=E%3Dmc%5E2" alt="E=mc^2"/>  </p>
@@ -176,9 +178,153 @@ class MdAstTest {
         )
 
         assertEquals(1, document.children.size)
-        assertTrue(document.children.single() is MathBlock)
-        assertEquals("E=mc^2", (document.children.single() as MathBlock).literal)
+        assertTrue(document.children.single() is Paragraph)
+        assertEquals(
+            "E=mc^2",
+            document
+                .allNodes()
+                .filterIsInstance<InlineMath>()
+                .single()
+                .literal,
+        )
+        assertFalse(document.allNodes().any { it is MathBlock })
+    }
+
+    @Test
+    fun songby_terminal_row_separator_should_promote_eeimg1_and_preserve_tex() {
+        // Songby answer captured 2026-08-20: https://www.zhihu.com/question/7177834636/answer/1924167314070278930
+        val formula = "\\frac{1}{\\text D}e^t\\frac{1}{\\text D}e^tt\\\\"
+        val document = htmlToMdAst("<p>解为 ${equationImage(formula)} 由引理可知。</p>")
+
+        assertEquals(listOf(Paragraph::class, MathBlock::class, Paragraph::class), document.children.map { it::class })
+        assertEquals("解为 ", (document.children[0] as Paragraph).plainText())
+        assertEquals(formula, (document.children[1] as MathBlock).literal)
+        assertEquals(" 由引理可知。", (document.children[2] as Paragraph).plainText())
+    }
+
+    @Test
+    fun top_level_align_should_promote_eeimg1_to_math_block() {
+        val formula = "% leading comment\n  \\begin{align}a&=b\\\\c&=d\\end{align}\\\\"
+        val document = htmlToMdAst("<p>${equationImage(formula)}</p>")
+
+        assertEquals(
+            formula,
+            document.children
+                .filterIsInstance<MathBlock>()
+                .single()
+                .literal,
+        )
         assertFalse(document.allNodes().any { it is InlineMath })
+    }
+
+    @Test
+    fun tag_command_should_promote_eeimg1_and_preserve_tex() {
+        val formulas = listOf(
+            "x^2+y^2=1\\tag{2}",
+            "\\tan\\theta=\\mu\\tag1",
+            "\\vec{DE'}\\cdot\\vec{AC'}=0\\tag 3",
+            "x=1\\tag*{named}",
+            "\\boxed{x=1\\tag{4}}",
+        )
+
+        formulas.forEach { formula ->
+            val document = htmlToMdAst("<p>before ${equationImage(formula)} after</p>")
+
+            assertTrue(formula.zhihuEquationSemantics().hasEquationTag)
+            assertEquals(listOf(Paragraph::class, MathBlock::class, Paragraph::class), document.children.map { it::class })
+            assertEquals(formula, (document.children[1] as MathBlock).literal)
+        }
+    }
+
+    @Test
+    fun tag_inside_comment_should_not_promote_eeimg1() {
+        val formula = "% \\tag{1}\nx=1"
+        val document = htmlToMdAst("<p>before ${equationImage(formula)} after</p>")
+
+        assertFalse(formula.zhihuEquationSemantics().hasEquationTag)
+        assertEquals(
+            formula,
+            document
+                .allNodes()
+                .filterIsInstance<InlineMath>()
+                .single()
+                .literal,
+        )
+        assertFalse(document.allNodes().any { it is MathBlock })
+    }
+
+    @Test
+    fun nested_row_separators_should_not_promote_eeimg1() {
+        val formulas = listOf(
+            "\\begin{matrix}a\\\\b\\end{matrix}",
+            "\\begin{cases}a&x>0\\\\b&x\\leq0\\end{cases}",
+            "\\begin{aligned}a&=b\\\\c&=d\\end{aligned}",
+        )
+
+        formulas.forEach { formula ->
+            val document = htmlToMdAst("<p>before ${equationImage(formula)} after</p>")
+
+            assertEquals(
+                formula,
+                document
+                    .allNodes()
+                    .filterIsInstance<InlineMath>()
+                    .single()
+                    .literal,
+            )
+            assertFalse(document.allNodes().any { it is MathBlock }, formula)
+        }
+    }
+
+    @Test
+    fun nonterminal_top_level_row_separator_should_promote_eeimg1_and_preserve_tex() {
+        val formula = "a\\\\b"
+        val document = htmlToMdAst("<p>before ${equationImage(formula)} after</p>")
+
+        assertEquals(listOf(Paragraph::class, MathBlock::class, Paragraph::class), document.children.map { it::class })
+        assertEquals(formula, (document.children[1] as MathBlock).literal)
+    }
+
+    @Test
+    fun terminal_row_separator_should_allow_trailing_whitespace_and_comments() {
+        val formula = "\\frac12x^2\\ln x-\\frac34x^2\\\\   % Zhihu source comment\n\t"
+
+        listOf("1", "0").forEach { eeimg ->
+            val document = htmlToMdAst("<p>${equationImage(formula, eeimg)}</p>")
+
+            assertEquals(
+                formula,
+                document.children
+                    .filterIsInstance<MathBlock>()
+                    .single()
+                    .literal,
+            )
+        }
+    }
+
+    @Test
+    fun displaystyle_alone_should_not_promote_eeimg1() {
+        val formula = "\\displaystyle\\int_0^t te^t\\text dt"
+        val document = htmlToMdAst("<p>before ${equationImage(formula)} after</p>")
+
+        assertEquals(
+            formula,
+            document
+                .allNodes()
+                .filterIsInstance<InlineMath>()
+                .single()
+                .literal,
+        )
+        assertFalse(document.allNodes().any { it is MathBlock })
+    }
+
+    @Test
+    fun eeimg2_should_always_be_math_block() {
+        val formula = "x"
+        val document = htmlToMdAst("<p>before ${equationImage(formula, eeimg = "2")} after</p>")
+
+        assertEquals(listOf(Paragraph::class, MathBlock::class, Paragraph::class), document.children.map { it::class })
+        assertEquals(formula, (document.children[1] as MathBlock).literal)
     }
 
     @Test
@@ -306,10 +452,24 @@ class MdAstTest {
         val html = File("../app/src/androidTest/assets/issue-495-answer.html").readText()
         val document = htmlToMdAst(html)
         val nodes = document.allNodes()
+        val mathBlocks = nodes.filterIsInstance<MathBlock>()
 
         assertTrue(document.children.size > 100)
-        assertEquals(406, nodes.size)
-        assertEquals(148, nodes.count { it is MathBlock || it is InlineMath })
+        assertEquals(
+            // Two formula-only paragraphs use nonterminal top-level rows, so promoting them removes
+            // their former Paragraph wrappers while preserving the formula count and source.
+            listOf(407, 148, 67, 81, 53, 62),
+            listOf(
+                nodes.size,
+                nodes.count { it is MathBlock || it is InlineMath },
+                mathBlocks.size,
+                nodes.count { it is InlineMath },
+                mathBlocks.count { it.literal.endsWith("\\\\") },
+                mathBlocks.count { it.literal.zhihuEquationSemantics().hasEquationTag },
+            ),
+        )
+        // A numbered equation has display intent independently of a terminal row separator.
+        assertFalse(nodes.filterIsInstance<InlineMath>().any { it.literal.zhihuEquationSemantics().hasEquationTag })
     }
 
     @Test
@@ -351,6 +511,14 @@ class MdAstTest {
         is ContainerNode -> children.joinToString(separator = "") { it.plainText() }
         else -> ""
     }
+
+    private fun equationImage(
+        formula: String,
+        eeimg: String = "1",
+    ): String =
+        """<img class="ztext-math" eeimg="$eeimg" src="https://www.zhihu.com/equation?tex=${
+            URLEncoder.encode(formula, StandardCharsets.UTF_8.name())
+        }" alt="formula"/>"""
 }
 
 internal fun Node.allNodes(): List<Node> =


### PR DESCRIPTION
## 改动

- `eeimg=1` 公式不再一律按 Inline 处理：TeX 源码含顶层 `\\` 行分隔、`\tag` 命令或顶层 `align`/`align*` 环境时，与知乎官方 MathJax 一致地提升为 Display 公式。
- 判定只读取源码结构：注释内的命令、花括号分组或矩阵类环境内部的 `\\` 不触发提升；`eeimg=2` 行为不变。
- TeX 源码在 AST 节点上逐字节原样保留。

## 行为边界

- 不含上述结构的行内公式渲染完全不变。
- 被提升的公式独立成块并参与段落切分，与官方客户端展示一致。

## 验证

- `./gradlew ktlintCheck :shared:jvmTest :app:compileLiteDebugKotlin --no-configuration-cache`（新增 10 个判定用例：顶层/嵌套 `\\`、行尾空白与注释、`\tag`、注释内 `\tag` 反例、顶层 `align`、`\displaystyle` 反例、`eeimg=2` 不变式等）
- 真机 Pixel 9 Pro XL Lite Debug（与提椠 Display 公式 PR 叠加构建）对照 #697 链接回答，Inline/Display 分类与官方一致。
- 未跑全量 instrument test，交由 CI。
