### PR TITLE
feat: 按问题顺序连续朗读并跳过已读回答

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayer.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayer.kt
@@ -592,8 +592,7 @@ object ReadingQueueSourceRegistry {
             .getAlreadyOpenedContentIds(
                 database = getContentFilterDatabase(),
                 content = answerIds.map { answerId -> ContentType.ANSWER to answerId.toString() },
-            )
-            .mapNotNull { key -> key.substringAfter(':', "").toLongOrNull() }
+            ).mapNotNull { key -> key.substringAfter(':', "").toLongOrNull() }
             .toSet()
     }
 
@@ -633,15 +632,15 @@ object ReadingQueueSourceRegistry {
         } else {
             source
                 .drop(currentIndex)
-                .take(safeLimit)
+                // Read past the requested window so skipping opened answers can still fill it.
+                .take(MAX_READING_QUEUE_SIZE)
                 .map { item -> if (item.key == current.key) current else item }
         }
 
         val candidateAnswerIds = buildList {
             addAll(sourceQueue.drop(1))
             addAll(fallbackAfterCurrent)
-        }
-            .asSequence()
+        }.asSequence()
             .filter { it.contentType == ReadingContentType.Answer }
             .map(ReadingQueueItem::id)
             .distinct()
@@ -662,8 +661,7 @@ object ReadingQueueSourceRegistry {
             .distinctBy(ReadingQueueItem::key)
             .filter { item ->
                 item.contentType != ReadingContentType.Answer || item.id !in openedAnswerIds
-            }
-            .toList()
+            }.toList()
         if (source == null || currentIndex < 0) {
             return (filteredSourceQueue + filteredFallbackQueue)
                 .distinctBy(ReadingQueueItem::key)

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayer.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayer.kt
@@ -27,12 +27,15 @@ import com.github.zly2006.zhihu.data.Feed
 import com.github.zly2006.zhihu.data.FeedDisplayItem
 import com.github.zly2006.zhihu.data.navDestination
 import com.github.zly2006.zhihu.data.target
+import com.github.zly2006.zhihu.filter.ContentOpenEventSupport
 import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.ArticleType
 import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.navigation.Pin
 import com.github.zly2006.zhihu.navigation.Question
 import com.github.zly2006.zhihu.platform.SettingsStore
+import com.github.zly2006.zhihu.viewmodel.filter.ContentType
+import com.github.zly2006.zhihu.viewmodel.filter.getContentFilterDatabase
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.number
 import kotlinx.datetime.toLocalDateTime
@@ -583,6 +586,17 @@ fun splitReadingSpeechIntoChunks(
 object ReadingQueueSourceRegistry {
     private val sources = LinkedHashMap<String, List<ReadingQueueItem>>()
 
+    private suspend fun lookupOpenedAnswerIds(answerIds: List<Long>): Set<Long> {
+        if (answerIds.isEmpty()) return emptySet()
+        return ContentOpenEventSupport
+            .getAlreadyOpenedContentIds(
+                database = getContentFilterDatabase(),
+                content = answerIds.map { answerId -> ContentType.ANSWER to answerId.toString() },
+            )
+            .mapNotNull { key -> key.substringAfter(':', "").toLongOrNull() }
+            .toSet()
+    }
+
     fun register(
         sourceId: String,
         items: List<ReadingQueueItem>,
@@ -604,39 +618,66 @@ object ReadingQueueSourceRegistry {
         }
     }
 
-    fun queueStartingAt(
+    suspend fun queueStartingAt(
         current: ReadingQueueItem,
         sourceId: String?,
         limit: Int,
         fallbackAfterCurrent: List<ReadingQueueItem> = emptyList(),
+        openedAnswerIdsProvider: suspend (List<Long>) -> Set<Long> = ::lookupOpenedAnswerIds,
     ): List<ReadingQueueItem> {
         val safeLimit = limit.coerceIn(1, MAX_READING_QUEUE_SIZE)
         val source = sourceId?.let(sources::get)
         val currentIndex = source?.indexOfFirst { it.key == current.key } ?: -1
+        val sourceQueue = if (source == null || currentIndex < 0) {
+            listOf(current)
+        } else {
+            source
+                .drop(currentIndex)
+                .take(safeLimit)
+                .map { item -> if (item.key == current.key) current else item }
+        }
+
+        val candidateAnswerIds = buildList {
+            addAll(sourceQueue.drop(1))
+            addAll(fallbackAfterCurrent)
+        }
+            .asSequence()
+            .filter { it.contentType == ReadingContentType.Answer }
+            .map(ReadingQueueItem::id)
+            .distinct()
+            .toList()
+        val openedAnswerIds = openedAnswerIdsProvider(candidateAnswerIds)
+
+        val filteredSourceQueue = sourceQueue.filter { item ->
+            item.key == current.key ||
+                item.contentType != ReadingContentType.Answer ||
+                item.id !in openedAnswerIds
+        }
+        if (fallbackAfterCurrent.isEmpty()) {
+            return filteredSourceQueue.take(safeLimit)
+        }
+
+        val filteredFallbackQueue = fallbackAfterCurrent
+            .asSequence()
+            .distinctBy(ReadingQueueItem::key)
+            .filter { item ->
+                item.contentType != ReadingContentType.Answer || item.id !in openedAnswerIds
+            }
+            .toList()
         if (source == null || currentIndex < 0) {
-            return (listOf(current) + fallbackAfterCurrent)
+            return (filteredSourceQueue + filteredFallbackQueue)
                 .distinctBy(ReadingQueueItem::key)
                 .take(safeLimit)
         }
-
-        val sourceQueue = source
-            .drop(currentIndex)
-            .take(safeLimit)
-            .map { item -> if (item.key == current.key) current else item }
-        if (fallbackAfterCurrent.isEmpty()) return sourceQueue
-
-        val sourceContinuationKeys = sourceQueue.drop(1).map(ReadingQueueItem::key)
-        val fallbackKeys = fallbackAfterCurrent
-            .distinctBy(ReadingQueueItem::key)
-            .map(ReadingQueueItem::key)
+        val sourceContinuationKeys = filteredSourceQueue.drop(1).map(ReadingQueueItem::key)
         if (
             sourceContinuationKeys.isNotEmpty() &&
-            fallbackKeys.take(sourceContinuationKeys.size) != sourceContinuationKeys
+            filteredFallbackQueue.take(sourceContinuationKeys.size).map(ReadingQueueItem::key) != sourceContinuationKeys
         ) {
-            return sourceQueue
+            return filteredSourceQueue.take(safeLimit)
         }
 
-        return (sourceQueue + fallbackAfterCurrent)
+        return (filteredSourceQueue + filteredFallbackQueue)
             .distinctBy(ReadingQueueItem::key)
             .take(safeLimit)
     }

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PinScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PinScreen.kt
@@ -307,18 +307,20 @@ fun PinScreen(
                             if (isCurrentReadingItem) {
                                 readingPlayer.togglePlayPause()
                             } else {
-                                readingPlayer.start(
-                                    ReadingStartRequest(
-                                        queue = ReadingQueueSourceRegistry.queueStartingAt(
-                                            current = item,
+                                coroutineScope.launch {
+                                    readingPlayer.start(
+                                        ReadingStartRequest(
+                                            queue = ReadingQueueSourceRegistry.queueStartingAt(
+                                                current = item,
+                                                sourceId = pin.readingQueueSourceId,
+                                                limit = readingPreferences.queueLimit,
+                                            ),
+                                            preferences = readingPreferences,
                                             sourceId = pin.readingQueueSourceId,
-                                            limit = readingPreferences.queueLimit,
+                                            playbackSpeed = readingPlaybackSpeed,
                                         ),
-                                        preferences = readingPreferences,
-                                        sourceId = pin.readingQueueSourceId,
-                                        playbackSpeed = readingPlaybackSpeed,
-                                    ),
-                                )
+                                    )
+                                }
                             }
                         },
                         enabled = readingPlayer.isSupported && readingItem?.hasReadableFields(readingPreferences) == true,

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/article/ArticleActionsMenu.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/article/ArticleActionsMenu.kt
@@ -256,14 +256,17 @@ fun ArticleActionsMenu(
                         readingPlayer.stop()
                     } else {
                         coroutineScope.launch {
+                            // Home feed mixes unrelated content; the question navigator owns answer order.
+                            val useQuestionAnswerOrder = article.type == ArticleType.Answer &&
+                                article.readingQueueSourceId?.startsWith("home:") == true
                             val originQueue = ReadingQueueSourceRegistry.queueStartingAt(
                                 current = readingItem,
-                                sourceId = article.readingQueueSourceId,
+                                sourceId = article.readingQueueSourceId.takeUnless { useQuestionAnswerOrder },
                                 limit = readingPreferences.queueLimit,
                             )
                             val queue = if (
                                 article.type == ArticleType.Answer &&
-                                originQueue.size < readingPreferences.queueLimit &&
+                                (useQuestionAnswerOrder || originQueue.size < readingPreferences.queueLimit) &&
                                 readingPreferences.queueLimit > 1
                             ) {
                                 val fallbackAfterCurrent = try {
@@ -298,7 +301,7 @@ fun ArticleActionsMenu(
                                 }
                                 ReadingQueueSourceRegistry.queueStartingAt(
                                     current = readingItem,
-                                    sourceId = article.readingQueueSourceId,
+                                    sourceId = article.readingQueueSourceId.takeUnless { useQuestionAnswerOrder },
                                     limit = readingPreferences.queueLimit,
                                     fallbackAfterCurrent = fallbackAfterCurrent,
                                 )

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayerTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayerTest.kt
@@ -278,6 +278,12 @@ class ReadingPlayerTest {
         assertEquals("<p>正文</p>", queue.first().bodyHtml)
     }
 
+    /**
+     * Contract: https://github.com/zly2006/zhihu-plus-plus/issues/705
+     * Introduced by: https://github.com/zly2006/zhihu-plus-plus/pull/708
+     * Target state: already-opened answers are omitted while the remaining question answers keep order.
+     * Verifies the queue's observable item order and current-item body preservation.
+     */
     @Test
     fun queueSkipsOpenedAnswersWhileKeepingQuestionOrder() = runTest {
         val items = (1L..6L).map { id ->
@@ -301,6 +307,12 @@ class ReadingPlayerTest {
         assertEquals("<p>正文</p>", queue.first().bodyHtml)
     }
 
+    /**
+     * Contract: https://github.com/zly2006/zhihu-plus-plus/issues/705
+     * Introduced by: https://github.com/zly2006/zhihu-plus-plus/pull/708
+     * Target state: skipping opened answers still fills the configured queue limit from later answers.
+     * Verifies that users receive the requested number of unread answers instead of a shortened queue.
+     */
     @Test
     fun queueFillsLimitAfterSkippingOpenedAnswers() = runTest {
         val items = (1L..8L).map { id ->

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayerTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayerTest.kt
@@ -302,6 +302,26 @@ class ReadingPlayerTest {
     }
 
     @Test
+    fun queueFillsLimitAfterSkippingOpenedAnswers() = runTest {
+        val items = (1L..8L).map { id ->
+            ReadingQueueItem(
+                contentType = ReadingContentType.Answer,
+                id = id,
+            )
+        }
+        ReadingQueueSourceRegistry.register("question:1", items)
+
+        val queue = ReadingQueueSourceRegistry.queueStartingAt(
+            current = items.first(),
+            sourceId = "question:1",
+            limit = 3,
+            openedAnswerIdsProvider = { ids -> ids.filter { it in setOf(2L, 3L) }.toSet() },
+        )
+
+        assertEquals(listOf(1L, 4L, 5L), queue.map(ReadingQueueItem::id))
+    }
+
+    @Test
     fun explicitOriginWinsWhenTheSameItemAppearsInMultipleSources() = runTest {
         val current = ReadingQueueItem(ReadingContentType.Answer, id = 1)
         val sourceA = listOf(current, ReadingQueueItem(ReadingContentType.Answer, id = 2))

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayerTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayerTest.kt
@@ -18,12 +18,12 @@
 package com.github.zly2006.zhihu.reading
 
 import com.github.zly2006.zhihu.platform.SettingsStore
+import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlinx.coroutines.test.runTest
 
 class ReadingPlayerTest {
     @AfterTest

--- a/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayerTest.kt
+++ b/shared/src/commonTest/kotlin/com/github/zly2006/zhihu/reading/ReadingPlayerTest.kt
@@ -23,6 +23,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
 
 class ReadingPlayerTest {
     @AfterTest
@@ -256,7 +257,7 @@ class ReadingPlayerTest {
     }
 
     @Test
-    fun queueStartsAtCurrentItemAndNeverExceedsLimit() {
+    fun queueStartsAtCurrentItemAndNeverExceedsLimit() = runTest {
         val items = (1L..6L).map { id ->
             ReadingQueueItem(
                 contentType = ReadingContentType.Answer,
@@ -278,7 +279,30 @@ class ReadingPlayerTest {
     }
 
     @Test
-    fun explicitOriginWinsWhenTheSameItemAppearsInMultipleSources() {
+    fun queueSkipsOpenedAnswersWhileKeepingQuestionOrder() = runTest {
+        val items = (1L..6L).map { id ->
+            ReadingQueueItem(
+                contentType = ReadingContentType.Answer,
+                id = id,
+                title = "回答$id",
+            )
+        }
+        ReadingQueueSourceRegistry.register("question:1", items)
+        val current = items[1].copy(bodyHtml = "<p>正文</p>")
+
+        val queue = ReadingQueueSourceRegistry.queueStartingAt(
+            current = current,
+            sourceId = "question:1",
+            limit = 5,
+            openedAnswerIdsProvider = { ids -> ids.filter { it in setOf(3L, 5L) }.toSet() },
+        )
+
+        assertEquals(listOf(2L, 4L, 6L), queue.map(ReadingQueueItem::id))
+        assertEquals("<p>正文</p>", queue.first().bodyHtml)
+    }
+
+    @Test
+    fun explicitOriginWinsWhenTheSameItemAppearsInMultipleSources() = runTest {
         val current = ReadingQueueItem(ReadingContentType.Answer, id = 1)
         val sourceA = listOf(current, ReadingQueueItem(ReadingContentType.Answer, id = 2))
         val sourceB = listOf(current, ReadingQueueItem(ReadingContentType.Answer, id = 3))
@@ -295,7 +319,7 @@ class ReadingPlayerTest {
     }
 
     @Test
-    fun directNavigationDoesNotReuseAnOldOrigin() {
+    fun directNavigationDoesNotReuseAnOldOrigin() = runTest {
         val current = ReadingQueueItem(ReadingContentType.Answer, id = 1)
         ReadingQueueSourceRegistry.register(
             "source:a",
@@ -311,7 +335,7 @@ class ReadingPlayerTest {
     }
 
     @Test
-    fun answerSwitchedBeyondItsOriginFallsBackToQuestionOrder() {
+    fun answerSwitchedBeyondItsOriginFallsBackToQuestionOrder() = runTest {
         ReadingQueueSourceRegistry.register(
             "home:feed",
             listOf(
@@ -342,7 +366,7 @@ class ReadingPlayerTest {
     }
 
     @Test
-    fun matchingOriginStillWinsOverQuestionFallback() {
+    fun matchingOriginStillWinsOverQuestionFallback() = runTest {
         val current = ReadingQueueItem(ReadingContentType.Answer, id = 1)
         ReadingQueueSourceRegistry.register(
             "home:feed",
@@ -362,7 +386,7 @@ class ReadingPlayerTest {
     }
 
     @Test
-    fun exhaustedMatchingOriginFallsBackToQuestionOrder() {
+    fun exhaustedMatchingOriginFallsBackToQuestionOrder() = runTest {
         val current = ReadingQueueItem(ReadingContentType.Answer, id = 1)
         ReadingQueueSourceRegistry.register("question:1:answers:default", listOf(current))
 
@@ -380,7 +404,7 @@ class ReadingPlayerTest {
     }
 
     @Test
-    fun matchingQuestionOriginExtendsAfterItsLoadedItems() {
+    fun matchingQuestionOriginExtendsAfterItsLoadedItems() = runTest {
         val current = ReadingQueueItem(ReadingContentType.Answer, id = 1)
         val loadedNext = ReadingQueueItem(ReadingContentType.Answer, id = 11)
         ReadingQueueSourceRegistry.register(
@@ -403,7 +427,7 @@ class ReadingPlayerTest {
     }
 
     @Test
-    fun partiallyMatchingFallbackDoesNotMixDivergingOrderIntoOrigin() {
+    fun partiallyMatchingFallbackDoesNotMixDivergingOrderIntoOrigin() = runTest {
         val current = ReadingQueueItem(ReadingContentType.Answer, id = 1)
         val firstLoaded = ReadingQueueItem(ReadingContentType.Answer, id = 11)
         val secondLoaded = ReadingQueueItem(ReadingContentType.Answer, id = 12)


### PR DESCRIPTION
## 改动

- 连续朗读回答时不再沿用首页混合信息流顺序，改由问题回答导航器提供同一问题下的回答顺序。
- 队列会查询 Room 已读记录并跳过已打开回答；过滤后继续向后取回答，仍尽量填满用户配置的队列长度。
- 当前回答始终保留在队首，且保留已加载的正文内容；问题页、收藏夹等非首页来源仍维持原来源队列语义。
- `PinScreen` 与文章操作菜单改为在协程中构建挂起队列。
- 已合并当前 `master`（`c5b36e7b9`），合并提交为 `92bfa6224`，包含最新 instrument test 治理规范与测试要求。

Resolves #705

## 测试契约与红转绿证据

| 测试 | 修复前（`c5b36e7b9`） | 修复后（`f43b2f079`） |
| --- | --- | --- |
| `queueSkipsOpenedAnswersWhileKeepingQuestionOrder` | 临时父版本工作树运行后 `AssertionError`，旧实现仍返回已读回答，失败于 `ReadingPlayerTest.kt:298` | 通过；已读回答被跳过，剩余回答顺序与当前正文保持正确 |
| `queueFillsLimitAfterSkippingOpenedAnswers` | 临时父版本工作树运行后 `AssertionError`，旧实现只截取过滤前窗口，失败于 `ReadingPlayerTest.kt:318` | 通过；过滤后会继续向后补足到队列上限 |

修复前命令：

```bash
./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process :shared:jvmTest --tests com.github.zly2006.zhihu.reading.ReadingPlayerTest
```

终态：`29 tests completed, 2 failed`，且只有上表两个新增契约断言失败。

修复后命令：

```bash
./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process :shared:jvmTest \
  --tests com.github.zly2006.zhihu.reading.ReadingPlayerTest \
  --tests com.github.zly2006.zhihu.navigation.QuestionAnswerNavigatorTest
```

终态：`BUILD SUCCESSFUL in 4m 15s`。原有队列测试仅因生产接口变为挂起函数而改用 `runTest`，行为断言未变并全部通过。

## 其他验证

- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process assembleLiteDebug`：`BUILD SUCCESSFUL in 34m 33s`
- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process ktlintCheck`：`BUILD SUCCESSFUL in 16m 15s`
- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process :shared:runKtlintCheckOverCommonTestSourceSet`：`BUILD SUCCESSFUL in 1m 12s`
- `git diff --check`：通过
- 本 PR 没有新增或修改 Android instrument test；按最新治理规范未在本地运行完整 instrument suite，交由 GitHub CI 验收。

## GitHub CI 终态

- PR 708 合并检查 run `33298503205`：Build、KtLint、Unit Tests、Mock Instrumented Tests 及 5 个 shard 全部通过。Shard 3 首次因 AVD 状态栏像素采样抖动失败，重跑 job `99242956471` 后通过，未修改产品代码绕过该回归测试。
- PR 708 当前 `mergeStateStatus=CLEAN`、`mergeable=MERGEABLE`。

无行为断言、默认跳过的 Markdown AVD 校准测试按治理规范放在独立清理分支处理，不混入本功能 PR。
