### PR TITLE
fix: 修复收藏页 FAB 被底栏遮挡

### DIFF
--- a/.agents/skills/zhihu-parallel-pr-workflow/SKILL.md
+++ b/.agents/skills/zhihu-parallel-pr-workflow/SKILL.md
@@ -9,7 +9,12 @@ description: Coordinate Zhihu++ issue and PR implementation through subagents wi
 
 This workflow is only for work with real parallel value: multiple independent issues or PRs, an explicit user request for subagents/delegation, or independently executable scopes that materially reduce wall-clock time. Do not trigger it merely because a task references one GitHub issue or will end in one PR. A single narrow issue should stay with the main agent, including implementation, validation, screenshots, and PR publication, unless the user explicitly asks to delegate it.
 
-Mentioning this skill is not authorization to use subagents. One product feature and its small accompanying workflow-documentation change remain one main-agent task unless the user explicitly requests delegation.
+When the user explicitly requests implementing the latest independent issues in parallel, and
+those issues contain owner-authored (`to agent:`) directions, parallel delegation is the
+default: assign one complete issue/capability to each worker and keep the main agent focused on
+coordination, review, and final acceptance. This default does not relax any trust, version,
+reproduction, validation, or publication gates below. Mentioning this skill alone is not
+authorization to use subagents.
 
 Example: adding one menu action and adjusting that menu's sheet behavior is one bounded UI change. Spawning a worker only adds handoff and review overhead, so the main agent should complete it directly.
 

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CollectionBrowseScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CollectionBrowseScreen.kt
@@ -19,6 +19,7 @@ package com.github.zly2006.zhihu.ui
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -86,6 +87,7 @@ import kotlin.random.Random
 @Composable
 fun CollectionBrowseScreen(
     urlToken: String?,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
     showBackButton: Boolean = true,
     scrollToTopTrigger: Int = 0,
     isActive: Boolean = true,
@@ -194,7 +196,9 @@ fun CollectionBrowseScreen(
     }
 
     Scaffold(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding),
         topBar = {
             TopAppBar(
                 title = {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CollectionScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/CollectionScreen.kt
@@ -18,6 +18,7 @@
 package com.github.zly2006.zhihu.ui
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -67,6 +68,7 @@ import kotlinx.coroutines.launch
 fun CollectionScreen(
     urlToken: String?,
     testCollections: List<Collection>? = null,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
     showBackButton: Boolean = true,
     isActive: Boolean = true,
 ) {
@@ -90,7 +92,9 @@ fun CollectionScreen(
     }
 
     Scaffold(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding),
         topBar = {
             TopAppBar(
                 title = {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/ZhihuMain.kt
@@ -612,7 +612,10 @@ fun ZhihuMain(
                     }
                     composable<Collections> { navEntry ->
                         val data: Collections = navEntry.toRoute()
-                        CollectionScreen(data.userToken)
+                        CollectionScreen(
+                            urlToken = data.userToken,
+                            contentPadding = innerPadding,
+                        )
                     }
                     composable<CollectionContent> { navEntry ->
                         val content: CollectionContent = navEntry.toRoute()
@@ -794,6 +797,7 @@ private fun MainTabsPager(
             )
             MainTabPage.MyCollectionsPage -> MyCollectionsTopLevelPage(
                 scrollToTopTrigger = scrollToTopTrigger,
+                innerPadding = innerPadding,
                 collectionDirectBrowseEnabled = collectionDirectBrowseEnabled,
                 isActive = pagerState.currentPage == pageIndex,
             )
@@ -805,6 +809,7 @@ private fun MainTabsPager(
 @Composable
 private fun MyCollectionsTopLevelPage(
     scrollToTopTrigger: Int,
+    innerPadding: PaddingValues,
     collectionDirectBrowseEnabled: Boolean,
     isActive: Boolean,
 ) {
@@ -812,6 +817,7 @@ private fun MyCollectionsTopLevelPage(
     if (collectionDirectBrowseEnabled) {
         CollectionBrowseScreen(
             urlToken = account.urlToken,
+            contentPadding = innerPadding,
             showBackButton = false,
             scrollToTopTrigger = scrollToTopTrigger,
             isActive = isActive,
@@ -819,6 +825,7 @@ private fun MyCollectionsTopLevelPage(
     } else {
         CollectionScreen(
             urlToken = account.urlToken,
+            contentPadding = innerPadding,
             showBackButton = false,
             isActive = isActive,
         )


### PR DESCRIPTION
## 改动
- 收藏页和收藏直达页都显式吃主壳 `innerPadding`，避免 FAB 被底栏遮挡。
- 修正 `zhihu-parallel-pr-workflow` 里的并行默认说明和 `to agent` 表述。

## 验证
- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process :shared:compileCommonMainKotlinMetadata`
- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process ktlintFormat`
- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process assembleLiteDebug`（通过）
- 使用远端 `$off-android-avd-ci-debug` AVD（API 35）安装并运行 Lite Debug APK，进入“我的收藏夹”验证 FAB 未被底部区域遮挡。

截图来自实际运行的 #710 Lite Debug APK + 远端 `off-ci-api35-1` AVD；先将“收藏夹”加入首页底栏，再从首页底栏点击进入：

![首页底栏进入收藏夹后的 FAB](https://raw.githubusercontent.com/zly2006/agent-image/main/zhihu-plus-plus/pr-710/favorites-fab-bottomnav.png)

Resolves #707
