### PR TITLE
fix: 修复 Android 个人主页折叠栏状态栏间距

### DIFF
--- a/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PeopleScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/zly2006/zhihu/ui/PeopleScreen.kt
@@ -29,12 +29,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
@@ -727,7 +730,9 @@ fun PeopleScreen(
             .nestedScroll(scrollBehavior.nestedScrollConnection)
             .fillMaxSize(),
         topBar = {
-            Box {
+            Box(
+                modifier = Modifier.windowInsetsPadding(WindowInsets.statusBars),
+            ) {
                 Column {
                     Box(modifier = Modifier.height(headerHeight)) {
                         UserInfoHeader(


### PR DESCRIPTION
## 改动

- 修复 Android 端个人主页自定义折叠栏对系统状态栏的间距处理。
- 展开态与收起态统一应用状态栏 inset，避免搜索按钮和 Tab 行上下错位。

## 验证

- `:shared:compileKotlinJvm`
- `:macosApp:compileKotlinMacosArm64`
- ktlint 格式化通过。
