### PR TITLE
refactor: 删除无断言的 AVD 校准测试

### DIFF
--- a/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/zly2006/zhihu/ArticleScreenInstrumentedTest.kt
@@ -26,7 +26,6 @@ import android.view.InputDevice
 import android.view.MotionEvent
 import androidx.compose.foundation.ComposeFoundationFlags
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.width
@@ -40,7 +39,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
@@ -102,13 +100,11 @@ import com.github.zly2006.zhihu.ui.article.ArticleActionsMenu
 import com.github.zly2006.zhihu.ui.rememberArticleTtsState
 import com.github.zly2006.zhihu.viewmodel.ArticleViewModel
 import com.github.zly2006.zhihu.viewmodel.ZhihuApiEnvironment
-import com.hrm.markdown.renderer.Markdown
 import com.hrm.markdown.renderer.MarkdownImageData
 import io.ktor.client.HttpClient
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -287,81 +283,6 @@ class ArticleScreenInstrumentedTest {
             "Issue #495 median first frame took ${medianMillis}ms; benchmark includes HTML parsing, Compose layout, and draw",
             medianMillis < ISSUE_495_FIRST_FRAME_LIMIT_MS,
         )
-    }
-
-    /**
-     * Regression: https://github.com/zly2006/zhihu-plus-plus/issues/495
-     * Fixed by: https://github.com/zly2006/zhihu-plus-plus/pull/646
-     */
-    @Test
-    fun markdownJvmToAvdCalibrationBenchmark() {
-        assumeTrue(
-            "Run explicitly with -e markdownPerformance true; normal functional suites should not occupy an AVD for calibration",
-            InstrumentationRegistry.getArguments().getString("markdownPerformance") == "true",
-        )
-        val scenarios = linkedMapOf(
-            "short-prose" to "一段普通正文，用于覆盖最常见的短回答。",
-            "formatted-prose" to (1..30).joinToString("\n\n") { index ->
-                "第 $index 段包含 **加粗**、*斜体*、~~删除线~~ 和 [链接](https://example.com/$index)。"
-            },
-            "block-math" to (1..80).joinToString("\n\n") { index ->
-                "${'$'}${'$'}\\sum_{i=1}^{n} \\frac{x_i^{$index}}{1+x_i^2}${'$'}${'$'}"
-            },
-        )
-        val markdown = mutableStateOf("calibration bootstrap")
-        val scrollState = ScrollState(0)
-        composeRule.setScreenContent {
-            Markdown(
-                markdown = markdown.value,
-                modifier = androidx.compose.ui.Modifier
-                    .fillMaxSize(),
-                scrollState = scrollState,
-                enableScroll = true,
-                enableSelection = true,
-            )
-        }
-        composeRule.waitUntil(timeoutMillis = 10_000) {
-            composeRule
-                .onAllNodesWithText("calibration bootstrap", substring = true, useUnmergedTree = true)
-                .fetchSemanticsNodes(atLeastOneRootRequired = false)
-                .isNotEmpty()
-        }
-        composeRule.onRoot().captureToImage()
-
-        repeat(2) { warmup ->
-            scenarios.forEach { (name, body) ->
-                val marker = "$name warmup $warmup"
-                composeRule.runOnUiThread { markdown.value = "$marker\n\n$body" }
-                composeRule.waitUntil(timeoutMillis = 10_000) {
-                    composeRule
-                        .onAllNodesWithText(marker, substring = true, useUnmergedTree = true)
-                        .fetchSemanticsNodes(atLeastOneRootRequired = false)
-                        .isNotEmpty()
-                }
-                composeRule.onRoot().captureToImage()
-            }
-        }
-        val medians = scenarios.mapValues { (name, body) ->
-            val samples = List(7) { iteration ->
-                val marker = "$name calibration $iteration"
-                val startedAt = SystemClock.elapsedRealtimeNanos()
-                composeRule.runOnUiThread { markdown.value = "$marker\n\n$body" }
-                composeRule.waitUntil(timeoutMillis = 10_000) {
-                    composeRule
-                        .onAllNodesWithText(marker, substring = true, useUnmergedTree = true)
-                        .fetchSemanticsNodes(atLeastOneRootRequired = false)
-                        .isNotEmpty()
-                }
-                composeRule.waitForIdle()
-                val elapsedMs = (SystemClock.elapsedRealtimeNanos() - startedAt) / 1_000_000.0
-                composeRule.onRoot().captureToImage()
-                elapsedMs
-            }
-            samples.sorted()[samples.size / 2].also { median ->
-                Log.i(ISSUE_495_BENCHMARK_TAG, "calibrationScenario=$name samplesMs=$samples medianMs=$median")
-            }
-        }
-        Log.i(ISSUE_495_BENCHMARK_TAG, "calibrationMediansMs=$medians")
     }
 
     /**


### PR DESCRIPTION
## 基线与范围

- 基线：`c5b36e7b968bfc803aa5edc85ac6820ce1cf300a`
- Android instrument test：84 → 83
- 决策统计：保留 83、迁移 0、合并 0、删除 1
- 本 PR 只修改 `ArticleScreenInstrumentedTest`，不包含产品行为变更。

## 删除项

| 测试 | 分类 | 来源 | 删除依据 |
| --- | --- | --- | --- |
| `markdownJvmToAvdCalibrationBenchmark` | `UNVERIFIED` 校准实验 | [#495](https://github.com/zly2006/zhihu-plus-plus/issues/495) / [#646](https://github.com/zly2006/zhihu-plus-plus/pull/646) | 默认通过 assumption 跳过；显式运行时也只输出三组耗时中位数，没有任何失败断言，因此不能保护历史回归，也无法完成红转绿验证。PR #646 的验收说明已明确日常性能回归优先 JVM，AVD 倍率只用于一次性校准。 |

同时删除该实验独占的 `ScrollState`、`mutableStateOf`、`Markdown` 与 `assumeTrue` 导入。

## 保留覆盖

没有删除历史回归覆盖。Issue #495 的 Android 端用户可感知性能仍由下列更强测试保护：

| 测试 | 分类 | Issue | 修复 PR | 必须使用 Android 的原因 |
| --- | --- | --- | --- | --- |
| `issue495FirstFrameBenchmarkIncludesHtmlParsingLayoutAndDraw` | `REGRESSION` | [#495](https://github.com/zly2006/zhihu-plus-plus/issues/495) | [#556](https://github.com/zly2006/zhihu-plus-plus/pull/556) | 实际执行 Android Compose 正文首帧的 HTML 解析、布局、绘制和像素回读，并以 5 秒阈值失败。 |
| `issue495MaterializesEstimatedOffscreenBlocksWhenScrolledIntoView` | `REGRESSION` | [#495](https://github.com/zly2006/zhihu-plus-plus/issues/495) | [#556](https://github.com/zly2006/zhihu-plus-plus/pull/556) | 需要真实 Compose 滚动、视口物化与绘制语义。 |
| `deferredMarkdownSaveStateUsesBundleSafeKeys` | `REGRESSION` | [#495](https://github.com/zly2006/zhihu-plus-plus/issues/495) | [#646](https://github.com/zly2006/zhihu-plus-plus/pull/646) | 需要 Android Activity/Bundle 保存恢复边界。 |

其余 80 个保留测试未修改；逐项 issue/PR provenance KDoc 均通过仓库治理脚本检查。由于本 PR 没有新增或修改保留测试，不需要为它们重新制造红转绿记录。

## 验证

- provenance audit：通过，83 个保留测试均在 `@Test` 前包含仓库 issue 与 PR 完整 URL。
- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process :app:compileLiteDebugAndroidTestKotlin`：`BUILD SUCCESSFUL in 20m 11s`
- `./gradlew --no-daemon -Dkotlin.compiler.execution.strategy=in-process ktlintFormat`：`BUILD SUCCESSFUL in 2m 26s`
- `git diff --check`：通过
- 未运行完整 instrument suite；按治理规范交由 GitHub CI 验收。
- PR 713 的 GitHub Actions run `33305444607`：Build、KtLint、Unit Tests、Mock Instrumented Tests 及 5 个 shard 全部通过；当前 `mergeStateStatus=CLEAN`、`mergeable=MERGEABLE`。
