### PR TITLE
fix: 恢复首页前台过滤即时展示并并行加载详情

### DIFF
--- a/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
+++ b/shared/src/androidMain/kotlin/com/github/zly2006/zhihu/viewmodel/AndroidPaginationEnvironment.android.kt
@@ -383,16 +383,20 @@ open class SharedAndroidPaginationEnvironment(
         recordContentOpenEvent(destination, questionId)
     }
 
-    override suspend fun applyHomeFeedFilters(items: List<FeedDisplayItem>): HomeFeedFilterResult {
-        val settings = feedDisplaySettings()
+    override suspend fun applyForegroundHomeFeedFilter(items: List<FeedDisplayItem>): List<FeedDisplayItem> {
         val filterSettings = context.contentFilterSettings()
         val filterDatabase = getContentFilterDatabase(context)
-        val foregroundItems = ForegroundReadFilterPipeline(
+        return ForegroundReadFilterPipeline(
             settings = filterSettings,
             contentFilterManager = ContentFilterManager(filterDatabase.contentFilterDao()),
             blockedFeedRecordDao = filterDatabase.blockedFeedRecordDao(),
         ).filter(items)
-        val filteredItems = FeedDisplayFilterPipeline(
+    }
+
+    override suspend fun applyBackgroundHomeFeedFilter(items: List<FeedDisplayItem>): List<FeedDisplayItem> {
+        val filterSettings = context.contentFilterSettings()
+        val filterDatabase = getContentFilterDatabase(context)
+        return FeedDisplayFilterPipeline(
             settings = filterSettings,
             contentDetailProvider = this::getOrFetchContentDetail,
             contentFilterPipeline = FeedContentFilterPipeline(
@@ -421,12 +425,7 @@ open class SharedAndroidPaginationEnvironment(
             onDetailsKeywordFiltered = { item, keyword ->
                 Log.e("ContentFilterExtensions", "Filtered item '${item.title}' due to keyword '$keyword' in details: ${item.content}")
             },
-        ).filter(foregroundItems)
-        return HomeFeedFilterResult(
-            foregroundItems = foregroundItems,
-            filteredItems = filteredItems,
-            reverseBlock = settings.reverseBlock,
-        )
+        ).filter(items)
     }
 
     override suspend fun recordContentInteraction(feed: Feed) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationViewModel.kt
@@ -410,12 +410,9 @@ interface MobileHomeFeedEnvironment : ZhihuApiEnvironment {
 interface FeedDisplayEnvironment {
     fun feedDisplaySettings(): FeedDisplaySettings = FeedDisplaySettings()
 
-    suspend fun applyHomeFeedFilters(items: List<FeedDisplayItem>): HomeFeedFilterResult =
-        HomeFeedFilterResult(
-            foregroundItems = items,
-            filteredItems = items,
-            reverseBlock = feedDisplaySettings().reverseBlock,
-        )
+    suspend fun applyForegroundHomeFeedFilter(items: List<FeedDisplayItem>): List<FeedDisplayItem> = items
+
+    suspend fun applyBackgroundHomeFeedFilter(items: List<FeedDisplayItem>): List<FeedDisplayItem> = items
 }
 
 interface HistoryEnvironment {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/feed/HomeFeedViewModel.kt
@@ -29,6 +29,7 @@ import com.github.zly2006.zhihu.data.target
 import com.github.zly2006.zhihu.navigation.Question
 import com.github.zly2006.zhihu.util.Log
 import com.github.zly2006.zhihu.viewmodel.ContentInteractionEnvironment
+import com.github.zly2006.zhihu.viewmodel.HomeFeedFilterResult
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.QualityFilterMode
 import com.github.zly2006.zhihu.viewmodel.filter.ContentDetailProvider
@@ -184,16 +185,24 @@ class HomeFeedViewModel :
                 loadedItems
             }
 
-            val filterResult = environment.applyHomeFeedFilters(newItems)
-            if (!filterResult.reverseBlock) {
+            val reverseBlock = environment.feedDisplaySettings().reverseBlock
+            val foregroundItems = environment.applyForegroundHomeFeedFilter(newItems)
+            if (!reverseBlock) {
                 withContext(Dispatchers.Main) {
-                    addDisplayItems(filterResult.foregroundItems)
+                    addDisplayItems(foregroundItems)
                 }
             }
 
-            if (filterResult.reverseBlock) {
-                addDisplayItems(filterResult.filteredItems)
+            val filteredItems = environment.applyBackgroundHomeFeedFilter(foregroundItems)
+            if (reverseBlock) {
+                addDisplayItems(filteredItems)
             }
+
+            val filterResult = HomeFeedFilterResult(
+                foregroundItems = foregroundItems,
+                filteredItems = filteredItems,
+                reverseBlock = reverseBlock,
+            )
 
             // 移除被过滤的条目，并更新已保留条目的 raw 内容
             withContext(Dispatchers.Main) {

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/filter/ContentFilterExtensions.kt
@@ -29,6 +29,9 @@ import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.NavDestination
 import com.github.zly2006.zhihu.navigation.Pin
 import com.github.zly2006.zhihu.platform.SettingsStore
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.Json
 
 class ForegroundReadFilterPipeline(
@@ -235,17 +238,21 @@ class FeedDisplayFilterPipeline(
             emptyList<FeedDisplayItem>() to items
         }
 
-        val itemToFilterableMap = mutableMapOf<FeedDisplayItem, FilterableContent>()
+        val itemToFilterableMap = coroutineScope {
+            otherItems
+                .map { item ->
+                    async {
+                        val identity = item.resolveContentIdentity()
+                        val rawContent = resolveRawContent(item)
 
-        otherItems.forEach { item ->
-            val identity = item.resolveContentIdentity()
-            val rawContent = resolveRawContent(item)
+                        if (rawContent is DataHolder.DummyContent) {
+                            onDetailFetchFailed(item)
+                        }
 
-            if (rawContent is DataHolder.DummyContent) {
-                onDetailFetchFailed(item)
-            }
-
-            itemToFilterableMap[item] = item.toFilterableContent(identity, rawContent)
+                        item to item.toFilterableContent(identity, rawContent)
+                    }
+                }.awaitAll()
+                .toMap()
         }
 
         val filterableContents = itemToFilterableMap.values.toList()

--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/AndroidHomeFeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/viewmodel/za/AndroidHomeFeedViewModel.kt
@@ -30,6 +30,7 @@ import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.Pin
 import com.github.zly2006.zhihu.navigation.resolveContent
 import com.github.zly2006.zhihu.viewmodel.ContentInteractionEnvironment
+import com.github.zly2006.zhihu.viewmodel.HomeFeedFilterResult
 import com.github.zly2006.zhihu.viewmodel.PaginationEnvironment
 import com.github.zly2006.zhihu.viewmodel.feed.BaseFeedViewModel
 import com.github.zly2006.zhihu.viewmodel.feed.HomeFeedInteractionViewModel
@@ -85,16 +86,24 @@ class AndroidHomeFeedViewModel :
                     }
 
                 // 前台先做本地已读过滤，再立即展示
-                val filterResult = environment.applyHomeFeedFilters(itemsToDisplay)
-                if (!filterResult.reverseBlock) {
+                val reverseBlock = environment.feedDisplaySettings().reverseBlock
+                val foregroundItems = environment.applyForegroundHomeFeedFilter(itemsToDisplay)
+                if (!reverseBlock) {
                     withContext(Dispatchers.Main) {
-                        addDisplayItems(filterResult.foregroundItems)
+                        addDisplayItems(foregroundItems)
                     }
                 }
 
-                if (filterResult.reverseBlock) {
-                    addDisplayItems(filterResult.filteredItems)
+                val filteredItems = environment.applyBackgroundHomeFeedFilter(foregroundItems)
+                if (reverseBlock) {
+                    addDisplayItems(filteredItems)
                 }
+
+                val filterResult = HomeFeedFilterResult(
+                    foregroundItems = foregroundItems,
+                    filteredItems = filteredItems,
+                    reverseBlock = reverseBlock,
+                )
 
                 // 移除被过滤的条目，并更新已保留条目的 raw 内容
                 withContext(Dispatchers.Main) {

--- a/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.jvm.kt
@@ -275,14 +275,18 @@ class DesktopPaginationEnvironment(
         recordContentOpenEvent(destination, questionId)
     }
 
-    override suspend fun applyHomeFeedFilters(items: List<FeedDisplayItem>): HomeFeedFilterResult {
+    override suspend fun applyForegroundHomeFeedFilter(items: List<FeedDisplayItem>): List<FeedDisplayItem> {
         val settings = settingsStore.toFeedFilterSettings()
-        val foregroundItems = ForegroundReadFilterPipeline(
+        return ForegroundReadFilterPipeline(
             settings = settings,
             contentFilterManager = ContentFilterManager(contentFilterDb.contentFilterDao()),
             blockedFeedRecordDao = contentFilterDb.blockedFeedRecordDao(),
         ).filter(items)
-        val filteredItems = FeedDisplayFilterPipeline(
+    }
+
+    override suspend fun applyBackgroundHomeFeedFilter(items: List<FeedDisplayItem>): List<FeedDisplayItem> {
+        val settings = settingsStore.toFeedFilterSettings()
+        return FeedDisplayFilterPipeline(
             settings = settings,
             contentDetailProvider = ContentDetailProvider(::getOrFetchContentDetail),
             contentFilterPipeline = FeedContentFilterPipeline(
@@ -298,12 +302,7 @@ class DesktopPaginationEnvironment(
                 ),
             ),
             blockedFeedRecordDao = contentFilterDb.blockedFeedRecordDao(),
-        ).filter(foregroundItems)
-        return HomeFeedFilterResult(
-            foregroundItems = foregroundItems,
-            filteredItems = filteredItems,
-            reverseBlock = settings.reverseBlock,
-        )
+        ).filter(items)
     }
 
     override suspend fun recordContentInteraction(feed: Feed) {

--- a/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedDisplayFilterPipelineTest.kt
+++ b/shared/src/jvmTest/kotlin/com/github/zly2006/zhihu/viewmodel/filter/FeedDisplayFilterPipelineTest.kt
@@ -29,7 +29,9 @@ import com.github.zly2006.zhihu.navigation.Article
 import com.github.zly2006.zhihu.navigation.ArticleType
 import com.github.zly2006.zhihu.navigation.Question
 import com.github.zly2006.zhihu.viewmodel.feed.resolveFeedQuestionAuthorInfo
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonObject
 import kotlin.io.path.createTempDirectory
@@ -104,6 +106,31 @@ class FeedDisplayFilterPipelineTest {
                 .observeAll()
                 .first(),
         )
+        fixture.database.close()
+    }
+
+    @Test
+    fun fetchesContentDetailsConcurrently() = runTest {
+        val fixture = fixture()
+        val allDetailsStarted = CompletableDeferred<Unit>()
+        val releaseDetails = CompletableDeferred<Unit>()
+        var startedCount = 0
+        val provider = ContentDetailProvider {
+            startedCount++
+            if (startedCount == 2) allDetailsStarted.complete(Unit)
+            releaseDetails.await()
+            article("loaded")
+        }
+        val job = launch {
+            fixture.pipeline(detailProvider = provider).filter(
+                listOf(item("one", 1), item("two", 2)),
+            )
+        }
+
+        allDetailsStarted.await()
+        assertEquals(2, startedCount)
+        releaseDetails.complete(Unit)
+        job.join()
         fixture.database.close()
     }
 

--- a/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.native.kt
+++ b/shared/src/nativeMain/kotlin/com/github/zly2006/zhihu/viewmodel/PaginationEnvironment.native.kt
@@ -240,14 +240,18 @@ internal class NativePaginationEnvironment(
     override suspend fun recordOpenEvent(destination: Article, questionId: Long?) =
         recordContentOpenEvent(destination, questionId)
 
-    override suspend fun applyHomeFeedFilters(items: List<FeedDisplayItem>): HomeFeedFilterResult {
+    override suspend fun applyForegroundHomeFeedFilter(items: List<FeedDisplayItem>): List<FeedDisplayItem> {
         val settings = settingsStore.toFeedFilterSettings()
-        val foregroundItems = ForegroundReadFilterPipeline(
+        return ForegroundReadFilterPipeline(
             settings = settings,
             contentFilterManager = ContentFilterManager(contentFilterDatabase.contentFilterDao()),
             blockedFeedRecordDao = contentFilterDatabase.blockedFeedRecordDao(),
         ).filter(items)
-        val filteredItems = FeedDisplayFilterPipeline(
+    }
+
+    override suspend fun applyBackgroundHomeFeedFilter(items: List<FeedDisplayItem>): List<FeedDisplayItem> {
+        val settings = settingsStore.toFeedFilterSettings()
+        return FeedDisplayFilterPipeline(
             settings = settings,
             contentDetailProvider = ContentDetailProvider(::getOrFetchContentDetail),
             contentFilterPipeline = FeedContentFilterPipeline(
@@ -263,12 +267,7 @@ internal class NativePaginationEnvironment(
                 ),
             ),
             blockedFeedRecordDao = contentFilterDatabase.blockedFeedRecordDao(),
-        ).filter(foregroundItems)
-        return HomeFeedFilterResult(
-            foregroundItems = foregroundItems,
-            filteredItems = filteredItems,
-            reverseBlock = settings.reverseBlock,
-        )
+        ).filter(items)
     }
 
     override suspend fun recordContentInteraction(feed: Feed) {


### PR DESCRIPTION
## 改动

- 恢复首页和移动首页“前台已读过滤 → 立即展示 → 后台内容过滤”的分阶段调用顺序。
- 后台内容过滤的详情获取改为并行请求，所有详情完成后仍按原有规则统一过滤并更新条目。
- 增加两个详情请求同时启动的 JVM 回归测试。

## 原因

KMP 迁移时，前台过滤和后台过滤被合并到一个必须完整返回的环境方法中，导致网络详情请求完成前无法展示前台结果。后台详情请求原先还逐条串行执行，进一步放大了等待时间。

## 影响

前台已读过滤完成后即可显示内容；后台作者、关键词、主题、NLP 和广告过滤语义保持不变，只缩短详情加载阶段的等待时间。反向屏蔽模式仍只显示后台过滤结果。

## 验证

- `./gradlew :shared:jvmTest --tests com.github.zly2006.zhihu.viewmodel.filter.FeedDisplayFilterPipelineTest --tests com.github.zly2006.zhihu.viewmodel.feed.HomeFeedFilterResultMergeTest`
- `./gradlew :shared:ktlintCommonMainSourceSetCheck :shared:ktlintCommonTestSourceSetCheck :shared:ktlintJvmMainSourceSetCheck :shared:ktlintJvmTestSourceSetCheck`
- `./gradlew --no-configuration-cache :app:compileLiteDebugKotlin :app:compileLiteDebugAndroidTestKotlin`
