### PR TITLE
feat: 提椠 Display 公式支持自动折行与 \tag

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,6 +45,14 @@ dependencyResolutionManagement {
                 includeGroupAndSubgroups("com.google")
             }
         }
+        maven("https://central.sonatype.com/repository/maven-snapshots/") {
+            content {
+                includeGroup("org.tiqian")
+            }
+            mavenContent {
+                snapshotsOnly()
+            }
+        }
         mavenCentral()
         maven("https://www.jitpack.io")
     }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -36,6 +36,9 @@ plugins {
 configurations.configureEach {
     resolutionStrategy {
         force("org.jetbrains.compose.material3:material3:1.10.0-alpha05")
+        // org.tiqian 走 Central snapshot 仓（维护者手动发布的 dev 通道，正式 alpha
+        // 发布后钉回固定版本）。短缓存让新发布的 snapshot 十分钟内可见。
+        cacheChangingModulesFor(10, "minutes")
     }
 }
 
@@ -156,8 +159,8 @@ kotlin {
         androidMain {
             kotlin.srcDir("src/tiqianMarkdownMain/kotlin")
             dependencies {
-                implementation("org.tiqian:markdown-compose:0.1.0-alpha05")
-                implementation("org.tiqian:math-font-stix:0.1.0-alpha05")
+                implementation("org.tiqian:markdown-compose:0.1.0-SNAPSHOT")
+                implementation("org.tiqian:math-font-stix:0.1.0-SNAPSHOT")
                 implementation("androidx.activity:activity-compose:1.13.0")
                 implementation("androidx.browser:browser:1.10.0")
                 implementation("androidx.core:core-ktx:1.19.0")
@@ -177,8 +180,8 @@ kotlin {
             kotlin.srcDir("src/tiqianMarkdownMain/kotlin")
         }
         jvmMain.dependencies {
-            implementation("org.tiqian:markdown-compose:0.1.0-alpha05")
-            implementation("org.tiqian:math-font-stix:0.1.0-alpha05")
+            implementation("org.tiqian:markdown-compose:0.1.0-SNAPSHOT")
+            implementation("org.tiqian:math-font-stix:0.1.0-SNAPSHOT")
             implementation("io.coil-kt.coil3:coil-network-ktor3:3.5.0")
             implementation("androidx.sqlite:sqlite-bundled:2.6.2")
             implementation(compose.desktop.currentOs)

--- a/shared/src/tiqianMarkdownMain/kotlin/com/github/zly2006/zhihu/markdown/TiqianMarkdownRenderer.kt
+++ b/shared/src/tiqianMarkdownMain/kotlin/com/github/zly2006/zhihu/markdown/TiqianMarkdownRenderer.kt
@@ -149,8 +149,8 @@ private fun rememberZhihuMarkdownStyle(
     blockSpacingScale: Float,
     mathFontFamilyId: String?,
 ): MarkdownStyle =
-    // Author-color adaptation (surface backdrop + harmonize toward the theme primary) is the
-    // Markdown Material 3 default; the app supplies nothing beyond its own scroll inset.
+    // App-side customization: body 字号/行高按阅读设置缩放、数学字体选择、块间距缩放，
+    // 以及 display 公式滚动宿主 inset。作者色适配沿用 Markdown Material 3 默认。
     rememberMarkdownStyle(
         defaultStyle = MarkdownStyle()
             .let { base ->

--- a/shared/src/tiqianMarkdownMain/kotlin/com/github/zly2006/zhihu/markdown/TiqianMarkdownRenderer.kt
+++ b/shared/src/tiqianMarkdownMain/kotlin/com/github/zly2006/zhihu/markdown/TiqianMarkdownRenderer.kt
@@ -149,6 +149,8 @@ private fun rememberZhihuMarkdownStyle(
     blockSpacingScale: Float,
     mathFontFamilyId: String?,
 ): MarkdownStyle =
+    // Author-color adaptation (surface backdrop + harmonize toward the theme primary) is the
+    // Markdown Material 3 default; the app supplies nothing beyond its own scroll inset.
     rememberMarkdownStyle(
         defaultStyle = MarkdownStyle()
             .let { base ->
@@ -163,6 +165,7 @@ private fun rememberZhihuMarkdownStyle(
                     math = base.math.copy(
                         font = mathFontFamilyId?.let(MarkdownMathFont::Packaged)
                             ?: MarkdownMathFont.LeteSansMath,
+                        displayScrollHostInset = 16.dp,
                     ),
                 )
             }.withBlockSpacingScale(blockSpacingScale),


### PR DESCRIPTION
## 改动

- 提椠渲染开启时，Display 公式支持超宽自动折行（关系符 / 标点 / 双目运算符分层断点，续行右对齐）与 `\tag` 编号渲染；配合 #698 的判定修正，解决 #697 中公式显示为源码的问题。
- `org.tiqian` 依赖切换到 Central SNAPSHOT 通道：由维护者手动发布的 dev 通道，正式 alpha 发布后钉回固定版本；为 snapshot 设置 10 分钟解析缓存，便于跟进渲染修复。
- Display 公式滚动宿主增加 16dp inset。

## 行为边界

- 未开启提椠渲染器的正文路径不受影响。
- 折行放不下的超长子式仍可横向滚动。
- 空 `\tag{}` 按源码忠实渲染为空括号，与知乎官方一致（已人工比对）。

## 验证

- `./gradlew ktlintCheck :shared:jvmTest :app:compileLiteDebugKotlin --no-configuration-cache`
- `:app:assembleLiteDebug` 全量构建，org.tiqian 依赖完全从 Central snapshot 仓远端解析。
- 真机 Pixel 9 Pro XL（与 #698 叠加构建）打开 #697 链接回答：Display 公式折行、`\tag` 与行内公式渲染正常。
- 未跑全量 instrument test，交由 CI。

Closes #697
